### PR TITLE
Improve rails guide

### DIFF
--- a/sources/guides/ruby_on_rails.md
+++ b/sources/guides/ruby_on_rails.md
@@ -1,59 +1,86 @@
-description: This guide shows you how to create, deploy, and run a simple Ruby on Rails project on Giant Swarm
+description: This guide shows how to dockerize a simple Ruby on Rails application and deploy it on Giant Swarm.
 
 # Swarmify Ruby on Rails
 
-<p class="lastmod">Last edited on January 13, 2015 by Marian Steinbach</p>
+<p class="lastmod">Last edited on January 25, 2015 by Marian Steinbach</p>
 
 The following guide will explain how to configure the [RailsTutorials Sample App](https://github.com/railstutorial/sample_app_rails_4/) to GiantSwarm. We will run one container for MySQL and one for your Rails application. You should have a basic understanding of Docker and Rails.
 
-## TL;DR with fig
+## Prerequisites
 
-Before we get into the details, let us first run the setup locally with [fig](http://www.fig.sh/). For this, we clone our repository, switch to the [dockerize branch](https://github.com/giantswarm/sample_app_rails_4/tree/dockerize) and start the setup with `fig up`:
+In order to follow along this guide you need the following installed and setup on your machine:
 
-    $ git clone https://github.com/giantswarm/sample_app_rails_4
-    $ cd sample_app_rails_4/
-    $ git checkout dockerize
-    $ fig up
+* Docker
+* Latest `swarm` app
+* Ruby 2.2
+* Bundler
+* MySQL development headers
 
-That's it. Two containers are up, linked, and running. You can now access your app on [port 3000](http://localhost:3000/) of your localhost.
+You can checkout the [dockerize branch](https://github.com/giantswarm/sample_app_rails_4/tree/dockerize) from our fork of the sample app to see the result of the changes.
 
 ## Get up and running with Docker on localhost
 
-Now let's see what needs to get done to manually dockerize the Sample Rails app. 
+The get started clone the sample app from GitHub and create a branch to work on:
 
-    $ git clone https://github.com/railstutorial/sample_app_rails_4
-    $ cd sample_app_rails_4/
-
-The team behind [Docker-Library](https://registry.hub.docker.com/_/rails/) ([GitHub repository](https://github.com/docker-library/rails)) already provides a base image for Ruby on Rails. We are using the "onbuild" version, which makes it easy to write our own Dockerfile. At the root of the sample rails app, create a new file called `Dockerfile` with the following statement: 
-
-```
-FROM rails:onbuild
+```shell
+$ git clone https://github.com/railstutorial/sample_app_rails_4
+$ cd sample_app_rails_4/
+$ git checkout -b dockerize
 ```
 
-Before you can build the Rails app we need to fix the `Gemfile` and set the Ruby version to `2.1.2`:
+First of all we need to create a `Dockerfile`. We could use the [official Rails Docker image](https://registry.hub.docker.com/_/rails/) but we need the `onbuild` image. Using this will make us dependent on their Ruby version updates. Updating the language should be managed by us and not but a third-party. We can still use the [Ruby base image](https://registry.hub.docker.com/_/ruby/) to build our own `Dockerfile`:
 
+```Dockerfile
+FROM ruby:2.2.0
+
+RUN apt-get update && apt-get install -y nodejs --no-install-recommends && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y mysql-client --no-install-recommends && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /usr/src/app
+
+WORKDIR /usr/src/app
+
+COPY Gemfile /usr/src/app/
+COPY Gemfile.lock /usr/src/app/
+RUN bundle install --deployment
+
+COPY . /usr/src/app
+
+EXPOSE 3000
+
+CMD ["rails", "server"]
 ```
-source 'https://rubygems.org'
-ruby '2.1.2'
-#ruby-gemset=railstutorial_rails_4_0
 
-gem 'rails', '4.0.8'
-gem 'bootstrap-sass', '2.3.2.0'
-....
+Another advantage of rolling our own `Dockerfile` is we will only install the used database dependency and not all of them. Instead of the global `--freeze` flag for Bundler we will use the `--deployment` flag.
+
+Before we can build our Docker image we need to make sure the `Gemfile.lock` is up to date:
+
+```shell
+$ bundle install
 ```
 
-Upon `docker build -t sample_rails_4 .` our patched Rails Gemfile is added and the dependencies are installed. Then the Rails sample app is added and Node.JS is installed. See the [Rails Dockerfile](
-https://github.com/docker-library/rails/blob/7bb6ade7f97129cc58967d7d0ae17f4b62ae52eb/onbuild/Dockerfile) for details.
+This step is required every time we change the dependencies in the `Gemfile`. After we done this we can finally build our Docker image:
 
-If you now run your container with `docker run -p 3000:3000 sample_rails_4` you should get a runtime error message informing you that no database is configured. So let's do that now.
+```shell
+$ docker build -t sample_rails_4
+```
+
+To start the container we need to specify two essential options: the port we want to be exposed and which Rails environment to be used:
+
+```shell
+$ docker run -e RAILS_ENV=production -p 3000:3000 sample_rails_4
+```
+
+**NOTE:** The `RAILS_ENV=production` part is important since we're preparing the image to be used in production. Setting this up for local development requires additional steps that will not be covered in this guide.
+
+This will run the sample application in production mode and make it available at <http://localhost:3000>. As soon as you go to the page you will get an error. A look into the log output shows we don't have a database configured yet. Let's do this next.
 
 ## Adding MySQL
 
 As a database we chose MySQL, which should run in its own container. Fortunatly we can use the predefined [MySQL docker image](https://registry.hub.docker.com/_/mysql/), which automatically creates a `root` user. It also supports reading the initial password from the `MYSQL_ROOT_PASSWORD` environment variable. So to start our database we run this:
 
 ```bash
-$ PASS=somesecretpassword
-$ docker run -d --name database -e MYSQL_ROOT_PASSWORD=${PASS} -p 3306 mysql
+$ docker run -d --name database -e MYSQL_ROOT_PASSWORD=somesecretpassword -p 3306 mysql
 ```
 
 To hook our Rails app to the database we are using [Docker links](https://docs.docker.com/userguide/dockerlinks/). When linking containers, Docker injects certain environment variables, which can be used to discover the IP and port of the linked container. We need to modify our Rails app to use these variables for connecting to the database:
@@ -72,19 +99,22 @@ production:
   port: <%=ENV['DATABASE_PORT_3306_TCP_PORT'] %>
 ```
 
-Since we now use the `mysql2` driver, we also need to add it to our Gemfile for the `production` group (you can also drop `pg` if you want):
+The original sample application uses Postgres as database. To use MySQL we need to replace the `pg` gem with the `mysql2` gem in our `Gemfile`:
 
 ```ruby
 # File Gemfile
+-  gem 'pg'
 +  gem 'mysql2'
 ```
 
-Since we have changed the Gemfile, we would normally need to build our application image again. But before we do that, let's fix the next problem. If we start our app and it connects to the database, it encounters two problems:
+Don't forget to run `bundle install` after this change.
+
+While this will allow us to connect to the MySQL database there is not much we can do on it yet. We need to address two issues:
 
 1. There is no database `app` in the MySQL container
-2. Without a database, all the tables are missing, too - we need to execute `rake db:migrate`
+2. After creating the database we need to create _and_ maintain the schema in it.
 
-We can fix this by writing a custom start script which ensures both points are fixed:
+Rails provides Rake tasks for both issues but we still need to execute them at some point. Because we're planning to deploy the app to Giant Swarm we must execute both tasks within a Docker container. There no best practise on how to solve these problems yet, but one way is a custom start script:
 
 ```bash
 #!/bin/bash
@@ -93,32 +123,25 @@ set -e
 
 cd /usr/src/app
 
-MYSQL_HOST=$DATABASE_PORT_3306_TCP_ADDR
-MYSQL_PORT=$DATABASE_PORT_3306_TCP_PORT
-
-MYSQL="mysql -h$MYSQL_HOST -P$MYSQL_PORT -u$MYSQL_USER -p$MYSQL_PASS"
-
-if [ ! $($MYSQL -e 'show databases;'| grep ^app$) ]; then
-  $MYSQL -e "create database app;"
-fi
-
+rake db:create
 rake db:migrate
 
 exec rails s $*
 ```
 
-To get this running we need to install a MySQL client and register our start script in our `Dockerfile`:
+Put this file under `script/docker_start` and mark it as executable:
 
-```
-FROM rails:onbuild
-
-RUN apt-get update && apt-get install -y mysql-client
-RUN chmod +x start
-
-CMD ["./start"]
+```shell
+$ chmod +x script/docker_start
 ```
 
-__NOTE__: We realize that this is a non-optimal solution for now, so this will likely change in the future.
+To use our custom script instead of the simple `rails server` we must change our `Dockerfile`. Replace the `CMD` with the following:
+
+```Dockerfile
+CMD ["./script/docker_start"]
+```
+
+**NOTE:** We realize that this is a non-optimal solution for now, so this will likely change in the future.
 
 One last step: As as we currently do not yet support SSL, we need to disable it for the production environment:
 
@@ -128,22 +151,25 @@ One last step: As as we currently do not yet support SSL, we need to disable it 
 +  config.force_ssl = false 
 ```
 
-Calling `docker build -t sample_rails_4 .` to build the new image, we can now run everything on the local Docker daemon:
+Now we can build the new image:
 
-```bash
-PASS=somesecretpassword
-SECRET_KEY=somesecretkeyforrails
+```shell
+$ docker build -t sample_rails_4
+```
 
+At this point we can run both the web app and the database together:
+
+```shell
 # Start the MySQL database
-docker run -d --name database -e MYSQL_ROOT_PASSWORD=${PASS} -p 3306 mysql
+$ docker run -d --name database -e MYSQL_ROOT_PASSWORD=somesecretpassword -p 3306 mysql
 
 # Now the Rails app - linked to MySQL
-docker run -e RAILS_ENV=production -e SECRET_KEY_BASE=${SECRET_KEY} \
-  -e MYSQL_PASS=${PASS} -e MYSQL_USER=root --link database:database \
+$ docker run -e RAILS_ENV=production -e SECRET_KEY_BASE=somesecretkeyforrails \
+  -e MYSQL_PASS=somesecretpassword -e MYSQL_USER=root --link database:database \
   -p 3000:3000 sample_rails_4
 ```
 
-You can now access your app on [port 3000](http://localhost:3000) of localhost again.
+Visiting the app again on <htt://localhost:3000> should not raise any more errors.
 
 ## Swarmifying
 
@@ -156,7 +182,7 @@ $ docker build -t <username>/sample_rails_4 .
 $ docker push <username>/sample_rails_4
 ```
 
-### The swarm.json
+### The `swarm.json`
 
 Now, we just need to add an application file describing our containers:
 
@@ -172,7 +198,7 @@ Now, we just need to add an application file describing our containers:
           "image": "mysql",
           "ports": ["3306"],
           "env": {
-            "MYSQL_ROOT_PASSWORD": "somesecretpassword"
+            "MYSQL_ROOT_PASSWORD": "$mysqlpass"
           },
           "volumes": [
             {
@@ -185,10 +211,10 @@ Now, we just need to add an application file describing our containers:
           "component_name": "rails",
           "image": "<username>/sample_rails_4",
           "env": {
-            "SECRET_KEY_BASE": "somesecretkeyforrails",
+            "SECRET_KEY_BASE": "$railssecretkey",
             "RAILS_ENV": "production",
-            "MYSQL_PASS": "somesecretpassword",
-            "MYSQL_USER": "root"
+            "MYSQL_PASS": "$mysqlpass",
+            "MYSQL_USER": "$mysqluser"
           },
           "dependencies": [
             {
@@ -213,6 +239,18 @@ Here, we define one app `rails-sample-1` with one service `web`. This service co
 2. By adding a `domains` definition, so our load balancer can forward public requests to your container.
 
 You can either use your own domains (which you have to configure to forward to us) or use a subdomain of the cluster you are using. In this example we are using `gigantic.io` - modify this to match your needs.
+
+The last step to make this work is to add the actual environment variables. Since we don't want to write them directly into the `swarm.json` we extract them into the `swarmvars.json`:
+
+```json
+{
+    "GIANT_SWARM_USER/ENV": {
+        "mysqlpass": "somesecretpassword",
+        "mysqluser": "root",
+        "railssecretkey": "somesecretkeyforrails"
+    }
+}
+```
 
 ### Run 
 


### PR DESCRIPTION
I rewritten some parts of the guide and fixed the sample code to make everything work again.

What I've done:
1. Removed fig from the guide. IMO this doesn't add value to it since it focus on deploying to Giant Swarm and not local deployment.
2. Created a custom Dockerfile since the official one will break again on a new version of Ruby (and we want to use the `--deployment` flag for bundler)
3. Removed the Ruby version specifier from the Gemfile. It is not required and just adds obsolete complexity to the guide.
4. Used idiomatic Rails methods to create the database
5. Added a `swarmvars.json`

That are the major changes. I tried to make the part about changing to MySQL and creating the custom start script a more obvious to people like me (read: not using Docker everyday :wink:). Additionally I made the code examples more "pastable".

The changes to the sample app will be pushed as soon as someone gave me access to the repo. Will create a PR first.

Original Author: @dbreuer
Created at 26-01-2015 23:09:25
Gitlab: [giantswarm/docs!99](https://git.giantswarm.io/giantswarm/docs/merge_requests/99)

<!---
@huboard:{"order":0.0076904296875,"milestone_order":2,"custom_state":"archived"}
-->
