### PR TITLE
Update index.html

### DIFF
--- a/swarmdocs/layouts/index.html
+++ b/swarmdocs/layouts/index.html
@@ -44,11 +44,12 @@
           </ul>
           <div class="tab-content">
             <div role="tabpanel" class="tab-pane active" id="mac">
-              <pre><code class="nohighlight"><b>$</b> brew tap giantswarm/swarm
-<b>$</b> brew install swarm-client
-<b>$</b> git clone git@github.com:giantswarm/helloworld.git
-<b>$</b> cd helloworld
-<b>$</b> swarm login <b class="username">yourusername</b></code></pre>
+              <pre><code class="nohighlight">
+                <b>$</b> brew tap giantswarm/swarm
+                <b>$</b> brew install swarm-client
+                <b>$</b> git clone https://github.com/giantswarm/helloworld.git
+                <b>$</b> cd helloworld
+                <b>$</b> swarm login <b class="username">yourusername</b></code></pre>
               <p>Now enter your Giant Swarm credentials.</p>
 
               <pre><code class="nohighlight"><b>$</b> swarm up --var=domain=helloworld-<b class="username">yourusername</b>.gigantic.io</code></pre>


### PR DESCRIPTION
Two changes suggested by one of our hiring interviewees (cc @annaloew).
- Use https instead of git for the `git clone` as it does not require one to have setup the SSH keys within Github
- Combined the `tar` and `cp` command into one
- and changed the target folder to `/usr/local/bin` - up for discussion

He also suggested to remove the `$` infront to make it easier to copy & paste, but I am not sure about that. Is there any way in CSS to make stuff not copyable/background? Maybe with the CSS `:before` ?
