### PR TITLE
Updates the helloworld link to the actual username

### DIFF
--- a/swarmdocs/layouts/index.html
+++ b/swarmdocs/layouts/index.html
@@ -118,7 +118,7 @@
 
               <pre><code class="nohighlight"><b>$</b> swarm up --var=domain=helloworld-<b class="username">yourusername</b>.gigantic.io</code></pre>
 
-              <p>Then open your running application at <a href="http://helloworld-yourusername.gigantic.io/" target="_blank">helloworld-yourusername.gigantic.io</a></p>
+              <p class="helloworldlink">Then open your running application at <a href="http://helloworld-yourusername.gigantic.io/" target="_blank">helloworld-yourusername.gigantic.io</a></p>
             </div>
             <div role="tabpanel" class="tab-pane" id="linux">
               <pre><code class="nohighlight"><b>$</b> curl -O http://downloads.giantswarm.io/swarm/clients/{{ partial "cli_latest_version" . }}/swarm-{{ partial "cli_latest_version" . }}-linux-amd64.tar.gz
@@ -130,7 +130,7 @@
 
               <pre><code class="nohighlight">swarm up --var=domain=helloworld-<b class="username">yourusername</b>.gigantic.io</code></pre>
 
-              <p>Then open your running application at <a href="http://helloworld-yourusername.gigantic.io/" target="_blank">helloworld-yourusername.gigantic.io</a></p>
+              <p class="helloworldlink">Then open your running application at <a href="http://helloworld-yourusername.gigantic.io/" target="_blank">helloworld-yourusername.gigantic.io</a></p>
             </div>
           </div>
         </div>

--- a/swarmdocs/static/js/base.js
+++ b/swarmdocs/static/js/base.js
@@ -190,6 +190,7 @@ var username = getParameterByName("username");
 if (typeof username !== "undefined" && username !== "") {
     $(".username").text(username);
     $(".welcome-alert").show();
+    $(".helloworldlink").html('Then open your running application at <a href="http://helloworld-' + username + '.gigantic.io/" target="_blank">helloworld-' + username + '.gigantic.io</a>')
 }
 
 /** Adapt docs menu **/


### PR DESCRIPTION
From a feedback of a user: The last link in the quickstart doesn't link to their actual app. The username is not replaced. Test via: https://docs.giantswarm.io/?username=blabla

This PR fixes this. 
