### PR TITLE
Deleted opensource infobox

### DIFF
--- a/swarmdocs/layouts/shortcodes/cli_opensourced.html
+++ b/swarmdocs/layouts/shortcodes/cli_opensourced.html
@@ -1,1 +1,0 @@
-<p class="well"><strong>Great News:</strong> We just opened the CLI&apos;s source code. Find out how to contribute on <a href="https://github.com/giantswarm/cli" target="_blank">GitHub</a>!</p>


### PR DESCRIPTION
Need https://github.com/giantswarm/docs-content/pull/178 merged before.
