### PR TITLE
Fix image width for small images

### DIFF
--- a/swarmdocs/static/css/base.css
+++ b/swarmdocs/static/css/base.css
@@ -922,7 +922,7 @@ a.item .hellip {
   background-color: #3e83ac; }
 
 .content img {
-  width: 100%;
+  max-width: 100%;
   height: auto;
   margin-top: 20px;
   margin-bottom: 20px; }

--- a/swarmdocs/static/css/base.sass
+++ b/swarmdocs/static/css/base.sass
@@ -414,7 +414,7 @@ a.item .hellip
   background-color: #3e83ac
 
 .content img
-  width: 100%
+  max-width: 100%
   height: auto
   margin-top: 20px
   margin-bottom: 20px


### PR DESCRIPTION
Puja noticed an issue with image with on this page:
https://docs.giantswarm.io/guides/using-the-cabin-ios-app/

That's because we limit the width of images to 100% of the container width.
The method we used forced images to be 100% of the container width. Instead
we should only let them be as big as the container width, but if they are smaller
then to let them be smaller. `max-width` does that.
