### PR TITLE
Update highligtjs to 9.8.0 - Adds HTML and YAML highlighting

### DIFF
--- a/swarmdocs/layouts/partials/footer.html
+++ b/swarmdocs/layouts/partials/footer.html
@@ -77,7 +77,7 @@
     </footer>
     <script type="text/javascript" src="https://s.giantswarm.io/giantswarmio/0.10.18/1/jquery-1.11.2.min.js"></script>
     <script type="text/javascript" src="https://s.giantswarm.io/giantswarmio/0.10.18/1/bootstrap.min.js"></script>
-    <script type="text/javascript" src="https://s.giantswarm.io/highlightjs/8.4.0/1/highlight.min.js"></script>
+    <script type="text/javascript" src="https://s.giantswarm.io/highlightjs/9.8.0/1/highlight.pack.js"></script>
     <script type="text/javascript" src="/js/base.js?{{ partial "cachebreaker_js.html" . }}"></script>
     <script>
     // Google Analytics

--- a/swarmdocs/layouts/partials/header.html
+++ b/swarmdocs/layouts/partials/header.html
@@ -24,7 +24,7 @@
     <link rel="stylesheet" type="text/css" href="https://s.giantswarm.io/giantswarmio/0.10.18/1/bootstrap.min.css">
     <link rel="stylesheet" type="text/css" href="https://s.giantswarm.io/giantswarmio/0.10.18/1/base.css">
     <link rel="stylesheet" type="text/css" href="/css/font-awesome-4.0.3.css">
-    <link rel="stylesheet" type="text/css" href="https://s.giantswarm.io/highlightjs/8.4.0/1/solarized_dark.min.css">
+    <link rel="stylesheet" type="text/css" href="https://s.giantswarm.io/highlightjs/9.8.0/1/solarized_dark.min.css">
     <link rel="stylesheet" type="text/css" href="/css/base.css?{{ partial "cachebreaker_css.html" . }}">
   </head>
   <body data-spy="scroll" data-target="#TableOfContents" class="{{if .IsPage}}{{ replace .RelPermalink "/" "_" }}{{end}}">


### PR DESCRIPTION
This fixes broken highlighing for YAML blocks.

Highlightjs got a bit heavier though. Used to be 7.7kb, now it is 19kb

Related to: https://github.com/giantswarm/giantswarm/issues/968