### PR TITLE
Adding breadcrumb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ venv*
 swarmdocs/public
 swarmdocs/archetypes
 swarmdocs/content
+swarmdocs/data
 swarmdocs/static/img
 swarmdocs/layouts/partials/cachebreaker*
 swarmdocs/layouts/shortcodes/gsctl_version.html

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ docker-build: build-css
 	git clone --depth 1 git@github.com:giantswarm/docs-content.git
 	cp -r docs-content/content swarmdocs/
 	cp -r docs-content/img swarmdocs/static/
+	cp -r docs-content/data swarmdocs/
 	#
 	# Cache breaker
 	echo -n `md5 -q ./swarmdocs/static/css/base.css|head -c 9` > swarmdocs/layouts/partials/cachebreaker_css.html

--- a/swarmdocs/layouts/_default/single.html
+++ b/swarmdocs/layouts/_default/single.html
@@ -15,6 +15,9 @@
     </div>
   </div>
   <div class="col-sm-12 col-md-8 col-lg-8 col-lg-offset-1">
+
+    {{ partial "breadcrumb.html" . }}
+
     <div class="content">
       <p class="lastmod">Last modified {{ .Date.Format "January 2, 2006" }}</p>
 

--- a/swarmdocs/layouts/partials/breadcrumb.html
+++ b/swarmdocs/layouts/partials/breadcrumb.html
@@ -1,0 +1,21 @@
+{{/* Breadcrumb that is rendered based on path segments.
+  A minimum length is configured, so that the breadcrumb does not
+  appear on the two topmost levels.
+  Friendly labels can be configured in docs/data/navtitles.yaml
+*/}}
+{{ $shortenedUrl := print ( .RelPermalink | replaceRE "[^/]+/$" "") }}
+{{ $urlElements := split $shortenedUrl "/" }}
+{{ $breadcrumLen := len $urlElements }}
+{{ if gt $breadcrumLen 1 }}
+<ol class="breadcrumb">
+  <li class="prefix">Back to:</li>
+  <li class="item"><a href="/" class="crumb">Docs</a></li>
+  {{ range $index, $element := split $shortenedUrl "/" }}
+    {{ $.Scratch.Add "path" $element }}
+      {{ if ne $element "" }}
+      <li class="item"><a href="/{{ $.Scratch.Get "path" }}/">{{- if isset $.Site.Data.navtitles . }}{{- index $.Site.Data.navtitles . -}}{{ else }}{{ . }}{{ end -}}</a></li>
+      {{ $.Scratch.Add "path" "/" }}
+      {{ end }}
+  {{ end }}
+</ol>
+{{ end }}

--- a/swarmdocs/static/css/base.css
+++ b/swarmdocs/static/css/base.css
@@ -954,9 +954,15 @@ ul.links li {
 .breadcrumb {
   background-color: #fff !important;
   padding-left: 0px !important;
-  border-top: 1px solid #ddd; }
+  margin-top: 0px;
+  margin-bottom: 15px;
+  padding-top: 0px;
+  padding-bottom: 0px !important;
+  font-size: 13px; }
   .breadcrumb li + li:before {
-    content: "→"; }
+    content: ""; }
+  .breadcrumb li.item + li.item:before {
+    content: "▸"; }
 
 .nav li a {
   padding-left: 22px;

--- a/swarmdocs/static/css/base.sass
+++ b/swarmdocs/static/css/base.sass
@@ -451,10 +451,16 @@ ul.links li
 .breadcrumb
   background-color: #fff !important
   padding-left: 0px !important
-  border-top: 1px solid #ddd
+  margin-top: 0px
+  margin-bottom: 15px
+  padding-top: 0px
+  padding-bottom: 0px !important
+  font-size: 13px
 
   li + li:before
-    content: "→"
+    content: ""
+  li.item + li.item:before
+    content: "▸"
 
 .nav
   li


### PR DESCRIPTION
This change introduces a breadcrumb menu in top of article pages when they are deep enough in the structure. So users have a better idea where they are and can quickly navigate to higher levels.

Preview:

![image](https://cloud.githubusercontent.com/assets/273727/21719500/75028302-d41e-11e6-9da2-4ecce2958f1c.png)

Currently there is no content in docs-content deep enough to test this. This changes with https://github.com/giantswarm/docs-content/pull/224