### PR TITLE
JavaScript for ingress base domain replacement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,7 @@ build-css:
 vendor: clean
 	# Vendor docs-content
 	mkdir vendor
-	#git clone --depth 1 https://github.com/giantswarm/docs-content.git vendor/docs-content
-	git clone -b adaptable-ingress-url-schema --depth 1 https://github.com/giantswarm/docs-content.git vendor/docs-content
+	git clone --depth 1 https://github.com/giantswarm/docs-content.git vendor/docs-content
 	rm -rf vendor/docs-content/.git # Ensure git doesn't commit this as a subproject, but as actual files in the repo
 
 	# Vendor hugo


### PR DESCRIPTION
Implements https://github.com/giantswarm/giantswarm/issues/1514. See also https://github.com/giantswarm/docs-content/pull/239

---

This PR introduces JavaScript that is applied on the Ingress guide at 

http://localhost/guides/accessing-services-from-the-outside/

The Guide now contains a form that allows to adapt the Ingress Base Domain used throughout the page.

In addition, the adapted ingress base domain can be set via a URL parameter. Example:

http://localhost/guides/accessing-services-from-the-outside/?basedomain=.foo.bar.baz

---

### TODO

- [x] Improve form CSS
- [x] Change back `Makefile` to use docs-content master when https://github.com/giantswarm/docs-content/pull/239 is merged