### PR TITLE
adding api specs to reference

### DIFF
--- a/src/layouts/index.html
+++ b/src/layouts/index.html
@@ -80,6 +80,7 @@
         <li><a href="/reference/gsctl/">gsctl - The Giant Swarm command line utility</a></li>
         <li><a href="/reference/cluster-definition/">Cluster definition YAML reference</a> <span class="label label-info">NEW</span></li>
         <li><a href="/reference/kubectl/">Installing and updating kubectl - The Kubernetes command line utility</a></li>
+        <li><a href="/api/">The Giant Swarm API v4</a></li>
         <li><a href="https://kubernetes.io/docs/user-guide/kubectl-overview/">kubectl reference <i class="fa fa-external-link" aria-hidden="true"></i></a></li>
         <li><a href="https://kubernetes.io/docs/concepts/overview/kubernetes-api/">Kubernetes API reference <i class="fa fa-external-link" aria-hidden="true"></i></a></li>
         <li><a href="/reference/giantswarm-aws-architecture/">The Giant Swarm AWS Architecture</a></li>


### PR DESCRIPTION
This should be enough, right?

Should we add this as external link?