### PR TITLE
Setting a revisionHistoryLimit

### DIFF
--- a/helm/docs-chart/templates/deployment.yaml
+++ b/helm/docs-chart/templates/deployment.yaml
@@ -8,6 +8,7 @@ metadata:
     component: content
 spec:
   replicas: 2
+  revisionHistoryLimit: 3
   template:
     metadata:
       name: content


### PR DESCRIPTION
Purpose: Have less old `content` replicasets around. General cleanliness.