### PR TITLE
Switch to highlight.js 9.12.0

### DIFF
--- a/src/layouts/partials/footer.html
+++ b/src/layouts/partials/footer.html
@@ -77,7 +77,7 @@
     </footer>
     <script type="text/javascript" src="https://s.giantswarm.io/giantswarmio/0.10.18/1/jquery-1.11.2.min.js"></script>
     <script type="text/javascript" src="https://s.giantswarm.io/giantswarmio/0.10.18/1/bootstrap.min.js"></script>
-    <script type="text/javascript" src="https://s.giantswarm.io/highlightjs/9.8.0/1/highlight.pack.js"></script>
+    <script type="text/javascript" src="https://s.giantswarm.io/highlightjs/9.12.0/1/highlight.min.js"></script>
     <script type="text/javascript" src="/js/base.js?{{ partial "cachebreaker_js.html" . }}"></script>
     <script>
     // Google Analytics

--- a/src/layouts/partials/header.html
+++ b/src/layouts/partials/header.html
@@ -24,7 +24,7 @@
     <link rel="stylesheet" type="text/css" href="https://s.giantswarm.io/giantswarmio/0.10.18/1/bootstrap.min.css">
     <link rel="stylesheet" type="text/css" href="https://s.giantswarm.io/giantswarmio/0.10.18/1/base.css">
     <link rel="stylesheet" type="text/css" href="/css/font-awesome-4.0.3.css">
-    <link rel="stylesheet" type="text/css" href="https://s.giantswarm.io/highlightjs/9.8.0/1/solarized_dark.min.css">
+    <link rel="stylesheet" type="text/css" href="https://s.giantswarm.io/highlightjs/9.12.0/1/solarized-dark.min.css">
     <link rel="stylesheet" type="text/css" href="/css/base.css?{{ partial "cachebreaker_css.html" . }}">
   </head>
   <body data-spy="scroll" data-target="#TableOfContents" class="{{if .IsPage}}{{ replace .RelPermalink "/" "_" }}{{end}}">
@@ -33,5 +33,3 @@
     <section id="main">
       <div class="container">
         {{ partial "docsnav.html" . }}
-
-

--- a/src/static/css/base.css
+++ b/src/static/css/base.css
@@ -651,7 +651,7 @@ a code {
   float: right; }
 
 .quickstart .other-link a, .quickstart .other-link a:hover {
-  background-color: transparent;
+  background-color: rgba(0, 0, 0, 0);
   border: none;
   font-size: 14px;
   line-height: 1.6; }


### PR DESCRIPTION
This propagates this change https://github.com/giantswarm/web-assets/pull/19 into docs

The `background-color: rgba(0, 0, 0, 0);` is simply a different output generated by a newer sass version