### PR TITLE
Fix docker-compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -20,7 +20,7 @@ services:
     volumes:
       - ./test/certificate:/etc/nginx/certs
     ports:
-      - "443:8000"
+      - "8000:8000"
 
   indexer:
     image: quay.io/giantswarm/docs-indexer:latest
@@ -34,5 +34,5 @@ services:
       KEEP_PROCESS_ALIVE: "True"
       ELASTICSEARCH_ENDPOINT: http://admin:e4dfbjb3rohi8qpoadsffodin@sitesearch:9200
       APIDOCS_BASE_URI: https://docs.giantswarm.io/api/
-      API_SPEC_FILES: yaml/spec.yaml,yaml/definitions.yaml,yaml/parameters.yaml
+      API_SPEC_FILES: yaml/spec.yaml,yaml/definitions.yaml,yaml/parameters.yaml,yaml/responses.yaml
       APIDOCS_BASE_PATH: /api/


### PR DESCRIPTION
Updates the docker-compose config to match the latest changes in https://github.com/giantswarm/docs-proxy/pull/26 and https://github.com/giantswarm/docs-indexer/pull/14

To be merged when https://github.com/giantswarm/docs-proxy/pull/26 is merged