### PR TITLE
Add related links to gsctl reference

### DIFF
--- a/src/content/reference/gsctl/create-cluster.md
+++ b/src/content/reference/gsctl/create-cluster.md
@@ -118,3 +118,4 @@ contact the Giant Swarm support team.
 - [`gsctl create kubeconfig`](../create-kubeconfig/): Obtaining a key pair and enabling `kubctl` to access a cluster
 - [`gsctl delete cluster`](../delete-cluster/): Reference for deleting a cluster
 - [`gsctl` Reference](../)
+- [API: Create cluster](/api/#operation/addCluster)

--- a/src/content/reference/gsctl/create-keypair.md
+++ b/src/content/reference/gsctl/create-keypair.md
@@ -64,3 +64,4 @@ __Warning:__ Setting `system:masters` as an organization means the user who uses
 ## Related
 
 - [`gsctl create kubeconfig`](../create-kubeconfig/): Create a key pair and prepare your kubectl configuration to access the cluster.
+- [API: Create key pair](/api/#operation/addKeyPair)

--- a/src/content/reference/gsctl/create-kubeconfig.md
+++ b/src/content/reference/gsctl/create-kubeconfig.md
@@ -144,3 +144,4 @@ resources to your cluster.
 
 - [`gsctl create keypair`](../cerate-keypair/): Create and download a key pair
 - [kubectl reference](https://kubernetes.io/docs/user-guide/kubectl-overview/)
+- [API: Create key pair](/api/#operation/addKeyPair)

--- a/src/content/reference/gsctl/delete-cluster.md
+++ b/src/content/reference/gsctl/delete-cluster.md
@@ -30,4 +30,6 @@ $ gsctl delete cluster --force --cluster=<cluster-id>
 
 ## Related
 
+- [`gsctl scale cluster`](../scale-cluster/)
 - [`gsctl` reference overview](../)
+- [API: Delete cluster](/api/#operation/deleteCluster)

--- a/src/content/reference/gsctl/info.md
+++ b/src/content/reference/gsctl/info.md
@@ -86,3 +86,4 @@ Maximum workers per cluster:  20
 
 - [`gsctl` reference overview](../)
 - [`gsctl select endpoint`](../select-endpoint/)
+- [API: Get information on the installation](/api/#operation/getInfo)

--- a/src/content/reference/gsctl/list-clusters.md
+++ b/src/content/reference/gsctl/list-clusters.md
@@ -30,6 +30,7 @@ The details displayed are:
 
 ## Related
 
-- [`gsctl create cluster`](../create-cluster/): Creating a cluster
-- [`gsctl delete cluster`](../create-cluster/): Deleting a cluster
-- [`gsctl list releases`](../list-releases/): Listing available releases
+- [`gsctl create cluster`](../create-cluster/)
+- [`gsctl scale cluster`](../scale-cluster/)
+- [`gsctl delete cluster`](../delete-cluster/)
+- [API: Get clusters](/api/#operation/getClusters)

--- a/src/content/reference/gsctl/list-keypairs.md
+++ b/src/content/reference/gsctl/list-keypairs.md
@@ -70,3 +70,4 @@ CREATED                 EXPIRES                 ID          DESCRIPTION         
 - [`gsctl create kubeconfig`](../create-kubeconfig/)
 - [X.509 on Wikipedia](https://en.wikipedia.org/wiki/X.509)
 - [Securing your cluster with RBAC and PSP](/guides/securing-with-rbac-and-psp/)
+- [API: Get key pairs](/api/#operation/getKeyPairs)

--- a/src/content/reference/gsctl/list-releases.md
+++ b/src/content/reference/gsctl/list-releases.md
@@ -80,3 +80,4 @@ Output details:
 
 - [`gsctl create cluster`](../create-cluster/)
 - [`gsctl show cluster`](../show-cluster/)
+- [API: Get releases](/api/#operation/getReleases)

--- a/src/content/reference/gsctl/login.md
+++ b/src/content/reference/gsctl/login.md
@@ -46,3 +46,4 @@ $ gsctl login <email> -e <endpoint> -p <password>
 ## Related
 
 - [`gsctl` reference overview](../)
+- [API: Create auth token](/api/#operation/createAuthToken)

--- a/src/content/reference/gsctl/scale-cluster.md
+++ b/src/content/reference/gsctl/scale-cluster.md
@@ -42,4 +42,6 @@ Use `gsctl scale cluster --help` for a additional (global) arguments.
 
 ## Related
 
+- [`gsctl delete cluster`](../delete-cluster/)
 - [`gsctl` reference overview](../)
+- [API: Modify cluster](/api/#operation/modifyCluster)

--- a/src/content/reference/gsctl/show-cluster.md
+++ b/src/content/reference/gsctl/show-cluster.md
@@ -71,3 +71,5 @@ The output lines in detail:
 
 - [`gsctl list clusters`](../list-clusters/)
 - [`gsctl scale cluster`](../scale-cluster/)
+- [`gsctl delete cluster`](../delete-cluster/)
+- [API: Get cluster details](/api/#operation/getCluster)


### PR DESCRIPTION
This adds more related links to the gsctl reference pages, including to the related API documentation.