### PR TITLE
Update and simplify scale cluster reference

### DIFF
--- a/src/content/reference/gsctl/scale-cluster.md
+++ b/src/content/reference/gsctl/scale-cluster.md
@@ -1,7 +1,7 @@
 +++
 title = "gsctl Command Reference: scale cluster"
 description = "The 'gsctl scale cluster' command allows to add or remove worker nodes to reach a desired number."
-date = "2018-03-28"
+date = "2018-08-21"
 type = "page"
 weight = 53
 +++
@@ -14,7 +14,11 @@ When using the command, you define how many worker nodes (short: workers) you in
 
 When **scaling up** (increasing the number of workers), the new workers will be configured in the same way as the existing workers.
 
-When **scaling down** (reducing the number of workers), the decision on which workers get removed is left to the AWS Auto Scaling Groups logic. We use the [default termination policy](http://docs.aws.amazon.com/autoscaling/latest/userguide/as-instance-termination.html#default-termination-policy). In brief, this policy will remove the oldest workers first. If all workers have the same age, the workers to be removed will be selected at random.
+When **scaling down** (reducing the number of workers), the decision on which workers get removed is left to the cloud provider.
+
+For AWS, the Auto Scaling Group's logic determines which workers are removed. We use the [default termination policy](http://docs.aws.amazon.com/autoscaling/latest/userguide/as-instance-termination.html#default-termination-policy). In brief, this policy will remove the oldest workers first. If all workers have the same age, the workers to be removed will be selected at random.
+
+On Azure, the virtual machine scale set (VMSS) behaviour is responsible for the termination order. Here, VMs with the highest IDs are removed first.
 
 ## Command Usage {#usage}
 
@@ -34,9 +38,6 @@ After the command execution is finished, it can take a couple of minutes until t
 
 - `-w`, `--num-workers` (required): The desired amount of worker nodes after scaling.
 - `--force`: If set, no confirmation is required when reducing the number of workers. You should only use this argument in automations when you are sure that reducing the number of workers is desired.
-- `--memory-gb`: Currently not functional. Once scaling is supported on KVM, which argument will allow to configure the amount of RAM of the worker node(s) to be added.
-- `--storage-gb`: Currently not functional. Once scaling is supported on KVM, which argument will allow to configure the amount of local storage of the worker node(s) to be added.
-- `--num-cpus`: Currently not functional. Once scaling is supported on KVM, which argument will allow to configure the number of CPU cores (threads) of the worker node(s) to be added.
 
 Use `gsctl scale cluster --help` for a additional (global) arguments.
 


### PR DESCRIPTION
This updates the reference for "scale cluster" command by

- removing info on KVM-specific restrictions
- Adding Azure scaling logic details
- removing the description of flags that no longer make sense