### PR TITLE
Improve docker-compose entry for docs-indexer

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -24,6 +24,7 @@ services:
 
   indexer:
     image: quay.io/giantswarm/docs-indexer:latest
+    restart: on-failure
     depends_on:
       - sitesearch
     environment:
@@ -31,7 +32,6 @@ services:
       REPOSITORY_BRANCH: master
       REPOSITORY_SUBFOLDER: src/content
       EXTERNAL_REPOSITORY_SUBFOLDER: docs
-      KEEP_PROCESS_ALIVE: "True"
       ELASTICSEARCH_ENDPOINT: http://admin:e4dfbjb3rohi8qpoadsffodin@sitesearch:9200
       APIDOCS_BASE_URI: https://docs.giantswarm.io/api/
       API_SPEC_FILES: yaml/spec.yaml,yaml/definitions.yaml,yaml/parameters.yaml,yaml/responses.yaml


### PR DESCRIPTION
This removes the need to keep the indexer process running forever after it did its job.