### PR TITLE
Reference page for 'gsctl upate organisation set-credentials'

### DIFF
--- a/src/content/reference/gsctl/index.md
+++ b/src/content/reference/gsctl/index.md
@@ -1,7 +1,7 @@
 +++
 title = "gsctl Reference"
 description = "Documentation on gsctl, the Giant Swarm command line utility to create and delete clusters, create key pairs and more."
-date = "2018-04-26"
+date = "2018-09-11"
 type = "page"
 weight = 10
 +++
@@ -14,25 +14,26 @@ gsctl is the command line utility to manage your Giant Swarm clusters.
 
 Follow the links below for detailed documentation, where available. You can also always use `gsctl <command> --help`.
 
-| Command              | Description
-|----------------------|------------
-| `create cluster`     | [Create a new cluster](create-cluster/)
-| `create keypair`     | [Create and download new key pair](create-keypair/)
-| `create kubeconfig`  | [Create/download new key pair and update `kubectl` configuration](create-kubeconfig/)
-| `delete cluster`     | [Delete cluster](delete-cluster/)
-| `info`               | [Print information on status, configuration, and the installation](info/)
-| `list endpoints`     | [List endpoints](list-endpoints/)
-| `list clusters`      | [List clusters](list-clusters/)
-| `list organizations` | List organizations
-| `list keypairs`      | [List key pairs](list-keypairs/)
-| `list releases`      | [List releases](list-releases/)
-| `login`              | [Sign in as a user](login/)
-| `logout`             | Sign out
-| `ping`               | Check API connection
-| `scale cluster`      | [Add or remove worker nodes of a cluster](scale-cluster/)
-| `select endpoint`    | [Select an endpoint](select-endpoint/)
-| `show cluster`       | [Show cluster details](show-cluster/)
-| `version`            | Print version number
+| Command                               | Description
+|---------------------------------------|------------
+| `create cluster`                      | [Create a new cluster](create-cluster/)
+| `create keypair`                      | [Create and download new key pair](create-keypair/)
+| `create kubeconfig`                   | [Create/download new key pair and update `kubectl` configuration](create-kubeconfig/)
+| `delete cluster`                      | [Delete cluster](delete-cluster/)
+| `info`                                | [Print information on status, configuration, and the installation](info/)
+| `list endpoints`                      | [List endpoints](list-endpoints/)
+| `list clusters`                       | [List clusters](list-clusters/)
+| `list organizations`                  | List organizations
+| `list keypairs`                       | [List key pairs](list-keypairs/)
+| `list releases`                       | [List releases](list-releases/)
+| `login`                               | [Sign in as a user](login/)
+| `logout`                              | Sign out
+| `ping`                                | Check API connection
+| `scale cluster`                       | [Add or remove worker nodes of a cluster](scale-cluster/)
+| `select endpoint`                     | [Select an endpoint](select-endpoint/)
+| `show cluster`                        | [Show cluster details](show-cluster/)
+| `update organization set-credentials` | [Set provider credentials for an organnization](update-org-set-credentials/)
+| `version`                             | Print version number
 
 
 ## Installing and Updating {#install}

--- a/src/content/reference/gsctl/info.md
+++ b/src/content/reference/gsctl/info.md
@@ -1,6 +1,6 @@
 +++
 title = "gsctl Command Reference: info"
-description = "The 'gsctl info' lets you display information on your current status and configuration"
+description = "The 'gsctl info' command lets you display information on your current status and configuration"
 date = "2018-04-26"
 type = "page"
 weight = 41

--- a/src/content/reference/gsctl/update-org-set-credentials.md
+++ b/src/content/reference/gsctl/update-org-set-credentials.md
@@ -1,0 +1,74 @@
++++
+title = "gsctl Command Reference: update organization set-credentials"
+description = "The 'gsctl update organization set-credentials' command allows to set cloud provider credentials for an organization."
+date = "2018-09-11"
+type = "page"
+weight = 55
++++
+
+# `update organization set-credentials`
+
+Giant Swarm allows you to run clusters in your own cloud provider account/subscription. We call this by the catchy term "Bring Your Own Cloud" (BYOC). As a prerequisite, the organizaiton that should own the clusters has to be prepared with cloud privider credentials.
+
+Please refer to our detailed guides on how to prepare roles and credentials inside you AWS account or Azure subscription:
+
+- [Prepare an AWS account to run Giant Swarm tenant clusters](/guides/prepare-aws-account-for-tenant-clusters/)
+- [Prepare an Azure subscription to run Giant Swarm tenant clusters](/guides/prepare-azure-subscription-for-tenant-clusters/)
+
+gsctl provides this command to store the credentials connected to your organization. After doing this, you will want to [create a cluster](../create-cluster/) owned by the organization configured that way.
+
+**Note:** The credentials of an organization are currently immutable. Once set, you cannot modify or remove them. However you can create and delete organization at will.
+
+## Usage
+
+Regardless which is your cloud provider, you need an organization to work with. If you haven't created one for the purpose yet, this can be done in our web user interface.
+
+In this gsctl command, the flag `-o` or `--organization` specifies the organization to set the credentials for.
+
+### For AWS
+
+For AWS you provide two ARN (Amazon Resource Name) strings for two separate roles. Here is the general syntax:
+
+```nohighlight
+gsctl update organization set-credentials \
+  -o|--organization <org-id>  \
+  --aws-operator-role <role-arn> \
+  --aws-admin-role <role-arn>
+```
+
+The `--aws-operator-role` flag defines the role ARN for the role to be used by our software running the clusters in your account. The `--aws-admin-role` flag takes the ARN or a role to be assumed by our support staff members. Both are mandatory.
+
+For example, if your organization name was `myorg` and your AWS account ID was `0123456789`, the command would be:
+
+```nohighlight
+gsctl update organization set-credentials \
+  -o myorg  \
+  --aws-operator-role arn:aws:iam::0123456789:role/GiantSwarmAWSOperator \
+  --aws-admin-role arn:aws:iam::0123456789:role/GiantSwarmAdmin
+```
+
+## For Azure
+
+For Azure we require you to pass four credential details. Here is the general syntax:
+
+```nohighlight
+gsctl update organization set-credentials \
+  -o|--organization <org-id>  \
+  --azure-subscription-id <subcription-id> \
+  --azure-tenant-id <tenant-id> \
+  --azure-client-id <client-id> \
+  --azure-secret-key <secret-key> \
+```
+
+The flags mean:
+
+- `--azure-subscription-id`: ID of your Azure subscription
+- `--azure-tenant-id`: ID of the tenant to use within your subscription
+- `--azure-client-id`: ID of the service principal to use by our software and staff
+- `--azure-secret-key`: Secret key for the above service principal
+
+## Related
+
+- [Prepare an AWS account to run Giant Swarm tenant clusters](/guides/prepare-aws-account-for-tenant-clusters/)
+- [Prepare an Azure subscription to run Giant Swarm tenant clusters](/guides/prepare-azure-subscription-for-tenant-clusters/)
+- [API: Set credentials](https://docs.giantswarm.io/api/#operation/addCredentials)


### PR DESCRIPTION
For https://github.com/giantswarm/giantswarm/issues/3987

This adds a reference page for the `gsctl` command added in https://github.com/giantswarm/gsctl/pull/291