### PR TITLE
Set specific image tag to nginx:1.14.0-alpine, fix linkcheck

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,15 @@ jobs:
       
       - run:
           name: Linkcheck
-          command: make linkcheck
+          command: |
+            docker run -d --rm --name server -p 80:80 quay.io/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME:$CIRCLE_SHA1
+            sleep 2
+            docker run --rm -ti --name linkchecker \
+                --link server:server \
+                jare/linkchecker \
+                http://server:80 \
+                --check-extern -t 5 --ignore-url /api/
+            docker kill server
 
       - deploy:
           name: Deploy (only if branch is "master")

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:stable-alpine
+FROM nginx:1.14.0-alpine
 
 EXPOSE  80
 WORKDIR /


### PR DESCRIPTION
Two chores:

- sets the Docker image to a specific version, so that we know what we are running.
- fixes the linkcheck in CI to actually use the image tag built in the previous steps, not `latest`