### PR TITLE
Align intermediate headline case

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is the main documentation repository for the documentation available at https://docs.giantswarm.io.
 
-## Repository Overview
+## Repository overview
 
 
 This repository named `docs` holds the main **content** of our documentation. The documentation

--- a/README.md
+++ b/README.md
@@ -102,6 +102,32 @@ The best way to contribute changes are pull requests. Please note the following 
 
 - When creating a pull request, please remember you accept that your contribution will be published under the Creative Commons referenced below. Giant Swarm will be able to use your content without restriction.   Giant Swarm is not obliged to list you as the author of your contribution, but will attempt to do so where possible.
 
+## Style
+
+We use [Title Case](https://titlecase.com/) for the main article headline, but not for lower level headlines.
+
+For **code blocks**, we give language hints to ensure proper syntax highlighting. A YAML block, for example, is opened with triple backticks followed by `yaml`.
+
+However, shell commands and their output get the fake hint `nohighlight` to prevent any funky syntax highlighting.
+
+Shell commands in code blocks are prepended with a `$ ` (dollar sign and one blank character).
+
+We use long-form CLI flags and avoid the possible equal sign between flag name and value, for best readability.
+
+Right:
+
+```nohighlight
+$ gsctl create cluster --owner acme
+```
+
+Wrong:
+
+```nohighlight
+$ gsctl create cluster --owner=acme
+$ gsctl create cluster -o=acme
+$ gsctl create cluster -o acme
+```
+
 ## License
 
 The content in this repository is licensed under the [Creative Commons Attribution ShareAlike](http://creativecommons.org/licenses/by-sa/4.0/) license.

--- a/src/content/basics/aws-architecture/index.md
+++ b/src/content/basics/aws-architecture/index.md
@@ -11,7 +11,7 @@ categories = ["basics"]
 
 Giant Swarm's Architecture is split into two logical parts, one being the Control Plane and the other being multiple Tenant Clusters. Among other services (for details see Service Architecture below), the control plane runs our [AWS Operator](https://github.com/giantswarm/aws-operator), which handles the full lifecycle management of Tenant Clusters.
 
-## Giant Swarm Control Plane
+## Giant Swarm control plane
 
 ![Control Plane Architecture](/img/architecture-aws-control-plane.png)
 
@@ -23,7 +23,7 @@ The Giant Swarm API, Monitoring and Alerting frontends as well as our Web Manage
 
 Access to those interfaces can be configured to work with the customers' Identity Management System.
 
-## Giant Swarm Tenant Cluster
+## Giant Swarm tenant cluster
 
 ![Tenant Cluster Architecture](/img/architecture-aws-tenant-cluster.png)
 
@@ -35,7 +35,7 @@ One is the Kubernetes API that can be connected to your Identity Management Syst
 
 Networking within the cluster is handled through Calico. 
 
-## Service Architecture
+## Service architecture
 
 ![Service Architecture](/img/architecture-aws-services.png)
 

--- a/src/content/basics/giant-swarm-operational-layers/index.md
+++ b/src/content/basics/giant-swarm-operational-layers/index.md
@@ -11,7 +11,7 @@ categories = ["basics"]
 
 A Giant Swarm installation has several operational layers, which depict a separation of concerns both on an operational as well as on a security level. In the following we will define the layers and explain the intended operational model.
 
-## Operational Layers
+## Operational layers
 
 We will go through the operational layers one by one from the bottom (infrastructure) to the top (user space) and explain the intended opreational model by defining (typical) users and permission levels. The layers are:
 
@@ -28,7 +28,7 @@ This layer does not include the actual hardware and maintenance of the data cent
 
 Giant Swarm SREs on this layer have root level SSH access to everything that pertains to a Giant Swarm installation. This is facilitated by a Single Sign On (SSO) mechanism including MFA (multi-factor authentication). On the cloud they additionally have access to the cloud account/subscription through a role to set up and manage the cloud resources.
 
-### Giant Swarm Control Plane {#controlplane}
+### Giant Swarm control plane {#controlplane}
 
 The Giant Swarm Control Plane consists mainly of services running inside the Control Plane Kubernetes cluster.
 
@@ -52,7 +52,7 @@ This is the standard type of Giant Swarm API user that is given out to DevOps/Op
 
 Such users have access to all clusters in the organizations they belong to. They can create new clusters and organizations as well as manage or delete cluster and organization that they are part of. They can be considered multi-cluster admins.
 
-### User Space {#userspace}
+### User space {#userspace}
 
 The user space layer is defined as the layer pertaining to a single Tenant Cluster Kubernetes API. Tenant Cluster are the Kubernetes clusters that run your workloads.
 
@@ -62,7 +62,7 @@ However, a user with access to the Kubernetes API does not by default also gain 
 
 This enables the customer to individually set up their user management according to the needs of their organization. The configuration for this can be kept in version control and needs to be done by an initial cluster admin user, which can be created by the Giant Swarm API user mentioned above.
 
-## Further Reading
+## Further reading
 
 - [Securing your Cluster with RBAC and PSP](https://docs.giantswarm.io/guides/securing-with-rbac-and-psp/)
 - [Creating a kubeconfig with gsctl](https://docs.giantswarm.io/reference/gsctl/create-kubeconfig/)

--- a/src/content/basics/kubernetes-on-giant-swarm/index.md
+++ b/src/content/basics/kubernetes-on-giant-swarm/index.md
@@ -30,7 +30,7 @@ There are some things not included in the cluster as managed by us:
 
 - Additional user-space services like Dashboard, Monitoring, Logging, Registry, etc. are not installed (getting them running is [really easy](/guides/), though),
 
-## High Availability and Resilience
+## High availability and resilience
 
 As mentioned above your cluster has a single running master. However, the cluster is set up in a way that your cluster keeps running even if the master is unavailable for a while (e.g. due to planned upgrades, failure, etc.), the only slight degradation you might notice is that while the master is down, you cannot change the state of your pods and other resources. As soon as the master is up again, you regain full control.
 

--- a/src/content/basics/kubernetes-resources/index.md
+++ b/src/content/basics/kubernetes-resources/index.md
@@ -11,11 +11,11 @@ categories = ["basics"]
 
 As your Giant Swarm cluster offers you a fully-managed Kubernetes, the fundamentals you need are basically concluded by the userside documentation of Kubernetes. We have compiled a list of the best resources to get you started fast.
 
-## Official Kubernetes Documentation
+## Official kubernetes documentation
 
 The first and most important source to enquire should be the [official Kubernetes documentation](http://kubernetes.io/docs/). And as the administration side is mostly taken care of by Giant Swarm, we recommend focussing on the [User Guide](http://kubernetes.io/docs/user-guide/) including the [Kubernetes 101](http://kubernetes.io/docs/user-guide/walkthrough/) and [201](http://kubernetes.io/docs/user-guide/walkthrough/k8s201/).
 
-## Useful Primitives
+## Useful primitives
 
 ### Pods 
 
@@ -23,7 +23,7 @@ Pods are the smallest deployable units of computing that can be created and mana
 
 [Pods Reference](http://kubernetes.io/docs/user-guide/pods/)
 
-### Labels & Selectors
+### Labels and selectors
 
 Labels are key/value pairs that can be attached to objects, such as pods, but also any other object in Kubernetes, even nodes. They should be used to specify identifying attributes of objects that are meaningful and relevant to users. You can then use Selectors to select single or groups of objects.
 
@@ -79,7 +79,7 @@ Giant Swarm clusters come with KubeDNS installed by default. You can use DNS to 
 
 [DNS Documentation](http://releases.k8s.io/master/build/kube-dns/README.md)
 
-## Useful Tools and Content
+## Useful tools and content
 
 There are some useful tools and content out there that help you with get to know Kubernetes.
 
@@ -87,7 +87,7 @@ There are some useful tools and content out there that help you with get to know
 - [Kompose](https://github.com/kubernetes-incubator/kompose) is a tool to move from `docker-compose` to Kubernetes.
 - [Helm](https://github.com/kubernetes/helm/blob/master/docs/install.md) is a package manager for Kubernetes that helps you deploy common applications to your cluster.
 
-## Useful Blog Posts
+## Useful blog posts
 
 We have also written some more detailed out blog posts about the basic Kubernetes concepts and use cases for them.
 
@@ -98,6 +98,6 @@ We have also written some more detailed out blog posts about the basic Kubernete
 - [Understanding Basic Kubernetes Concepts V - Daemon Sets and Jobs](https://blog.giantswarm.io/understanding-basic-kubernetes-concepts-v-daemon-sets-and-jobs/)
 - [Getting Started With A Local Kubernetes Environment](https://blog.giantswarm.io/getting-started-with-a-local-kubernetes-environment/)
 
-## Extended Reading
+## Extended reading
 
 For more extensive and deeper information on Kubernetes you should check out the [Reference Documentation](http://kubernetes.io/docs/reference/), which includes among others the [API documentation](http://kubernetes.io/docs/api/), [CLI documentation](http://kubernetes.io/docs/user-guide/kubectl-overview/), and a Glossary with deeper explanations of all resources.

--- a/src/content/basics/onprem-architecture/index.md
+++ b/src/content/basics/onprem-architecture/index.md
@@ -29,7 +29,7 @@ Via the Giant Swarm API, our [CLI](https://github.com/giantswarm/gsctl), or our 
 
 Access to the K8s API goes through the Control Plane. We can connect your Load Balancer for Ingress access. This Load Balancer can be either statically configured with healthchecks or controlled via API. Depending on the data center setup, there are different options that need to be evaluated.
 
-## Service Architecture
+## Service architecture
 
 ![Service Architecture](/img/architecture-aws-services.png)
 

--- a/src/content/basics/security/index.md
+++ b/src/content/basics/security/index.md
@@ -15,7 +15,7 @@ This reference gives you details on security-related measures in a Giant Swarm i
 
 ### Kubernetes {#k8s}
 
-#### Encryption of Secrets {#k8s-secrets}
+#### Encryption of secrets {#k8s-secrets}
 
 Secret encryption is ensured by running the Kubernetes `api-server` with the flag `--experimental-encryption-provider-config`. This means that all secrets are stored in Etcd in encrypted form and decrypted when accessed.
 
@@ -27,11 +27,11 @@ To learn more about secret encryption, look up [Encrypting data at rest](https:/
 
 This section applies to AWS-based installations only.
 
-#### Encryption of Local Storage {#local-storage}
+#### Encryption of local storage {#local-storage}
 
 Non-persistent volumes as well as docker images and logs are stored under `/var/lib/docker`. On AWS, `/var/lib/docker` is an Elastic Block Storage (EBS) volume. This volume is encrypted via AWS EBS Encryption. The key is created, stored and deleted using AWS Key Management Service (KMS).
 
-#### Encryption of Persistent Storage {#persistent-storage}
+#### Encryption of persistent storage {#persistent-storage}
 
 Persistent storage is managed by the `StorageClass` resource in Kubernetes. By default, the `StorageClass` resource is provided as an Elastic Block Storage (EBS) volumes. These volumes are encrypted via AWS EBS Encryption. The key is created, stored and deleted using AWS Key Management Service (KMS).
 

--- a/src/content/guides/accessing-services-from-the-outside/index.md
+++ b/src/content/guides/accessing-services-from-the-outside/index.md
@@ -15,11 +15,11 @@ Once you have a Pod or Service running on your cluster, you might want to access
 - [Authenticated access to a Pod through `kubectl port-forward`](#port-forward): This gives you direct network access to a port of a Pod, for test purposes.
 - [Authenticated access to a Service through the API proxy](#api-access): This gives you access to a Kubernetes Service, for test purposes.
 
-## Setting up a Public Ingress {#public-ingress}
+## Setting up a public Ingress {#public-ingress}
 
 Before we explain how to set up Ingress for a Service, please read the next section carefully to make sure the guide matches your situation as a Giant Swarm user.
 
-### Knowing your Ingress Base Domain {#base-zone}
+### Knowing your Ingress base domain {#base-zone}
 
 Setting up Ingress means to make Services publicly available via DNS names. For an application facing the public, you will eventually want to set up names ending in your own domain.
 
@@ -139,7 +139,7 @@ kubectl port-forward -n NAMESPACE $POD <local-port>:<pod-port> &
 
 Now you can access your Pod locally via `localhost:<local-port>`.
 
-## Access any Service from through the API proxy {#api-access}
+## Access any service from through the API proxy {#api-access}
 
 The Kubernetes API comes with an inbuilt proxy, which you can use to access Services deployed on your cluster. The URL schema is
 

--- a/src/content/guides/advanced-coredns-configuration/index.md
+++ b/src/content/guides/advanced-coredns-configuration/index.md
@@ -25,7 +25,7 @@ On cluster creation the ConfigMap is empty and below-mentioned defaults will be 
 
 __Warning:__ Please do not edit any of the other CoreDNS related resources. Only the user ConfigMap is safe to edit.
 
-## Cache Settings
+## Cache settings
 
 By default we set the cache TTL for CoreDNS to 30 seconds. You can customize the cache settings of CoreDNS by setting the value of the cache field in the user ConfigMap like following.
 
@@ -38,7 +38,7 @@ Above setting increases the TTL to 60 seconds.
 
 The cache plugin also supports much more detailed configuration which is documented in the [upstream documentation](https://coredns.io/plugins/cache/).
 
-## Additional Proxies
+## Additional proxies
 
 The default proxy entry we set in CoreDNS is
 

--- a/src/content/guides/advanced-ingress-configuration/index.md
+++ b/src/content/guides/advanced-ingress-configuration/index.md
@@ -14,7 +14,7 @@ The [NGINX-based Ingress Controller](https://github.com/kubernetes/ingress-nginx
 - [Per-Service options](#yaml) in each Ingress' YAML definition either directly or via [Annotations](https://kubernetes.io/docs/user-guide/annotations/).
 - [Global options](#configmap) that influence all Ingresses of a cluster via a ConfigMap.
 
-## Per-Service Options {#yaml}
+## Per-Service options {#yaml}
 
 ### Aggregating Ingresses
 
@@ -75,7 +75,7 @@ __Note:__ Your applications need to be capable of running on a non-root path eit
 
 If your cluster has TLS enabled, you can terminate TLS either in your application itself by enabling SSL passthrough or let the Ingress Controller terminate for you.
 
-#### SSL Passthrough
+#### SSL passthrough
 
 __Warning:__ This feature was disabled by default in Nginx ingress controller managed by Giant Swarm. Reason is a potential [crash](https://github.com/kubernetes/ingress-nginx/issues/2354) of internal TCP proxier. We recommend to [terminate TLS in ingress controller](#terminating-tls-in-ingress-controller) instead.
 
@@ -324,7 +324,7 @@ Make sure to use the exact annotation scheme `nginx.ingress.kubernetes.io/config
 
 Check out the [ingress-nginx repository](https://github.com/kubernetes/ingress-nginx/blob/master/docs/examples/customization/configuration-snippets/ingress.yaml) for more information.
 
-## Global (per Cluster) Options {#configmap}
+## Global (per cluster) options {#configmap}
 
 Your Giant Swarm installation comes with some global defaults for Ingress Controller configuration. However, you can override these defaults by setting your per cluster configuration in form of a ConfigMap named `nginx-ingress-controller-user-values` located in your `kube-system` namespace.
 

--- a/src/content/guides/authenticating-with-microsoft-azure-active-directory/index.md
+++ b/src/content/guides/authenticating-with-microsoft-azure-active-directory/index.md
@@ -13,7 +13,7 @@ A Giant Swarm installation can be configured to authenticate with Microsoft Azur
 
 On the user side, you can then authenticate using the Azure Auth Provider of `kubectl`. Your access to a cluster is decided by RBAC roles mapped to your user or group.
 
-## Setting up `kubectl` for Azure Auth
+## Setting up `kubectl` for Azure auth
 
 ### 1. Set up a user
 
@@ -59,7 +59,7 @@ This step needs to be done only once and will register your kubectl as an authen
 
 __Note__ that in some cases (depending on AD settings) the device authentication can only be done in a Browser running on a Windows machine.
 
-## Creating a `kubeconfig` for General Usage
+## Creating a `kubeconfig` for general usage
 
 If you are a Cluster Admin and want to create `kubeconfig` files to give out to your users you can use following template:
 
@@ -92,7 +92,7 @@ If you set all the above names to something generic, you can send the same file 
 
 Furthermore, to make the `kubeconfig` self-contained, you can replace `/path/to/ca.crt` with an inline representation of the file. For that you need to base64-encode the contents of `ca.crt` and paste them into the `kubeconfig`.
 
-## Binding Roles to Users and Groups coming from AAD
+## Binding roles to users and groups coming from AAD
 
 When authenticating with AAD your user identifies to Kubernetes with a username and the groups you are a member of in AAD. A Cluster Admin can bind roles to these to grant access on a specific cluster.
 
@@ -103,7 +103,7 @@ In the following examples we'll use one of the default cluster roles.
 
 __Note__ that you can only bind roles if your own role is wider defined than the role you want to bind for others. When in doubt use `cluster-admin` to apply bindings.
 
-### Binding a Single User
+### Binding a single user
 
 AAD prefixes usernames so that they look like the following:
 
@@ -130,7 +130,7 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 ```
 
-### Binding a Group of Users
+### Binding a group of users
 
 Unlike usernames, groups are not prefixed. You can identify them by the Object ID of the group in AAD.
 
@@ -151,11 +151,11 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 ```
 
-### Revoking Access
+### Revoking access
 
 Access is revoked as soon as the user has either been removed from a bound group or completely from the AAD tenant.
 
-## Further Reading
+## Further reading
 
 - [Securing your Cluster with RBAC and PSP
 ](https://docs.giantswarm.io/guides/securing-with-rbac-and-psp/)

--- a/src/content/guides/importing-certificates/index.md
+++ b/src/content/guides/importing-certificates/index.md
@@ -68,7 +68,7 @@ curl \
   https://api.mycluster.k8s.gigantic.io/api/v1
 ```
 
-## Importing CA and Certificate {#importing}
+## Importing CA and certificate {#importing}
 
 Operating systems and HTTP clients have a variety of ways to manage CAs and certificates. Even on one platform there are often several ways to achieve the same thing. We focus here on the more popular combinations of operating system and client, and we opt for ways using command line utilities, as we think this will mostly suit the target audience of this tutorial.
 
@@ -86,7 +86,7 @@ Operating systems and HTTP clients have a variety of ways to manage CAs and cert
 
 ### Mac OS
 
-#### Mac OS Keychain {#mac-os-keychain}
+#### Mac OS keychain {#mac-os-keychain}
 
 On Mac OS, browsers like **Safari** and **Chrome** rely on the system keychain for CA information and certificates. Firefox is an exception and treated in a [separate section](#mac-os-firefox).
 

--- a/src/content/guides/install-kubernetes-dashboard/index.md
+++ b/src/content/guides/install-kubernetes-dashboard/index.md
@@ -17,7 +17,7 @@ Keep in mind that Dashboard despite it 1.x version number is still an early-stag
 
 If you want to have some simple metrics (as shown in the screenshot above) integrated in your Dashboard, you can additionally [install Heapster](/guides/kubernetes-heapster/).
 
-## Deploying Dashboard
+## Deploying dashboard
 
 Deploying dashboard is easy and straight forward.
 
@@ -40,7 +40,7 @@ and then open your browser at http://localhost:8001/api/v1/namespaces/kube-syste
 
 You need to generate a Service Account token be have access to the dashboard.
 
-### Create a Cluster Admin service account
+### Create a cluster admin service account
 
 You can create a service account with `cluster-admin` role that will have access to all your resources.
 
@@ -53,9 +53,10 @@ $ kubectl create clusterrolebinding cluster-admin-dashboard-sa \
 
 Copy the token from the generated secret
 
-```
+```nohighlight
 $ kubectl get secret | grep cluster-admin-dashboard-sa
 cluster-admin-dashboard-sa-token-6xm8l   kubernetes.io/service-account-token   3         18m
+
 $ kubectl describe secret cluster-admin-dashboard-sa-token-6xm8l
 Name:         cluster-admin-dashboard-sa-token-6xm8l
 Namespace:    default
@@ -74,7 +75,7 @@ token:      eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJrdWJlcm5ldGVzL3NlcnZ
 
 Use this token to log into the dashboard.
 
-### Create Limited resources access service account
+### Create limited resources access service account
 
 You can restrict the cluster access by creating a limited clusterrole.
 
@@ -105,7 +106,7 @@ $ kubectl create clusterrolebinding pod-viewer-sa \
 
 Copy the token from the generated secret
 
-```
+```nohighlight
 $ kubectl get secret | grep pod-viewer
 pod-viewer-sa-token-2t2r9     kubernetes.io/service-account-token   3         2m
 kubectl describe secret pod-viewer-sa-token-2t2r9
@@ -128,7 +129,7 @@ After login, the user can only see `namespaces` and `pods`.
 
 ![Kubernetes Dashboard Limited user](/img/dashboard-pod-viewer.png)
 
-## Further Reading
+## Further reading
 
 - [Official User Guide](http://kubernetes.io/docs/user-guide/ui/)
 - [On Securing the Kubernetes Dashboard](https://blog.heptio.com/on-securing-the-kubernetes-dashboard-16b09b1b7aca)

--- a/src/content/guides/kubernetes-heapster/index.md
+++ b/src/content/guides/kubernetes-heapster/index.md
@@ -47,7 +47,7 @@ There are some common cases where Core Metrics are used by Kubernetes:
 - Kubernetes dashboard: see Pod and Nodes metrics integrated into the main Kubernetes UI dashboard. More info [here](/guides/install-kubernetes-dashboard)
 - Scheduler: in the future, core metrics will be considered in order to schedule best-effort Pods.
 
-## Further Reading
+## Further reading
 
 - [Kubernetes Monitoring Architecture](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/instrumentation/monitoring_architecture.md)
 - [Resource Metrics API](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/instrumentation/resource-metrics-api.md)

--- a/src/content/guides/limiting-pod-communication-with-network-policies/index.md
+++ b/src/content/guides/limiting-pod-communication-with-network-policies/index.md
@@ -15,7 +15,7 @@ Currently the API only includes Ingress rules, i.e. you can only limit traffic t
 
 Here we give an overview and introduction of how to create and use these policies.
 
-## Ingress Network Policies
+## Ingress network policies
 
 NetworkPolicy resources in Kubernetes use labels to select pods and define rules which specify what traffic is allowed to the selected pods.
 
@@ -27,7 +27,7 @@ Note that Network Policies are additive, so having two Network Policies that sel
 
 Keep in mind that a NetworkPolicy is applied to a particular Namespace and only selects Pods in that particular Namespace.
 
-### Default Policies
+### Default policies
 
 You can create default policies for a Namespace by creating a NetworkPolicy that select all Pods:
 
@@ -52,11 +52,11 @@ will result in all traffic to all Pods in the Namespace to be denied.
 
 Note that the namespace needs to exist before you apply the NetworkPolicy to it.
 
-### Creating Selective Network Policies
+### Creating selective network policies
 
 No matter if you set default policies or not, you can limit access to certain Pods by creating a NetworkPolicy that selects them.
 
-#### Allowing Specific Pod to Pod Access
+#### Allowing specific pod to pod access
 
 In the following example we allow traffic to Pods labeled `role: backend` from Pods with the `role: frontend` label and only on TCP port 6379.
 
@@ -85,7 +85,7 @@ You need to apply this policy to the Namespace that the backend Pods live in.
 kubectl -n <namespace> apply -f backend-access.yaml
 ```
 
-#### Allowing Pod to Pod Access within a Namespace
+#### Allowing pod to pod access within a namespace
 
 In some cases you might want to allow all intra-namespace communication. For this you can use open Pod selectors that catch all Pods.
 
@@ -122,7 +122,7 @@ kubectl apply -f freeforall-namespace.yaml
 kubectl apply -f intra-namespace-policy.yaml
 ```
 
-#### Allowing Traffic from Outside the Cluster
+#### Allowing traffic from outside the cluster
 
 In the case that you have publicly exposed a Service through Ingress and you have a default-deny policy in place or just want to limit that traffic to a specific port, you need a Network Policy like the following.
 
@@ -143,7 +143,7 @@ spec:
 
 The above will allow any traffic (no matter if outside or inside your cluster) to the Pods on port 80.
 
-## Limiting Egress Traffic with Calico Policies
+## Limiting egress traffic with calico policies
 
 For creating Egress Policies we currently have to circumvent Kubernetes and talk directly to Calico [using `calicoctl`](https://docs.projectcalico.org/v2.2/getting-started/kubernetes/tutorials/using-calicoctl).
 
@@ -158,7 +158,7 @@ For this we need two policies:
 1. Deny Egress for the whole cluster
 2. Allow Egress for the trusted namespace
 
-### 1. Default Deny Egress
+### 1. Default deny egress
 
 Following Egress policy denies outgoing connections from all sources to our specified destination. With `order: 500` we ensure that this is applied before any Kubernetes policies.
 
@@ -182,7 +182,7 @@ We apply the policy with
 calicoctl create -f default-deny-egress.yaml
 ```
 
-### 2. Allow Egress for Trusted Namespace
+### 2. Allow egress for trusted namespace
 
 For this we create another policy, just selecting our `trusted` namespace. Again, the order of 400 will ensure this is applied before any Kubernetes policies.
 
@@ -209,7 +209,7 @@ calicoctl create -f trusted-namespace.yaml
 
 Now connections to `8.8.8.8` will only be possible from Pods living in the namespace called `trusted`. As with Ingress Policies all other connections from the Pods will be disallowed.
 
-## Further Reading
+## Further reading
 
 - [The Unoffical Guide to Kubernetes Network Policies](https://ahmet.im/blog/kubernetes-network-policy/)
 - [Network Policies](https://kubernetes.io/docs/concepts/services-networking/networkpolicies/)

--- a/src/content/guides/prepare-azure-subscription-for-tenant-clusters/index.md
+++ b/src/content/guides/prepare-azure-subscription-for-tenant-clusters/index.md
@@ -20,7 +20,7 @@ In order to run Giant Swarm tenant clusters, an Azure subscription needs the fol
 - Role definition: a set of permission to operate tenant clusters in the Azure subscription.
 - Service Principal: an identity (bound to the previously defined Role definition) to access the Azure subscription.
 
-## Create Azure Role definition and Service Principal
+## Create Azure role definition and Service Principal
 
 In order to perform necessary actions to deploy and maintain tenant clusters in your Azure subscription, `azure-operator` needs to access the subscription using a Service Principal.
 Here we describe all the steps to set it up.
@@ -59,7 +59,7 @@ $ az role definition create --role-definition @guest.json
 
 On success this command prints the created role definition.
 
-#### 3. Service Principal
+#### 3. Service principal
 
 Create the service principal using the Azure CLI:
 

--- a/src/content/guides/recommendations-and-best-practices/index.md
+++ b/src/content/guides/recommendations-and-best-practices/index.md
@@ -11,9 +11,9 @@ tags = ["tutorial"]
 
 Keep in mind that these recommendations are just basic rules-of-thumb that you should adapt to your needs.
 
-## Creating a Cluster
+## Creating a cluster
 
-### Cluster Sizing
+### Cluster sizing
 
 There are a few questions that you might want to answer to determine the right size for your cluster:
 
@@ -30,7 +30,7 @@ You don't want your development environment to be down, because of a minor node 
 
 For production usage the cluster should have at least 5 nodes and a buffer of 2 nodes.
 
-#### Worker Node Size
+#### Worker node size
 
 When it comes to sizing your worker nodes, there should generally be a preference for more smaller nodes vs less bigger ones.
 However, avoid node sizes of less than 1 core and 2GB RAM.
@@ -39,7 +39,7 @@ To determine the right sizing in terms of cores and RAM, you need to know what k
  and how much resources they need.
 Note that even if average load might be low, you should also account for peak load times as well as startup-peaks (i.e. some apps need a lot of resources just for their startup).
 
-## Multi-Cluster and Multi-Tenant Setups
+## Multi-cluster and multi-tenant setups
 
 There are two ways to separate environments, teams, and in general deployments from each other:
 
@@ -86,7 +86,7 @@ This way the deployments are automated and no one can manually interfere in the 
 The downside to the multi-tenant single cluster approach is that it, as mentioned above,
  needs to be secured with much more scrutiny.
 
-## Further Reading
+## Further reading
 
 - [Creating clusters with gsct](/reference/gsctl/create-cluster/)
 - [Using RBAC Authorization](https://kubernetes.io/docs/admin/authorization/rbac/)

--- a/src/content/guides/scheduling-constraints-and-resource-qos/index.md
+++ b/src/content/guides/scheduling-constraints-and-resource-qos/index.md
@@ -13,7 +13,7 @@ Kubernetes provides resource Quality of Service (QoS) to Pods based on what reso
 
 The QoS is enforced automatically based on the constraints you set for your Pods in their specification.
 
-## Defining Resource Constraints for Pods
+## Defining resource constraints for Pods
 
 You can specify requests and limits for CPU and RAM usage for each container of a Pod by setting:
 
@@ -34,21 +34,21 @@ CPU resoures are measured in (v)Core equivalents. You can specify them in decima
 
 Memory resources are measured in bytes. You specify them as decimals with one of SI suffixes (E, P, T, G, M, K) or their power-of-two equivalents (Ei, Pi, Ti, Gi, Mi, Ki). For example, the following represent roughly the same value: 128974848, 129e6, 129M, 123Mi.
 
-## How Pods are Scheduled
+## How Pods are scheduled
 
-When a pod is created, the Kubernetes scheduler selects a node for the pod to run on. Each node has a maximum capacity for RAM and CPU. The scheduler ensures that, for each resource type, the sum of the resource requests (not limits!) of the containers scheduled to the node is less than the capacity of the node.
+When a pod is created, the Kubernetes scheduler selects a node for the Pod to run on. Each node has a maximum capacity for RAM and CPU. The scheduler ensures that, for each resource type, the sum of the resource requests (not limits!) of the containers scheduled to the node is less than the capacity of the node.
 
 Note that even when actual memory or CPU usage might be low, the scheduler will still refuse to place pods onto nodes if the capacity check fails. This protects against a resource shortage when resource usage increases, e.g. due to a daily peak or other kind of load increase.
 
-## Resource Guarantees
+## Resource guarantees
 
 Kubernetes differentiates between compressible and incompressible resources. Former currently supports CPU and latter currently only Memory.
 
 For compressible resources, Pods are guaranteed to get the amount they requested, they might or might not get additional resources. If Pods exceed their limits they will be throttled accordingly. If no limit is set they may use as much of the compressible resource as available.
 
-For incompressible resources, Pods are guaranteed to get the amount they requested. If they exceed their request they might get killed (e.g. when another pod requests more of the resource). If Pods use more than their limit, the process that is using the most amount of memory, inside one of the pod's containers, will be killed by the kernel.
+For incompressible resources, Pods are guaranteed to get the amount they requested. If they exceed their request they might get killed (e.g. when another pod requests more of the resource). If Pods use more than their limit, the process that is using the most amount of memory, inside one of the Pod's containers, will be killed by the kernel.
 
-## Quality of Service Classes
+## Quality of service classes
 
 There are three QoS classes for Pods: Guaranteed, Burstable, and Best-Effort.
 
@@ -58,7 +58,7 @@ If `requests` and optionally `limits` are set (not equal to `0`) for one or more
 
 If `requests` and `limits` are not set for all of the resources, across all containers, then the pod is classified as __Best-Effort__.
 
-## Further Reading
+## Further reading
 
 - [Managing Compute Resources](http://kubernetes.io/docs/user-guide/compute-resources/)
 - [Pod Quality of Service in Kubernetes](https://kubernetes.io/docs/tasks/configure-pod-container/quality-service-pod/)

--- a/src/content/guides/securing-with-rbac-and-psp/index.md
+++ b/src/content/guides/securing-with-rbac-and-psp/index.md
@@ -11,13 +11,13 @@ tags = ["tutorial"]
 
 Two of the most central mechanisms to secure your cluster in Kubernetes are Role Based Access Control (RBAC) and Pod Security Policies (PSP). Together, these two allow you to create fine-grained roles and policies to manage access control for users and software running on your cluster. Both are enabled by default on Giant Swarm clusters.
 
-## Role Based Access Control
+## Role based access control
 
 The RBAC API defines both roles and bindings on either namespace or cluster level. Like any other Kubernetes API object, these can be defined by writing YAML (or JSON) manifests.
 
 __Note__ that to apply these manifests, you need a user with higher level access than the access you want to set up. When in doubt, use a Cluster Admin account to apply RBAC manifests.
 
-### The Role and ClusterRole Resource {#role-resources}
+### The Role and ClusterRole resource {#role-resources}
 
 The `Role` and `ClusterRole` allow a cluster administrator to define a reusable set of permissions. While a `Role` is used to grant permissions within a single namespace, a `ClusterRole` can grant the same permissions, but can be bound on a cluster-scope.
 
@@ -189,7 +189,7 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 ```
 
-#### Referring to Subjects
+#### Referring to subjects
 
 Bindings can refer to subjects that are either single users, groups, or service accounts. The latter are needed to grant API access (and with PSPs also Pod privileges) to certain Pods, e.g. for monitoring and logging agents.
 
@@ -278,11 +278,11 @@ You need to either bind the already existing `privileged-psp-user` role, or crea
 
 For details on PSPs we defer to the [official PSP documentation](https://kubernetes.io/docs/concepts/policy/pod-security-policy/).
 
-## User Management with Giant Swarm
+## User management with Giant Swarm
 
 If you are managing users through the Giant Swarm API or its clients, `gsctl` or the Web UI (happa), you can specify a Common Name Prefix and Organizations when you create key-pairs of kubeconfigs.
 
-### Using Common Name as Username in Kubernetes
+### Using common name as username in Kubernetes
 
 Setting a Common Name Prefix results in a username like the following:
 
@@ -294,7 +294,7 @@ where `<cn-prefix>` is a username of your choice and `<cluster-domain>` is your 
 
 When binding roles to a user you need to use the full username mentioned above.
 
-### Using Organizations as Groups in Kubernetes
+### Using organizations as groups in Kubernetes
 
 Organizations you set when creating key-pairs or kubeconfigs get mapped to groups inside Kubernetes.
 
@@ -308,7 +308,7 @@ There is only a single predefined user group inside Kubernetes. Members of the `
 
 The `<cn-prefix>` defaults to the email you sign in with at Giant Swarm. The default organization is empty. Thus, a user that is created without any additional CN Prefix and/or Organizations won't have any rights on the cluster unless you bind a role to their specific username.
 
-## Bootstrapping and Managing Access Rights
+## Bootstrapping and managing access rights
 
 For bootstrapping and managing access rights on your Kubernetes cluster you first need a user that already has all rights that you want to give out. The easiest way to get such a user is creating a user that is in the `system:masters` group and thus carries Cluster Admin rights.
 
@@ -324,7 +324,7 @@ With this user we can now start creating Roles and Bindings for our users and ap
 
 Note that in these examples we are assuming you are creating users through Giant Swarm's API.
 
-### Giving Admin Access to a Specific Namespace
+### Giving admin access to a specific namespace
 
 There is a default admin role defined inside Kubernetes. You can bind that role to a user or group of users for a specific namespace with a Role Binding similar to following.
 
@@ -363,7 +363,7 @@ $ gsctl create kubeconfig -c w6wn8 -d "Marc" --cn-prefix "marc" --certificate-or
 
 Note that even when we don't need a specific username for giving Marc Admin rights, we should still set a CN Prefix so we can identify Marc's actions on the cluster.
 
-### Giving Read Access to the Whole Cluster
+### Giving read access to the whole cluster
 
 There is a default view role defined inside Kubernetes. You can bind that role to a user or group of users for the whole cluster with a Cluster Role Binding similar to following.
 
@@ -397,13 +397,14 @@ $ gsctl create kubeconfig -c w6wn8 -d "Marc" --cn-prefix "marc" --certificate-or
 
 With the above Marc would now be part of both groups and thus be bound by both bindings.
 
-### Running Applications that need API Access
+### Running applications that need API access
 
 Applications running inside your cluster that need access to the Kubernetes API need the right permissions bound to them. For this the Pods need to use a Service Account.
 
 The typical process looks like following example:
 
-#### 1. Create a Service Account for your App
+#### 1. Create a Service Account for your app
+
 ```yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -412,7 +413,7 @@ metadata:
   namespace: logging
 ```
 
-#### 2. Add the Service Account to your App
+#### 2. Add the Service Account to your app
 
 This is done by adding a line referncing the Service Account to the Pod spec of your Deployment or Daemonset. To be sure  you have the right place in the YAML you can put it right above the line `containers:` at the same intendation level. The section should look similar to following:
 
@@ -430,7 +431,7 @@ spec:
     [...]
 ```
 
-#### 3. Create a Role for your App
+#### 3. Create a Role for your app
 
 This role should be very specifc to the needs of your app and not allow anything more than what the app needs to work. In this example fluentd needs a Cluster Role that can get, watch, and list Pods and Namespaces in the whole cluster.
 ```yaml
@@ -463,13 +464,13 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 ```
 
-### Running Applications that need Privileged Access
+### Running applications that need privileged access
 
 Applications running inside your cluster that need to run in a privileged Security Context, e.g. as privileged containers, mounting host paths or exposing host ports, need the right permissions in the form of Pod Security Policies bound to them. For this the Pods again need to use a Service Account.
 
 The typical process looks like following example. If your app is already using a service account set up like the RBAC example above you can reuse that and skip steps 1, 2,and 5.
 
-#### 1. Create a Service Account for your App
+#### 1. Create a Service Account for your app
 
 ```yaml
 apiVersion: v1
@@ -479,7 +480,7 @@ metadata:
   namespace: logging
 ```
 
-#### 2. Add the Service Account to your App
+#### 2. Add the Service Account to your app
 
 This is done by adding a line referncing the Service Account to the Pod spec of your Deployment or Daemonset. To be sure you have the right place in the YAML you can put it right above the line `containers:` at the same intendation level. The section should look similar to following:
 
@@ -497,7 +498,7 @@ spec:
 [...]
 ```
 
-#### 3. Create a Pod Security Policy for your App
+#### 3. Create a Pod Security Policy for your app
 
 In Giant Swarm Kubernetes clusters there is a default Pod Security Policy (PSP) called `restricted` that applies when no specifc PSP is given. This PSP can help you create the specifc PSP needed for your app.
 
@@ -544,7 +545,7 @@ Note, how the above PSP allows the use volumes of type `configMap` and `hostPath
 
 We strongly recommend to create such specifc rules, so that no further privilege escalation can occur.
 
-#### 4. Create a Role for your App
+#### 4. Create a Role for your app
 
 Now that we have a PSP we need a role that is allowed to `use` that PSP.
 
@@ -606,13 +607,13 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 ```
 
-### Revoking Access
+### Revoking access
 
 You can revoke access from any user or group of users by either completely removing the binding(s) they are part of or, in case of bindings that bind to several subjects, removing them specifically from the list of subjects in that binding.
 
 Note that bindings that come with the cluster by default like `system:masters` cannot be removed as they are reconciliated. We highly recommend you only create short-lived users (i.e. certificates with a TTL of a day or less) for this kind of access.
 
-## Further Reading
+## Further reading
 
 - [Using RBAC Authorization](https://kubernetes.io/docs/admin/authorization/rbac/)
 - [Pod Security Policies](https://kubernetes.io/docs/concepts/policy/pod-security-policy/)

--- a/src/content/guides/services-of-type-loadbalancer-and-multiple-ingress-controllers/index.md
+++ b/src/content/guides/services-of-type-loadbalancer-and-multiple-ingress-controllers/index.md
@@ -45,7 +45,7 @@ status:
 
 The above YAML would expose port 8080 of our helloworld Pods on the http port of the provisioned ELB.
 
-### Exposing on a non-http port and protocol
+### Exposing on a non-HTTP port and protocol
 
 You can change the port of the load balancer and protocol of the load balancer by changing the `targetPort`field and adding a `ports.protocol` field. This way you can expose TCP services directly without having to customize the Ingress Controller.
 
@@ -72,11 +72,11 @@ status:
     - hostname: a54cae28bd42b11e7b2c7020a3f15370-27798109.eu-central-1.elb.amazonaws.com
 ```
 
-### Customizing the External Load Balancer
+### Customizing the external load balancer
 
 This section will focus on the custom options you can set on AWS Load Balancers via a Service of type `LoadBalancer`, but when available will also explain the settings for Azure Load Balancers. You can configure these options by adding annotations to the service.
 
-#### Internal Load Balancers
+#### Internal load balancers
 
 If you want the AWS ELB to be available only within your VPC (can be extended to other VPC by VPC peering) use the following annotation:
 
@@ -95,7 +95,7 @@ metadata:
     service.beta.kubernetes.io/azure-load-balancer-internal: "true"
 ```
 
-#### SSL Termination on AWS
+#### SSL termination on AWS
 
 There are three annotations you can set to configure SSL termination.
 
@@ -129,7 +129,7 @@ metadata:
 
 In the above example, if the service contained three ports, `80`, `443`, and `8443`, then `443` and `8443` would use the SSL certificate, but `80` would just be proxied HTTP.
 
-#### Access Logs on AWS
+#### Access logs on AWS
 
 Writing access logs to an S3 bucket is a standard feature of ELBs. For `LoadBalancer` Services this can also be configured using following annotations.
 
@@ -144,7 +144,7 @@ metadata:
     service.beta.kubernetes.io/aws-load-balancer-access-log-s3-bucket-prefix: logs/prod
 ```
 
-#### Connection Draining on AWS
+#### Connection draining on AWS
 
 You can set classic ELBs to drain connections and configure a timeout (in seconds) for the draining like following.
 
@@ -156,7 +156,7 @@ metadata:
     service.beta.kubernetes.io/aws-load-balancer-connection-draining-timeout: "60"
 ```
 
-#### AWS Network Load Balancer
+#### AWS network load balancer
 
 AWS is in the process of replacing ELBs with NLBs (Network Load Balancers) and ALBs (Application Load 
 Balancers). NLBs have a number of benefits over "classic" ELBs including scaling to many more requests. 
@@ -169,7 +169,7 @@ metadata:
     service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
 ```
 
-#### Other AWS ELB Configuration Options
+#### Other AWS ELB configuration options
 
 There are more annotations to manage Classic ELBs that are described below.
 
@@ -202,7 +202,7 @@ metadata:
     # A list of additional security groups to be added to the ELB.
 ```
 
-## Using Multiple Ingress Controllers {#multiple-ingress}
+## Using multiple Ingress Controllers {#multiple-ingress}
 
 By default a cluster in Giant Swarm is bootstrapped with a default Ingress Controller based on NGINX. This Ingress Controller is registered with the default `nginx` Ingress Class.
 
@@ -216,13 +216,13 @@ Some use cases for this might be:
 
 __Note__ that if you are running multiple Ingress Controllers you need to annotate each Ingress with the appropriate class, e.g.
 
-```YAML
+```yaml
 kubernetes.io/ingress.class: "nginx"
 ```
 
 or 
 
-```YAML
+```yaml
 kubernetes.io/ingress.class: "nginx-internal"
 ```
 
@@ -230,7 +230,7 @@ Not specifying the annotation will lead to multiple ingress controllers claiming
 
 Further note that if you are running additional Ingress Controllers you might need to configure them so their Ingress Class does not collide with the class of our default NGINX Ingress Controller. For the community supported NGINX Ingress Controller this is described in the [official documentation](https://kubernetes.github.io/ingress-nginx/user-guide/multiple-ingress/).
 
-## Further Reading
+## Further reading
 
 - [Services of type LoadBalancer](https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer)
 - [Running Multiple Ingress Controllers](https://github.com/kubernetes/ingress-nginx#running-multiple-ingress-controllers)

--- a/src/content/guides/using-persistent-volumes-on-aws/index.md
+++ b/src/content/guides/using-persistent-volumes-on-aws/index.md
@@ -90,7 +90,7 @@ __Warning__: Expanding the filesystem is fully supported in Giant Swarm clusters
 
 __Warning__: Expanding EBS volumes is a time consuming operation. Also, there is a per-volume quota of one modification every 6 hours.
 
-## Resizing Filesystem For Kubernetes 1.9
+## Resizing filesystem for Kubernetes 1.9
 
 This procedure is only required for Kubernetes 1.9. Newer clusters support filesystem resizing "out-of-the-box".
 
@@ -156,7 +156,7 @@ By default the Reclaim Policy of Persistent Volumes in your cluster is set to `D
 
 Note that deleting an application that is using Persistent Volumes might not automatically also delete its storage, so in most cases you will have to manually delete the `PersistenVolumeClaim` resources to clean up.
 
-## Further Reading
+## Further reading
 
 - [AWS Storage Classes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#aws)
 - [Persistent Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistent-volumes)

--- a/src/content/reference/cluster-definition/_index.md
+++ b/src/content/reference/cluster-definition/_index.md
@@ -64,7 +64,7 @@ workers:
 
 **Note:** As of now, in AWS based clusters all worker nodes must be of the same instance type. Based on your installation, only certain instance types may be available. Please contact the support team to learn which instance types are supported on your installation.
 
-## Definition Keys {#keys}
+## Definition keys {#keys}
 
 ### Root level keys {#root-keys}
 

--- a/src/content/reference/gsctl/_index.md
+++ b/src/content/reference/gsctl/_index.md
@@ -36,7 +36,7 @@ Follow the links below for detailed documentation, where available. You can also
 | `version`                             | Print version number
 
 
-## Installing and Updating {#install}
+## Installing and updating {#install}
 
 `gsctl` comes as a self-contained binary for Mac, Linux, and Windows. Below you find installation instructions for different platforms. If you want to build `gsctl` from source, find everything you need in its [GitHub repository](https://github.com/giantswarm/gsctl).
 
@@ -99,7 +99,7 @@ The following environment variables can be used to affect some behaviour:
 
 In addition, [global command-line options](global-options/) are available.
 
-## Known Bugs and Limitations {#known-limitations}
+## Known bugs and limitations {#known-limitations}
 
 Check our [issues](https://github.com/giantswarm/gsctl/issues?q=is%3Aopen+is%3Aissue+label%3Akind%2Fbug) with label `kind/bug`.
 

--- a/src/content/reference/gsctl/create-cluster.md
+++ b/src/content/reference/gsctl/create-cluster.md
@@ -19,7 +19,7 @@ You can make use of two different approaches:
 In fact, you can also mix the two approaches, as some command line arguments can be used to extend (or overwrite) the definition passed as a file.
 
 
-## Command Line Examples
+## Command line examples
 
 The shortest possible way to create a new cluster with default settings:
 
@@ -82,7 +82,7 @@ $ gsctl create cluster \
 In this case it doesn't matter if the definition file has an `owner`, `name`, or `release` attribute, as the command line arguments take precedence.
 
 
-## Full Argument Reference {#arguments}
+## Full argument reference {#arguments}
 
 Some arguments are specific to the provider used in the installation
 (KVM for bare metal clusters, or AWS as a cloud provider).

--- a/src/content/reference/gsctl/create-keypair.md
+++ b/src/content/reference/gsctl/create-keypair.md
@@ -39,7 +39,7 @@ Three files will be placed in the `certs` folder, which is a subfolder of your g
 
 - Your client certificate (file ending `.crt`).
 
-## Full Argument Reference {#arguments}
+## Full argument reference {#arguments}
 
 - `--cluster`, `-c`: Used to specify the cluster ID to create a key pair for.
 - `--cn-prefix`: The common name prefix for the issued certificates 'CN' field.
@@ -48,13 +48,13 @@ Three files will be placed in the `certs` folder, which is a subfolder of your g
 - `--description`, `-d`: Can be used to specify a description. If not given, a description like `Added by user email@example.com using 'gsctl create kubeconfig'` is set.
 - `--ttl`: Allows to set the key pair expiry, in days. Defaults to 30 days.
 
-## Key Pair Expiry {#expiry}
+## Key pair expiry {#expiry}
 
 Each key pair has a limited lifetime, which you can affect only on creation. In general, we suggest using short-lived key pairs for security reasons.
 
 Depending on the installation, there might be a minimum and maximum key pair lifetime configured, to enforce security policies. If you'd like to find out about effective limits of your installation, please ask our support team.
 
-## Kubernetes RBAC and the Certificate's Subject Common Name and Organization fields.
+## Kubernetes RBAC and the certificate's subject common name and organization fields.
 
 Using the `--certificate-organizations` and `--cn-prefix` flags you can influence the common name (CN) and organization (O) fields of the issued certificate.
 

--- a/src/content/reference/gsctl/create-kubeconfig.md
+++ b/src/content/reference/gsctl/create-kubeconfig.md
@@ -75,7 +75,7 @@ $ gsctl create kubeconfig --cluster w6wn8 \
   --certificate-organizations system:masters
 ```
 
-## Argument Reference {#arguments}
+## Argument reference {#arguments}
 
 - `--cluster`, `-c`: Used to specify the cluster ID to create a key pair for.
 - `--ttl`: Allows to set the key pair expiry, in days. Defaults to 30 days.
@@ -95,7 +95,7 @@ $ gsctl create kubeconfig --cluster w6wn8 \
 - `--certificate-organizations`: A comma separated list of organizations for the
   issued certificate's 'O' fields.
 
-## Key Pair Expiry {#expiry}
+## Key pair expiry {#expiry}
 
 A key pair has a limited lifetime, which you can affect only on creation. In
 general, we suggest using short-lived key pairs for security reasons, since
@@ -129,7 +129,7 @@ the paths to certificates and the key in the user and cluster entry.
 
 Old certificates and keys are not removed when new key pairs are fetched.
 
-## Kubernetes RBAC and the Certificate's Subject Common Name and Organization fields {#rbac}
+## Kubernetes RBAC and the certificate's subject common name and organization fields {#rbac}
 
 Using the `--certificate-organizations` and `--cn-prefix` flags you can
 influence the common name (CN) and organization (O) fields of the issued

--- a/src/content/reference/gsctl/delete-cluster.md
+++ b/src/content/reference/gsctl/delete-cluster.md
@@ -12,7 +12,7 @@ Deleting a cluster means that all workloads running on the cluster are terminate
 
 __Caution:__ There is no way to undo the deletion of a cluster. All data stored on the nodes will be lost.
 
-## Command Usage
+## Command usage
 
 To delete a cluster, issue a command like below, applying the ID of the cluster you want to delete:
 

--- a/src/content/reference/gsctl/list-endpoints.md
+++ b/src/content/reference/gsctl/list-endpoints.md
@@ -14,7 +14,7 @@ An endpoint is the Giant Swarm API URL for an installation you access using gsct
 If you have only one installation, you have only one endpoint.
 But if you are using, for example, one installation on-premises and one in the cloud, you have two endpoints.
 
-## Usage and Output
+## Usage and output
 
 The command has no specific flags. Simply run it like this:
 

--- a/src/content/reference/gsctl/list-keypairs.md
+++ b/src/content/reference/gsctl/list-keypairs.md
@@ -31,7 +31,7 @@ creation of a new key pair in the cluster's public key infrastructure (PKI) and
 download it to the client. The PKI stores metadata about the issued key pairs,
 but not the key pairs themselves.
 
-## Usage and Output {#usage}
+## Usage and output {#usage}
 
 The command requires as an argument the ID of the cluster to list key pairs for.
 

--- a/src/content/reference/gsctl/list-releases.md
+++ b/src/content/reference/gsctl/list-releases.md
@@ -25,7 +25,7 @@ to select a specific release when creating a cluster. In the near future it will
 also be possible to upgrade a cluster to a more recent release provided by the
 installation.
 
-## Usage and Output
+## Usage and output
 
 The command has no specific flags. Simply run it like this:
 

--- a/src/content/reference/gsctl/scale-cluster.md
+++ b/src/content/reference/gsctl/scale-cluster.md
@@ -20,7 +20,7 @@ For AWS, the Auto Scaling Group's logic determines which workers are removed. We
 
 On Azure, the virtual machine scale set (VMSS) behaviour is responsible for the termination order. Here, VMs with the highest IDs are removed first.
 
-## Command Usage {#usage}
+## Command usage {#usage}
 
 To scale a cluster, use this command syntax:
 
@@ -34,7 +34,7 @@ When adding worker nodes, no confirmation is required.
 
 After the command execution is finished, it can take a couple of minutes until the new workers are available in your Kubernetes clusters.
 
-## Full Argument Reference {#arguments}
+## Full argument reference {#arguments}
 
 - `-w`, `--num-workers` (required): The desired amount of worker nodes after scaling.
 - `--force`: If set, no confirmation is required when reducing the number of workers. You should only use this argument in automations when you are sure that reducing the number of workers is desired.


### PR DESCRIPTION
This changes all intermediate headlines to no longer use Title Case, as discussed internally.