### PR TITLE
Replace proxy by forward

### DIFF
--- a/src/content/guides/advanced-coredns-configuration/index.md
+++ b/src/content/guides/advanced-coredns-configuration/index.md
@@ -40,7 +40,7 @@ The cache plugin also supports much more detailed configuration which is documen
 
 ## Additional forwards (formerly known as proxy) {#additional-forwards}
 
-In CoreDNS version `1.4.0` the proxy plugin has been deprecated. The same behaviour can be achieved now with forward although syntax can be a bit different. The forward plugin indeed has better performance because it reuses opened upstream connections.
+In CoreDNS version `1.4.0` the proxy plugin has been deprecated. The same behaviour can be achieved now with forward although the syntax can be a bit different. The forward plugin has better performance because it reuses opened upstream connections.
 
 The default forward entry we set in CoreDNS is
 
@@ -48,25 +48,25 @@ The default forward entry we set in CoreDNS is
 forward . /etc/resolv.conf
 ```
 
-You can add additional forward entries by adding a each as a line to the foward field of the user ConfigMap. They will be select by sequential order.
+You can add additional forward entries by adding a each as a line to the forward field of the user ConfigMap. They will be selected in sequential order.
 
 You can use a simple line or multiple lines to define the upstreams of the default server block.
 
 ```yaml
 data:
-  foward: 1.1.1.1
+  forward: 1.1.1.1
 ```
 
 ```yaml
 data:
-  foward: |
+  forward: |
     1.1.1.1
     8.8.8.8
 ```
 
 __Warning:__ The number of forward upstreams is limited to 15.
 
-Above example would result in following additional forward entries in the CoreDNS configuration:
+Above example would result in the following additional forward entries in the CoreDNS configuration:
 
 ```yaml
 forward . 1.1.1.1 /etc/resolv.conf
@@ -82,7 +82,7 @@ The forward plugin also supports much more detailed configuration which is docum
 
 ## Advanced configuration
 
-In case you need to have a finer granularity you can define custom server blocks with all configuration desired. They will be parsed after the catch-all block in the Corefile. As an example, let's define a block for a `example.com` with some custom configuration:
+In case you need to have a finer granularity you can define custom server blocks with all desired configuration. They will be parsed after the catch-all block in the Corefile. As an example, let's define a block for a `example.com` with some custom configuration:
 
 ```yaml
 data:

--- a/src/content/guides/advanced-coredns-configuration/index.md
+++ b/src/content/guides/advanced-coredns-configuration/index.md
@@ -64,6 +64,8 @@ data:
     8.8.8.8
 ```
 
+__Warning:__ The number of forward upstreams is limited to 15.
+
 Above example would result in following additional forward entries in the CoreDNS configuration:
 
 ```yaml

--- a/src/content/guides/advanced-coredns-configuration/index.md
+++ b/src/content/guides/advanced-coredns-configuration/index.md
@@ -38,43 +38,43 @@ Above setting increases the TTL to 60 seconds.
 
 The cache plugin also supports much more detailed configuration which is documented in the [upstream documentation](https://coredns.io/plugins/cache/).
 
-## Additional proxies
+## Additional forwards (formerly known as proxy)
 
-The default proxy entry we set in CoreDNS is
+The default forward entry we set in CoreDNS is
 
 ```yaml
-proxy . /etc/resolv.conf
+forward . /etc/resolv.conf
 ```
 
-You can add additional proxy entries by adding a each as a line to the proxy field of the user ConfigMap.
+You can add additional forward entries by adding a each as a line to the foward field of the user ConfigMap.
 
 For a single entry you can use the same line.
 
 ```yaml
 data:
-  proxy: foo.com 1.1.1.1
+  foward: foo.com 1.1.1.1
 
 ```
 
-For multplie entries you add a string with a proxy entry per line.
+For multplie entries you add a string with a forward entry per line.
 
 ```yaml
 data:
-  proxy: |
+  forward: |
     foo.com 1.1.1.1
     bar.com 8.8.8.8
 ```
 
-Above example would result in following additional proxy entries in the CoreDNS configuration:
+Above example would result in following additional forward entries in the CoreDNS configuration:
 
 ```yaml
-proxy foo.com 1.1.1.1
-proxy bar.com 8.8.8.8
+forward foo.com 1.1.1.1
+forward bar.com 8.8.8.8
 ```
 
-This setting would proxy all requests within foo.com to 1.1.1.1 which is Cloudflare's DNS and all requests within bar.com to 8.8.8.8 which is Google Public DNS. All other requests will be resolved by the default DNS provider set for your cluster.
+This setting would forward all requests within foo.com to 1.1.1.1 which is Cloudflare's DNS and all requests within bar.com to 8.8.8.8 which is Google Public DNS. All other requests will be resolved by the default DNS provider set for your cluster.
 
-The proxy plugin also supports much more detailed configuration which is documented in the [upstream documentation](https://coredns.io/plugins/proxy/).
+The forward plugin also supports much more detailed configuration which is documented in the [upstream documentation](https://coredns.io/plugins/forward/).
 
 ## Advanced configuration
 
@@ -83,9 +83,9 @@ In case you need to use an additional plugin or an existing plugin but with a sp
 ```yaml
 data:
   custom: |
-    proxy foo.com 1.1.1.1 {
+    forward foo.com 1.1.1.1 {
       policy least_conn
-      spray
+      health_check 5s
     }
     cache 200 {
       denial 1024 10
@@ -98,4 +98,4 @@ __Warning:__ Please make sure you test the final `Corefile` carefully. We do not
 
 - [CoreDNS Website](https://coredns.io/)
 - [CoreDNS cache plugin](https://coredns.io/plugins/cache/)
-- [CoreDNS proxy plugin](https://coredns.io/plugins/proxy/)
+- [CoreDNS forward plugin](https://coredns.io/plugins/forward/)


### PR DESCRIPTION
In the version ["1.4.0"](https://coredns.io/2019/03/03/coredns-1.4.0-release/) `forward` has replaced `proxy`