### PR TITLE
Add health reference page

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,14 +44,14 @@ Each documentation page consists of a Markdown file that starts with some metada
 
 ### Code blocks
 
-We support fenced code blocks wrapped by the triple backtick operator. It is recommended to
+We support fenced code blocks wrapped by the triple back-tick operator. It is recommended to
 also declare the language a code snippet uses, to prevent faulty guessing. Example:
 
     ```json
     {"message": "this is JSON"}
     ```
 
-Shell snippets (commands and their output) should in generall prevent highlighting like this:
+Shell snippets (commands and their output) should in general prevent highlighting like this:
 
     ```nohighlight
     $ ls
@@ -60,7 +60,7 @@ Shell snippets (commands and their output) should in generall prevent highlighti
 
 ### Table of contents and headline anchors
 
-The rendered documentation pages will have a table of contents on the top left and an achor for every intermediate headline. This anchor is normally generated from the headline's content. For example, a headline
+The rendered documentation pages will have a table of contents on the top left and an anchor for every intermediate headline. This anchor is normally generated from the headline's content. For example, a headline
 
     ### Another section with more content
 
@@ -68,9 +68,9 @@ will result in a headline
 
     <h3 id="another-section-with-more-content">Another section with more content</h3>
 
-This means that anchors and URLs can become quite long. It also means that when the healine text changes, all links to this headline also have to be updated.
+This means that anchors and URLs can become quite long. It also means that when the headline text changes, all links to this headline also have to be updated.
 
-To control this behaviour, the anchor ID can be edited as a suffix to the markdown headline, like in the following example:
+To control this behavior, the anchor ID can be edited as a suffix to the markdown headline, like in the following example:
 
     ### Another section with more content {#more}
 
@@ -78,23 +78,23 @@ will result in a headline
 
     <h3 id="more">Another section with more content</h3>
 
-### Shortcodes
+### Short-codes
 
-Shortcodes allow the use of a string in any number of places in the docs,
+Short-codes allow the use of a string in any number of places in the docs,
 while maintaining it only in one place. We use these to place, for example,
 configuration details.
 
 The goal here is to give users accurate, complete and up-to-date information.
 
-Shortcodes exist as one file each in the folder [src/layouts/shortcodes](https://github.com/giantswarm/docs/tree/master/src/layouts/shortcodes).
+Short-codes exist as one file each in the folder [src/layouts/shortcodes](https://github.com/giantswarm/docs/tree/master/src/layouts/shortcodes).
 
 #### Usage
 
-A shortcode can only be placed in *Markdown* text. The file name (without
+A short-code can only be placed in *Markdown* text. The file name (without
 `.html` suffix) is used as a placeholder, wrapped in a certain way, like
 `{{% placeholder %}}`.
 
-For example, to place the shortcode from `first_aws_autoscaling_version.html`,
+For example, to place the short-code from `first_aws_autoscaling_version.html`,
 the content would look like this
 
 ```markdown
@@ -107,7 +107,7 @@ and would get rendered like
 ... since version 6.3.0 ...
 ```
 
-#### List of shortcodes with explanation
+#### List of short-codes with explanation
 
 - `autoscaler_utilization_threshold`: Utilization threshold for the kubernetes
 autoscaler, including percent unit, as we configure it by default. Below this

--- a/src/content/reference/health/_index.md
+++ b/src/content/reference/health/_index.md
@@ -6,7 +6,7 @@ layout = "subsection"
 weight = 30
 +++
 
-# Cluster health
+# Cluster Health
 
 Giant Swarm gives you a high-level assessment of the health of your tenant clusters. You can use this assessment to decide whether you should investigate a problem with the cluster, take any action (e. g. adding resources) or check back with the Giant Swarm support staff to collaborate on any issue mitigation.
 

--- a/src/content/reference/health/_index.md
+++ b/src/content/reference/health/_index.md
@@ -10,7 +10,7 @@ weight = 30
 
 Giant Swarm gives you a high-level assessment of the health of your tenant clusters. You can use this assessment to decide whether you should investigate a problem with the cluster, take any action (e. g. adding resources) or check back with the Giant Swarm support staff to collaborate on any issue mitigation.
 
-**Important note:** Cluster health is a recent addition and only takes into consideration a limited set of information. Some possible failure sources, like for example on the overlay networking layer, will not be taken into account. We are working on increasing the coverage and value your input regarding requirements and priorities.
+**Important note:** Cluster health is a recent addition and only takes into consideration a limited set of information. Some possible failure sources such as the overlay networking layer will not be taken into account. We are working on increasing the coverage and value your input regarding requirements and priorities.
 
 ## Health categories
 
@@ -18,7 +18,7 @@ We categorize cluster health in a system that comprises three levels:
 
 - <strong style="color: green">GOOD</strong>: The cluster should work as expected, is scalable and resilient.
 
-- <strong style="color: orange">PASSABLE</strong>: Some part of the cluster is in a state that is not considered ideal. Scalability or resilience may be impaired. However should not affect scheduled workloads and the cluster is considered functional in general.
+- <strong style="color: orange">PASSABLE</strong>: Some part of the cluster is in a state that is not considered ideal. Scalability or resilience may be impaired. This condition should not affect scheduled workloads, and the cluster is considered functional in general.
 
 - <strong style="color: red">BAD</strong>: Something is wrong with the cluster that likely needs fixing. Please contact the Giant Swarm support team to get more information regarding the investigation and mitigation.
 
@@ -28,7 +28,7 @@ While there are pure cluster-level state details that influence the health asses
 
 In clusters without node pools, aggregation of node health directly influences the cluster health assessment.
 
-For clusters with node pools, the node's health is aggregated on the node pools level. Then the cluster health is derived considering the health of all node pools in the cluster.
+For clusters with node pools, the node's health is aggregated on the node pools level. Then the cluster health is derived from the health of all node pools in the cluster.
 
 ```nohighlight
 TODO: image
@@ -68,20 +68,20 @@ When combining the outcome of different rules on a level, there is a simple prio
 
 - If the cluster's/node pool's AWS CloudFormation stack is in state `FAILED`, it will be reported as <strong style="color: red">BAD</strong>.
 
-- If a master node of the cluster/node pool is not GOOD:
+- If a master node of the cluster/node pool is not <strong style="color: green">GOOD</strong>:
   - If the cluster is in `Upgrading` state, then the cluster (or node pool) health is <strong style="color: orange">PASSABLE</strong>.
   - If the cluster is not in `Upgrading` state, then the cluster (or node pool) health is <strong style="color: red">BAD</strong>.
 
 - If the cluster (or node pool) state is neither `Creating` nor `Deleting`, then
   - If less than 75% of worker nodes are in state `Ready`, then cluster (or node pool) health is <strong style="color: orange">PASSABLE</strong>.
-  - If the cluster or node pool is supposed to have 20 or more workers and less than 50% of the worker nodes are in state `Ready`, then cluster (or node pool) health is <strong style="color: orange">RED</strong>.
-  - If less than three worker nodes are in a state other than `Ready`, the cluster (or node pool) health will be reported as <strong style="color: red">BAD</strong>.
+  - If the cluster or node pool is supposed to have 20 or more workers and less than 50% of the worker nodes are in state `Ready`, then cluster (or node pool) health is <strong style="color: red">BAD</strong>.
+  - Regardless of cluster size, if less than three worker nodes are in a state other than `Ready`, the cluster (or node pool) health will be reported as <strong style="color: red">BAD</strong>.
 
 #### Clusters with node pools
 
-- If any of the node pools is <strong style="color: orange">PASSABLE</strong>, the cluster health will be reported as <strong style="color: orange">PASSABLE</strong>.
+- If any of the node pools are <strong style="color: orange">PASSABLE</strong>, the cluster health will be reported as <strong style="color: orange">PASSABLE</strong>.
 
-- If any of the node pools is <strong style="color: red">BAD</strong>, the cluster health will be reported as <strong style="color: red">BAD</strong>.
+- If any of the node pools are <strong style="color: red">BAD</strong>, the cluster health will be reported as <strong style="color: red">BAD</strong>.
 
 
 ## Further reading

--- a/src/content/reference/health/_index.md
+++ b/src/content/reference/health/_index.md
@@ -1,0 +1,93 @@
++++
+title = "Cluster Health"
+description = "What defines a healthy or unhealthy tenant cluster according to Giant Swarm"
+date = "2019-09-16"
+layout = "subsection"
+weight = 30
++++
+
+# Cluster health
+
+Giant Swarm gives you a high-level assessment of the health of your tenant clusters. You can use this assessment to decide whether you should investigate a problem with the cluster, take any action (e. g. adding resources) or check back with the Giant Swarm support staff to collaborate on any issue mitigation.
+
+**Important note:** Cluster health is a recent addition and only takes into consideration a limited set of information. Some possible failure sources, like for example on the overlay networking layer, will not be taken into account. We are working on increasing the coverage and value your input regarding requirements and priorities.
+
+## Health categories
+
+We categorize cluster health in a system that comprises three levels:
+
+- <strong style="color: green">GOOD</strong>: The cluster should work as expected, is scalable and resilient.
+
+- <strong style="color: orange">PASSABLE</strong>: Some part of the cluster is in a state that is not considered ideal. Scalability or resilience may be impaired. However should not affect scheduled workloads and the cluster is considered functional in general.
+
+- <strong style="color: red">BAD</strong>: Something is wrong with the cluster that likely needs fixing. Please contact the Giant Swarm support team to get more information regarding the investigation and mitigation.
+
+## Aggregation throughout levels
+
+While there are pure cluster-level state details that influence the health assessment, a cluster's health assessment also reflects the state of the worker and master nodes the cluster comprises.
+
+In clusters without node pools, aggregation of node health directly influences the cluster health assessment.
+
+For clusters with node pools, the node's health is aggregated on the node pools level. Then the cluster health is derived considering the health of all node pools in the cluster.
+
+```nohighlight
+TODO: image
+
+  master node(s) --> cluster
+  worker nodes  /
+
+  master node(s) --> node pool --> cluster
+  worker nodes  /
+
+```
+
+### Rules
+
+This sections explains in full detail the logic that defines health assessment on each level.
+
+The rules contain both ones evaluated on an individual level as well as aggregation rules, taking into consideration health assessments from lower levels.
+
+When combining the outcome of different rules on a level, there is a simple priority system defining the result:
+
+- <strong style="color: orange">PASSABLE</strong> will override <strong style="color: green">GOOD</strong>.
+- <strong style="color: red">BAD</strong> will override <strong style="color: orange">PASSABLE</strong>.
+
+#### Master nodes
+
+- If the node's state anything different than `Ready`, the node's health is reported as <strong style="color: red">BAD</strong>.
+
+#### Worker nodes
+
+- If the node's state is not `Ready`, the node's health is reported as <strong style="color: orange">PASSABLE</strong>.
+
+- If the sum of CPU limits of workloads scheduled to the node exceed `TODO` % of the node's CPU resources, the node's health is reported as <strong style="color: orange">PASSABLE</strong>.
+
+#### Clusters and node pools
+
+- If the cluster/node pool is in state `Creating` or `Deleting`, it will be reported as <strong style="color: orange">PASSABLE</strong>.
+
+- If the cluster's/node pool's AWS CloudFormation stack is in state `FAILED`, it will be reported as <strong style="color: red">BAD</strong>.
+
+- If a master node of the cluster/node pool is not GOOD:
+  - If the cluster is in `Upgrading` state, then the cluster (or node pool) health is <strong style="color: orange">PASSABLE</strong>.
+  - If the cluster is not in `Upgrading` state, then the cluster (or node pool) health is <strong style="color: red">BAD</strong>.
+
+- If the cluster (or node pool) state is neither `Creating` nor `Deleting`, then
+  - If less than 75% of worker nodes are in state `Ready`, then cluster (or node pool) health is <strong style="color: orange">PASSABLE</strong>.
+  - If the cluster or node pool is supposed to have 20 or more workers and less than 50% of the worker nodes are in state `Ready`, then cluster (or node pool) health is <strong style="color: orange">RED</strong>.
+  - If less than three worker nodes are in a state other than `Ready`, the cluster (or node pool) health will be reported as <strong style="color: red">BAD</strong>.
+
+#### Clusters with node pools
+
+- If any of the node pools is <strong style="color: orange">PASSABLE</strong>, the cluster health will be reported as <strong style="color: orange">PASSABLE</strong>.
+
+- If any of the node pools is <strong style="color: red">BAD</strong>, the cluster health will be reported as <strong style="color: red">BAD</strong>.
+
+
+## Further reading
+
+```
+TODO: Links to
+- web interface reference regarding health display
+- API docs
+```

--- a/src/layouts/section/reference.html
+++ b/src/layouts/section/reference.html
@@ -7,13 +7,18 @@
     <ul class="linklist">
 
       <li>
+        <a href="web-interface/">Web Interface Reference</a>
+        <div class="meta">Documentation on our web interface, a visual way to manage clusters, create key pairs and more.</div>
+      </li>
+
+      <li>
         <a href="gsctl/">gsctl CLI Reference</a>
         <div class="meta">Documentation on gsctl, the Giant Swarm command line utility to create and delete clusters, create key pairs and more.</div>
       </li>
 
       <li>
-        <a href="web-interface/">Web Interface Reference</a>
-        <div class="meta">Documentation on our web interface, a visual way to manage clusters, create key pairs and more.</div>
+        <a href="health/">Cluster Health</a>
+        <div class="meta">What defines a healthy or unhealthy tenant cluster according to Giant Swarm.</div>
       </li>
 
       <li>


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/13

This PR is supposed to add a reference page on cluster health under the path

    /reference/health/

### TODO

- [ ] Review rules for correctness
