### PR TITLE
Add digital climate strike script

### DIFF
--- a/src/layouts/partials/footer.html
+++ b/src/layouts/partials/footer.html
@@ -15,5 +15,14 @@
     <script type="text/javascript" src="https://s.giantswarm.io/giantswarmio/0.10.18/1/bootstrap.min.js"></script>
     <script type="text/javascript" src="https://s.giantswarm.io/highlightjs/9.12.0/1/highlight.min.js"></script>
     <script type="text/javascript" src="/js/base.js?{{ partial "cachebreaker_js.html" . }}"></script>
+
+    <script type="text/javascript">
+    var DIGITAL_CLIMATE_STRIKE_OPTIONS = {
+      showCloseButtonOnFullPageWidget: true,
+      language: "en"
+    };
+    </script>     
+    <script src="https://assets.digitalclimatestrike.net/widget.js" async></script>
+
 </body>
 </html>


### PR DESCRIPTION
This PR adds a script that

- before September 20 will add a banner to our site
- on September 20 will add an overlay

as described at https://digital.globalclimatestrike.net/

See also https://github.com/giantswarm/giantswarmio-webapp/pull/593