### PR TITLE
Remove top nav from docs

### DIFF
--- a/src/layouts/partials/topnav.html
+++ b/src/layouts/partials/topnav.html
@@ -8,23 +8,5 @@
         We're Hiring!
       </a>
     </div>
-    <div class="navigation">
-      <a href="#" id="navigation_toggle"><i class="icon-bars"></i></a>
-      <ul>
-        <li>
-          <a href="https://giantswarm.io/product/" id="products_link">Product</a>
-        </li><li>
-          <a href="https://giantswarm.io/services/" id="services_link">Services</a>
-        </li><li>
-          <a href="https://giantswarm.io/company/" id="company_link">Company</a>
-        </li><li>
-          <a href="https://blog.giantswarm.io" id="blog_link">Blog</a>
-        </li><li class="active">
-          <a href="https://docs.giantswarm.io" id="docs_link">Documentation</a>
-        </li><li>
-          <a href="https://giantswarm.io/schedule-demo/" class="button button-green" id="schedule_demo_link">Schedule a Demo</a>
-        </li>
-      </ul>
-    </div>
   </nav>
 </header>

--- a/src/layouts/partials/topnav.html
+++ b/src/layouts/partials/topnav.html
@@ -1,8 +1,8 @@
 <header>
   <nav>
     <div class="branding">
-      <a href="https://giantswarm.io/" id="logo">
         <img alt="Giant Swarm" height="30" src="https://giantswarm.io/static/img/logo_simplified.svg" width="160">
+      <a href="https://www.giantswarm.io/" id="logo">
       </a>
       <a id="hiring-badge" href="https://giantswarm.breezy.hr" target="_blank">
         We're Hiring!


### PR DESCRIPTION
This removes the global navigation items from the docs header.

The actual goal is to add the new top navigation, but that will require some more work.

### Preview

![image](https://user-images.githubusercontent.com/273727/66222125-be315180-e6d0-11e9-8c54-f0c88e547106.png)
