### PR TITLE
Quote coredns cache example to prevent kubectl error

### DIFF
--- a/src/content/guides/advanced-coredns-configuration/index.md
+++ b/src/content/guides/advanced-coredns-configuration/index.md
@@ -31,7 +31,7 @@ By default we set the cache TTL for CoreDNS to 30 seconds. You can customize the
 
 ```yaml
 data:
-  cache: 60
+  cache: "60"
 ```
 
 Above setting increases the TTL to 60 seconds.


### PR DESCRIPTION
It's only a minor annoyance but I found this while testing the user settings migration.

Unless the cache value is quoted kubectl errors with.

```
error: configmaps "coredns-user-values" could not be patched: cannot convert int64 to string
You can run `kubectl replace -f /var/folders/w1/x1v98z3d05bdy21_yn5ncpk40000gp/T/kubectl-edit-3i5bh.yaml` to try this update again.
```