### PR TITLE
Fix links in content

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ build: vendor build-css
 
 	# Latest gsctl version
 	mkdir -p build/layouts/shortcodes
-	curl -s https://api.github.com/repos/giantswarm/gsctl/releases/latest | jq -r .tag_name | tr -d '\n' > build/layouts/shortcodes/gsctl_version.html
+	curl -s https://api.github.com/repos/giantswarm/gsctl/releases/latest | jq -j .tag_name > build/layouts/shortcodes/gsctl_version.html
 
 	# Tie in content from external repositories
 	./build-external-repositories.sh

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ build: vendor build-css
 
 	# Latest gsctl version
 	mkdir -p build/layouts/shortcodes
-	curl -s https://api.github.com/repos/giantswarm/gsctl/releases/latest | jq -r .tag_name > build/layouts/shortcodes/gsctl_version.html
+	curl -s https://api.github.com/repos/giantswarm/gsctl/releases/latest | jq -r .tag_name | tr -d '\n' > build/layouts/shortcodes/gsctl_version.html
 
 	# Tie in content from external repositories
 	./build-external-repositories.sh

--- a/README.md
+++ b/README.md
@@ -44,14 +44,14 @@ Each documentation page consists of a Markdown file that starts with some metada
 
 ### Code blocks
 
-We support fenced code blocks wrapped by the triple backtick operator. It is recommended to
+We support fenced code blocks wrapped by the triple back-tick operator. It is recommended to
 also declare the language a code snippet uses, to prevent faulty guessing. Example:
 
     ```json
     {"message": "this is JSON"}
     ```
 
-Shell snippets (commands and their output) should in generall prevent highlighting like this:
+Shell snippets (commands and their output) should in general prevent highlighting like this:
 
     ```nohighlight
     $ ls
@@ -60,7 +60,7 @@ Shell snippets (commands and their output) should in generall prevent highlighti
 
 ### Table of contents and headline anchors
 
-The rendered documentation pages will have a table of contents on the top left and an achor for every intermediate headline. This anchor is normally generated from the headline's content. For example, a headline
+The rendered documentation pages will have a table of contents on the top left and an anchor for every intermediate headline. This anchor is normally generated from the headline's content. For example, a headline
 
     ### Another section with more content
 
@@ -68,9 +68,9 @@ will result in a headline
 
     <h3 id="another-section-with-more-content">Another section with more content</h3>
 
-This means that anchors and URLs can become quite long. It also means that when the healine text changes, all links to this headline also have to be updated.
+This means that anchors and URLs can become quite long. It also means that when the headline text changes, all links to this headline also have to be updated.
 
-To control this behaviour, the anchor ID can be edited as a suffix to the markdown headline, like in the following example:
+To control this behavior, the anchor ID can be edited as a suffix to the markdown headline, like in the following example:
 
     ### Another section with more content {#more}
 
@@ -163,7 +163,7 @@ The best way to contribute changes are pull requests. Please note the following 
 
 Please avoid acronyms and abbreviations where possible, use them only where the acronym is easier to understand than the long form (example: `SSH` is self-explanatory, `secure shell` is not widely understood).
 
-When you want to use an acronym, please use the long form and the aronym form together at the first use on a page. Example:
+When you want to use an acronym, please use the long form and the acronym form together at the first use on a page. Example:
 
 > The Ingress Controller (IC) manages incoming traffic to your services.
 
@@ -175,7 +175,7 @@ We use [Title Case](https://titlecase.com/) for the main article headline, but n
 
 ### Code blocks and syntax highlighting
 
-For **code blocks**, we give language hints to ensure proper syntax highlighting. A YAML block, for example, is opened with triple backticks followed by `yaml`.
+For **code blocks**, we give language hints to ensure proper syntax highlighting. A YAML block, for example, is opened with triple back-ticks followed by `yaml`.
 
 However, shell commands and their output get the fake hint `nohighlight` to prevent any funky syntax highlighting.
 

--- a/src/content/basics/kubernetes-resources/index.md
+++ b/src/content/basics/kubernetes-resources/index.md
@@ -1,7 +1,7 @@
 +++
 title = "Kubernetes Resources"
 description = "Pointers to the best resources about Kubernetes to get you up to speed with Kubernetes fast"
-date = "2017-01-02"
+date = "2019-10-24"
 weight = 100
 type = "page"
 categories = ["basics"]
@@ -13,7 +13,7 @@ As your Giant Swarm cluster offers you a fully-managed Kubernetes, the fundament
 
 ## Official kubernetes documentation
 
-The first and most important source to enquire should be the [official Kubernetes documentation](http://kubernetes.io/docs/). And as the administration side is mostly taken care of by Giant Swarm, we recommend focussing on the [User Guide](http://kubernetes.io/docs/user-guide/) including the [Kubernetes 101](http://kubernetes.io/docs/user-guide/walkthrough/) and [201](http://kubernetes.io/docs/user-guide/walkthrough/k8s201/).
+The first and most important source to enquire should be the [official Kubernetes documentation](http://kubernetes.io/docs/). And as the administration side is mostly taken care of by Giant Swarm, we recommend focussing on the [task-specific tutorials](https://kubernetes.io/docs/tutorials/).
 
 ## Useful primitives
 
@@ -75,9 +75,9 @@ With namespaces you can split up your cluster into smaller separate environments
 
 ### DNS
 
-Giant Swarm clusters come with KubeDNS installed by default. You can use DNS to discover services and communicate between them.
+Giant Swarm clusters come with CoreDNS installed by default. You can use DNS to discover services and communicate between them.
 
-[DNS Documentation](http://releases.k8s.io/master/build/kube-dns/README.md)
+[CoreDNS documentation](https://coredns.io/manual/toc/)
 
 ## Useful tools and content
 

--- a/src/content/faq/index.md
+++ b/src/content/faq/index.md
@@ -1,7 +1,7 @@
 +++
 title = "FAQ"
 description = "Frequently Asked Questions"
-date = "2018-08-16"
+date = "2019-10-24"
 type = "page"
 +++
 
@@ -22,14 +22,6 @@ If your cluster is running on AWS using your own AWS account, you can use the [E
 Yes, for most databases there are ready built containers in the [Docker Hub](https://hub.docker.com/). If you can't find one for your database of choice, you should be able to easily build one. However, currently persistent volumes are only available on AWS. With a bare metal (KVM) based cluster, volumes are not persistent and won't survive rescheduling of their pods.
 
 Check out our guide on [using persistent volumes on AWS](https://docs.giantswarm.io/guides/using-persistent-volumes-on-aws/).
-
-## How do I make pods talk to each other?
-
-For pods to be available to other pods or to the outside you need to expose them through a service. See [Kubernetes Fundamentals](/basics/kubernetes-fundamentals/) for more details.
-
-## How can I provide environment variables for the containers?
-
-You can either define environment variables in your deployment or better use ConfigMaps and/or Secrets. See [Kubernetes Fundamentals](/basics/kubernetes-fundamentals/) for more details.
 
 ## Can I use TLS/HTTPS/SSL?
 

--- a/src/content/guides/accessing-services-from-the-outside/index.md
+++ b/src/content/guides/accessing-services-from-the-outside/index.md
@@ -1,7 +1,7 @@
 +++
 title = "Accessing Pods and Services from the outside"
 description = "You can access Pods and services from outside your cluster either through the API proxy or through an Ingress."
-date = "2018-02-20"
+date = "2019-10-24"
 type = "page"
 weight = 50
 tags = ["tutorial"]
@@ -154,9 +154,9 @@ Access will only be granted to clients which
 - trust the API's server certificate, which means they trust the Certificate Authority (CA) that signed it and
 - provide a valid client certificate.
 
-The Giant Swarm [web user interface](https://happa.giantswarm.io/getting-started/configure) shows you how to obtain the certificate files.
+The Giant Swarm [web user interface](/reference/web-interface/) shows you how to obtain the certificate files.
 
-To make these certificates available to HTTP clients/browsers, see our guide [Establishing Trust to Your Cluster's CA and Importing Certificates](../importing-certificates/) which explains this for different clients on various platforms.
+To make these certificates available to HTTP clients/browsers, see our guide [Establishing Trust to Your Cluster's CA and Importing Certificates](/guides/importing-certificates/) which explains this for different clients on various platforms.
 
 ### Example
 

--- a/src/content/guides/advanced-ingress-configuration/index.md
+++ b/src/content/guides/advanced-ingress-configuration/index.md
@@ -1,7 +1,7 @@
 +++
 title = "Advanced Ingress Configuration"
 description = "Here we describe how you can customize and enable specific features for the NGINX-based Ingress"
-date = "2019-10-23"
+date = "2019-10-24"
 type = "page"
 weight = 50
 tags = ["tutorial"]
@@ -145,7 +145,7 @@ spec:
 
 __Warning:__ When enabling `TLS` with the NGINX Ingress Controller, some more configuration settings become important. Notably [`HSTS`](https://www.owasp.org/index.php/HTTP_Strict_Transport_Security_Cheat_Sheet) will be enabled [by default](https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/configmap.md#configuration-options) with a duration of six month for your specified domain. Once a browser retrieved these `HSTS` instructions it will refuse to read any unencrypted resource from that domain and un-setting `HSTS` on your server will not have any affect on that browser for half a year. So you might want to disable this at first to avoid [unwanted surprises](https://github.com/kubernetes/ingress-nginx/issues/549#issuecomment-291894246). Please contact our support team to find out details on how to disable HSTS in your cluster.
 
-__Tip:__ If you want to use [Let’s Encrypt](https://letsencrypt.org/) certificates with your domains you can automate their creation and renewal with the help of [cert-manager](http://cert-manager.readthedocs.io/en/release-0.4/). After configuring cert-manager there is only an annotation with your Ingresses needed and your web page will be secured by a valid `TLS` certificate.
+__Tip:__ If you want to use [Let’s Encrypt](https://letsencrypt.org/) certificates with your domains you can automate their creation and renewal with the help of [cert-manager](http://cert-manager.readthedocs.io/). After configuring cert-manager there is only an annotation with your Ingresses needed and your web page will be secured by a valid `TLS` certificate.
 
 ### Authentication
 

--- a/src/content/guides/importing-certificates/index.md
+++ b/src/content/guides/importing-certificates/index.md
@@ -22,7 +22,7 @@ As a user of a Giant Swarm Kubernetes cluster, when you access services on the c
 
 The CA that issued the server certificate is one created by Giant Swarm exclusively for your cluster, so it is unknown to your browser.
 
-Both the CA file for your cluster and a personal key pair, consisting of a client certificate and a private key, can be obtained using either our [web user interface](https://happa.giantswarm.io/getting-started/configure) or [gsctl](/reference/gsctl/).
+Both the CA file for your cluster and a personal key pair, consisting of a client certificate and a private key, can be obtained using either our [web user interface](/reference/web-interface/) or [gsctl](/reference/gsctl/).
 
 In the tutorial we assume that you have done this and obtained three files:
 

--- a/src/content/guides/importing-certificates/index.md
+++ b/src/content/guides/importing-certificates/index.md
@@ -45,7 +45,7 @@ openssl pkcs12 -export -clcerts \
   -name "Key pair for Giant Swarm cluster"
 ```
 
-The `-passout` argument sets a password to encrypt the bundle. In our examples here, we use the password `giantswarm`. Feel free to pick your own password when following the tutorial, but make sure to prepend the `pass:` prefix as shown above. If you prefer to enter a password via a prompt instead of passing it as a clear text argument, you can completely ommit the `-passout pass:<your-password>` part.
+The `-passout` argument sets a password to encrypt the bundle. In our examples here, we use the password `giantswarm`. Feel free to pick your own password when following the tutorial, but make sure to prepend the `pass:` prefix as shown above. If you prefer to enter a password via a prompt instead of passing it as a clear text argument, you can completely omit the `-passout pass:<your-password>` part.
 
 Also note that we give a freely chosen name for the bundle using the `-name` argument. You can pick whatever name suits you. However, most platforms don't display this name in any meaningful place, so don't put too much effort in coming up with a good name.
 

--- a/src/content/guides/prepare-aws-account-for-tenant-clusters/index.md
+++ b/src/content/guides/prepare-aws-account-for-tenant-clusters/index.md
@@ -1,7 +1,7 @@
 +++
 title = "Prepare an AWS account to run Giant Swarm tenant clusters"
-description = "This guide will walk you through all necessary steps to set up an Amazon AWS account with approriate IAM roles for operating Giant Swarm tenant clusters."
-date = "2018-09-12"
+description = "This guide will walk you through all necessary steps to set up an Amazon AWS account with appropriate IAM roles for operating Giant Swarm tenant clusters."
+date = "2019-10-24"
 type = "page"
 weight = 100
 tags = ["tutorial"]
@@ -9,7 +9,7 @@ tags = ["tutorial"]
 
 # Prepare an AWS account to run Giant Swarm tenant clusters
 
-As detailed in the [Architecture](/reference/giantswarm-aws-architecture/) docs,
+As detailed in the [Architecture](/basics/aws-architecture/) docs,
 the tenant clusters (the clusters running your Kubernetes workloads) in a Giant
 Swarm installation are running in an AWS account separate from the control plane.
 This gives great flexibility depending on the requirements and the usage

--- a/src/content/guides/prepare-aws-account-for-tenant-clusters/index.md
+++ b/src/content/guides/prepare-aws-account-for-tenant-clusters/index.md
@@ -257,7 +257,7 @@ organization. These clusters' resources will be created in your AWS account.
 - [Basics and Concepts: Bring Your Own Cloud](/basics/byoc/)
 - [gsctl Reference: `update organization set-credentials`](/reference/gsctl/update-org-set-credentials/)
 - [API: Set credentials](https://docs.giantswarm.io/api/#operation/addCredentials)
-- [Giant Swarm Architecture](/reference/giantswarm-aws-architecture/)
+- [Giant Swarm Architecture](/basics/aws-architecture/)
 - [Giant Swarm API documentation](https://docs.giantswarm.io/api/)
 - [AWS Service Limits](https://docs.aws.amazon.com/general/latest/gr/aws_service_limits.html)
 - [AWS Support Center](https://console.aws.amazon.com/support/home)

--- a/src/content/reference/gsctl/create-kubeconfig.md
+++ b/src/content/reference/gsctl/create-kubeconfig.md
@@ -24,11 +24,11 @@ modes:
   `--self-contained` and set it's value to the desired output file path.
 
 In both cases, a new key pair will be created in your installation, just as it
-is the case with the [`gsctl create keypair`](../cerate-keypair/) command.
+is the case with the [`gsctl create keypair`](/reference/gsctl/create-keypair/) command.
 
 As a prerequisite, you need to be logged in to `gsctl` and you have to be
 a member of the organization owning the cluster. If you can find the cluster
-using [`gsctl list clusters`](../list-clusters/), this is the case.
+using [`gsctl list clusters`](/reference/gsctl/list-clusters/), this is the case.
 
 ## Command Line Examples {#example}
 
@@ -158,6 +158,6 @@ resources to your cluster.
 
 ## Related
 
-- [`gsctl create keypair`](../cerate-keypair/): Create and download a key pair
+- [`gsctl create keypair`](/reference/gsctl/create-keypair/): Create and download a key pair
 - [kubectl reference](https://kubernetes.io/docs/user-guide/kubectl-overview/)
 - [API: Create key pair](/api/#operation/addKeyPair)


### PR DESCRIPTION
After changing the container to run non-privileged, our linkcheck actually does what it's supposed to do. This PR removes all broken links.

In case of the FAQ page I removed the according sections. The questions are pretty trivial anyway and I feel they are far below what we can assume as prior knowledge on the user side by now.