### PR TITLE
Update the 'gsctl create cluster' reference page

### DIFF
--- a/src/content/reference/gsctl/create-cluster.md
+++ b/src/content/reference/gsctl/create-cluster.md
@@ -1,146 +1,60 @@
 +++
 title = "gsctl Command Reference: create cluster"
 description = "Detailed documentation on how to create a new cluster using the 'create cluster' command in gsctl."
-date = "2019-09-04"
+date = "2019-10-30"
 type = "page"
 weight = 20
 +++
 
 # `gsctl create cluster`
 
-With Giant Swarm, an organization can own any number of clusters. `gsctl create cluster` allows for creating a new Kubernetes cluster.
+<div class="well disclaimer">
+This page reflects the future-proof way to use the `gsctl create cluster` command, which applies to releases both before and after v0.18.0. Versions before v0.18.0 support additional command line flags to specify cluster details without using a definition file. Please check `gsctl create cluster --help` in your version to find out more.
+</div>
 
-You can make use of two different approaches to specify the details of the cluster to be created, like name, size etc.:
+The command `gsctl create cluster` allows to create new Kubernetes clusters.
 
-1. Using command line arguments as explained below.
+You can use the command with very simple syntax to create a cluster using default values. Note that several cluster specification details cannot be changed after creation.
 
-2. Using a [cluster definition YAML file](/reference/cluster-definition/) describing your desired cluster in YAML, which you then submit using `gsctl`.
-
-In fact, you can also mix the two approaches, as some command line arguments can be used to extend (or overwrite) the definition passed as a file.
-
+In order to configure all details of the cluster according to your requirements, you'll create a [cluster definition](/reference/cluster-definition/) first and pass it to the command.
 
 ## Command line examples
 
-The shortest possible way to create a new cluster with default settings:
+The first and rather trivial example shows how to create a cluster for organization `myorg` and specifying the cluster name, while leaving all other settings to defaults:
 
 ```nohighlight
-$ gsctl create cluster --owner=myorg
+$ gsctl create cluster --owner myorg --name "Test cluster"
 ```
 
-Here, `--owner` (alternatively: `-o`) specifies the name of the organization that will own the cluster.
-You have to be logged in as a member of that organization.
-
-As a result, a cluster with three nodes and a rather minimal node configuration will be created.
-The name will be auto-generated, so it might or might not make sense to you and your team mates.
-
-**Note:** The default configuration for nodes (amount of memory, disk storage, and CPU cores) may depend on your installation. Please contact us at support@giantswarm.io if you are unsure.
-
-To set a friendly name for your new cluster, pass the `--name` (or `-n`) argument with the `create cluster` command:
+The second example shows how to create a cluster where most or even all configurable details are specified, using a definition file:
 
 ```nohighlight
-$ gsctl create cluster -o myorg --name "Test Cluster"
+$ gsctl create cluster --file prod_cluster_definition.yaml
 ```
 
-To create a cluster that [auto-scales](/basics/cluster-size-autoscaling/) within a certain range, use the `--workers-min` and `--workers-max` arguments.
-To set both minimum and maximum worker node count to the same value, use `--num-workers` as a shorthand.
-
-```nohighlight
-$ gsctl create cluster \
-  --owner myorg \
-  --name "Autoscaling Cluster" \
-  --workers-min 6 --workers-max 10
-```
-
-```nohighlight
-$ gsctl create cluster \
-  --owner myorg \
-  --name "Dev cluster" \
-  --num-worker 10
-```
-
-You can use further command line arguments to specify additional parameters of the worker nodes. Still, all worker nodes will have an identical configuration. Example *for bare-metal installations*:
-
-```nohighlight
-$ gsctl create cluster \
-  --owner myorg \
-  --name "Dev cluster" \
-  --workers-min 5 \
-  --memory-gb 8 \
-  --num-cpus 2 \
-  --storage-gb 100
-```
-
-
-
-To create a cluster with a variety of different node specifications, submit a definition file instead:
-
-```nohighlight
-$ gsctl create cluster --file devcluster.yaml
-```
-
-Learn more about the expected file format in the [cluster defininition reference](../../cluster-definition/).
-
-The next example shows how the owner organization and the cluster name can be given as command line arguments when using a definition file:
-
-```nohighlight
-$ gsctl create cluster \
-  --file devcluster.yaml \
-  --owner=myorg \
-  --name="Another dev cluster" \
-  --release="1.4.6"
-```
-
-In this case it doesn't matter if the definition file has an `owner`, `name`, or `release` attribute, as the command line arguments take precedence.
-
+Note that command line flags take precedence over values in the definition. This way you can, for example, define a default cluster name in the definition, but set a specific one via the `--name` flag when applying the same definition several times.
 
 ## Full argument reference {#arguments}
 
-Some arguments are specific to the provider used in the installation
-(KVM for bare metal clusters, or AWS as a cloud provider).
-
-- `--owner`, `-o`: Name of the owner organization. Overwrites name given in definition file.
-- `--file`, `-f`: Definition file path. See [cluster defininition reference](../../cluster-definition/) for details.
+- `--file`, `-f`: Definition file path. See [cluster definition reference](../../cluster-definition/) for details. The value `-` means that the definition will be read from standard input.
+- `--owner`, `-o`: Name of the owner organization. Overwrites a name given per definition file.
 - `--name`: Name of the cluster. Overwrites name given in definition file.
-- `--num-workers`: Shorthand to set `--workers-min` and `--workers-max` to the same value.
-- `--workers-min`, `--workers-max`: Minimum and maximum number of worker nodes. For autoscaling clusters (available on AWS since release 6.3.0) this specifies the range within the autoscaler can scale the number of worker nodes. For releases prior to 6.3.0, and to pin the number of worker nodes to a specific amount, and on non-AWS installations, both values must be set to the same number.
-- `--num-workers` (*deprecated*): Shorthand to set both minimum and maximum number of worker nodes to the same value.
-- `--release`, `-r`: Specific release version number to use. Defaults to the latest active release. See [list releases](../list-releases/#definition) for details on releases.
-- `--dry-run`: Add this flag (no value expected) to simulate the cluster creation. This is especially useful in combination with the global `--verbose`/`-v` flag, which will display the resulting definition YAML based on any command line argument or definition file input.
+- `--release`, `-r`: Specific release version number to use. Defaults to the latest active release. See [list releases](/reference/gsctl/list-releases/) for details on releases.
 
-#### KVM specific {#arguments-kvm}
+## Passing the cluster definition via standard input {#stdin}
 
-- `--memory-gb`: Worker node memory size in GB. Cannot be combined with `--file`/`-f`.
-- `--num-cpus`: Number of CPU cores per worker node. Cannot be combined with `--file`/`-f`.
-Cannot be combined with `--file`/`-f`.
-- `--storage-gb`: Local node storage per node in GB. Cannot be combined with `--file`/`-f`.
+The `--file` (short `-f`) flag accepts the special value `-` to read a definition from standard input. Depending on your shell you can make use of that in various ways.
 
-#### AWS specific {#arguments-aws}
-
-- `--availability-zones`: Number of availability zones. Cannot be combined with `--file`/`-f`.
-- `--aws-instance-type`: AWS EC2 instance type to use for all worker nodes, e. g. `m5.large`.
-Note that not all instance types might be allowed in your installation. When in doubt, please
-contact the Giant Swarm support team.
-
-#### Azure specific {#arguments-azure}
-
-- `--azure-vm-size`: VM size to use for all worker nodes, e. g. `Standard_D2s_v3`.
-Note that not all VM sizes might be allowed in your installation.
-You can find out which VM sizes are allows using the [`gsctl info`](/reference/gsctl/info/) command.
-
-## YAML definition examples {#yaml-definition-examples}
-
-Here we show quickly how to create a cluster based on a [cluster definition](/reference/cluster-definition/). You can either instruct gsctl to access a file, or pass the definition content directly via STDIN.
-
-Here is how to pass a file path:
+For example, you can use a pipe like this:
 
 ```nohighlight
-gsctl create cluster -f ./cluster.yaml
+cat my-cluster.yaml | gsctl create cluster -f -
 ```
 
-To read the content from standard input (STDIN), use the `-f` flag with the dash/minus (`-`) instead of an actual file path. The example below works with bash:
+At least in bash, this syntax allows to include the entire definition in the command:
 
 ```bash
-$ gsctl create cluster -f - <<EOF
+gsctl create cluster --file - <<EOF
 owner: acme
 name: Dev cluster
 release: 7.1.1
@@ -150,7 +64,9 @@ EOF
 ## Related
 
 - [Cluster definition reference](/reference/cluster-definition/)
+- [`gsctl list releases`](/reference/gsctl/list-releases/) - List all available releases
+- [`gsctl create kubeconfig`](/reference/gsctl/create-kubeconfig/) - Getting a key pair and enabling `kubctl` to access a cluster
+- [`gsctl delete cluster`](/reference/gsctl/delete-cluster/) - Deleting a cluster
 - [Basics: Cluster Size and Autoscaling](/basics/cluster-size-autoscaling/)
-- [`gsctl create kubeconfig`](/reference/gsctl/create-kubeconfig/): Obtaining a key pair and enabling `kubctl` to access a cluster
-- [`gsctl delete cluster`](/reference/gsctl/delete-cluster/): Reference for deleting a cluster
-- [API: Create cluster](/api/#operation/addCluster)
+- [API: Create cluster (v4)](/api/#operation/addCluster)
+- [API: Create cluster (v5)](/api/#operation/addClusterV5)


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/7075

This PR updates the `gsctl create cluster` reference to reflect the usage which works **both** before and after the release of Node Pools and before/after merging https://github.com/giantswarm/gsctl/pull/433

We remove explanation of all command line flags which are removed in https://github.com/giantswarm/gsctl/pull/433 and instead show an extra box in the top which informs users to use the usage of older releases to find out more about these.

As a result of the changes the page becomes much more concise.

### Question to reviewers

Putting yourself into a perspective of an older user, is it clear enough that flags like `--memory-gb` won't come back? 

### Preview

![image](https://user-images.githubusercontent.com/273727/67848258-9a610000-fb04-11e9-89bf-45244a588bbb.png)