### PR TITLE
Re-order the documents on Basics

### DIFF
--- a/src/content/basics/app-catalog/index.md
+++ b/src/content/basics/app-catalog/index.md
@@ -2,7 +2,7 @@
 title = "The Giant Swarm App Catalog"
 description = "Overview of the Giant Swarm App Catalog, how it works and what to expect."
 date = "2019-02-11"
-weight = 15
+weight = 90
 type = "page"
 categories = ["basics"]
 +++

--- a/src/content/basics/aws-architecture/index.md
+++ b/src/content/basics/aws-architecture/index.md
@@ -2,7 +2,7 @@
 title = "The Giant Swarm AWS Architecture"
 description = "Architecture Overview showing how Giant Swarm is set up on Amazon Web Services"
 date = "2019-02-11"
-weight = 20
+weight = 50
 type = "page"
 categories = ["basics"]
 +++

--- a/src/content/basics/azure-architecture/index.md
+++ b/src/content/basics/azure-architecture/index.md
@@ -2,7 +2,7 @@
 title = "The Giant Swarm Azure Architecture"
 description = "Architecture Overview showing how Giant Swarm is set up on Microsoft Azure"
 date = "2019-07-16"
-weight = 20
+weight = 60
 type = "page"
 categories = ["basics"]
 +++

--- a/src/content/basics/byoc/index.md
+++ b/src/content/basics/byoc/index.md
@@ -2,7 +2,7 @@
 title = "Bring Your Own Cloud"
 description = "By default, all your tenant clusters run in the same cloud provider account. With BYOC (Bring Your Own Cloud) for AWS and Azure, you can define a specific cloud provider account to use per organization."
 date = "2018-11-16"
-weight = 50
+weight = 110
 type = "page"
 categories = ["basics"]
 +++

--- a/src/content/basics/cluster-size-autoscaling/index.md
+++ b/src/content/basics/cluster-size-autoscaling/index.md
@@ -2,7 +2,7 @@
 title = "Cluster Size and Autoscaling"
 description = "This article explains options you have for defining the size of a Kubernetes cluster with Giant Swarm, and automatically scaling it"
 date = "2019-11-14"
-weight = 45
+weight = 120
 type = "page"
 categories = ["basics"]
 +++

--- a/src/content/basics/giant-swarm-operational-layers/index.md
+++ b/src/content/basics/giant-swarm-operational-layers/index.md
@@ -3,7 +3,7 @@ title = "Giant Swarm Operational Layers"
 description = "Here you learn how the operational layers of Giant Swarm are defined and what the intended operational model is."
 date = "2018-10-12"
 type = "page"
-weight = 40
+weight = 80
 categories = ["basics"]
 +++
 

--- a/src/content/basics/giant-swarm-support/index.md
+++ b/src/content/basics/giant-swarm-support/index.md
@@ -3,7 +3,7 @@ title = "Giant Swarm Support"
 description = "An explanation of how our support service works."
 date = "2019-04-16"
 type = "page"
-weight = 20
+weight = 30
 categories = ["basics"]
 +++
 

--- a/src/content/basics/kubernetes-resources/index.md
+++ b/src/content/basics/kubernetes-resources/index.md
@@ -2,7 +2,7 @@
 title = "Kubernetes Resources"
 description = "Pointers to the best resources about Kubernetes to get you up to speed with Kubernetes fast"
 date = "2019-10-24"
-weight = 100
+weight = 140
 type = "page"
 categories = ["basics"]
 +++

--- a/src/content/basics/multiaz/index.md
+++ b/src/content/basics/multiaz/index.md
@@ -2,7 +2,7 @@
 title = "Clusters Over Multiple Availability Zones"
 description = "By default, cluster get started within a single availability zone. But you can define how many availability zones a cluster should have to get higher a availability for your clusters."
 date = "2018-11-22"
-weight = 50
+weight = 100
 type = "page"
 categories = ["basics"]
 +++

--- a/src/content/basics/nodepools/index.md
+++ b/src/content/basics/nodepools/index.md
@@ -2,7 +2,7 @@
 title: Node Pools
 description: A general description of node pools as a concept, it's benefits, and some details you should be aware of.
 date: 2019-11-19
-weight: 15
+weight: 130
 type: page
 categories: ["basics"]
 ---

--- a/src/content/basics/onprem-architecture/index.md
+++ b/src/content/basics/onprem-architecture/index.md
@@ -2,7 +2,7 @@
 title = "The Giant Swarm On Premises Architecture"
 description = "Architecture overview showing how Giant Swarm is set up within a customer data center on bare metal or virtual machines."
 date = "2018-08-16"
-weight = 30
+weight = 70
 type = "page"
 categories = ["basics"]
 +++

--- a/src/content/basics/secured-access-to-clusters/index.md
+++ b/src/content/basics/secured-access-to-clusters/index.md
@@ -2,7 +2,7 @@
 title = "Secure access to clusters for users and Giant Swarm support"
 description = "This documentation explains security measures for users and Giant Swarm support to access offered services"
 date = "2019-05-09"
-weight = 45
+weight = 40
 type = "page"
 categories = ["basics"]
 +++

--- a/src/content/basics/security/index.md
+++ b/src/content/basics/security/index.md
@@ -3,7 +3,7 @@ title = "Security"
 description = "Documentation of the Giant Swarm cluster security"
 date = "2017-10-12"
 type = "page"
-weight = 60
+weight = 20
 categories = ["basics"]
 +++
 


### PR DESCRIPTION
Change the weight attributes of the documents in order to create a more methodical order on the Basics Document Webpage.
Towards #7624