### PR TITLE
Review and update Security page on docs.giantswarm

### DIFF
--- a/src/content/basics/security/index.md
+++ b/src/content/basics/security/index.md
@@ -5,6 +5,7 @@ date = "2017-10-12"
 type = "page"
 weight = 20
 categories = ["basics"]
+last-review-date = "2020-01-19"
 +++
 
 # Security
@@ -17,7 +18,7 @@ This reference gives you details on security-related measures in a Giant Swarm i
 
 #### Encryption of secrets {#k8s-secrets}
 
-Secret encryption is ensured by running the Kubernetes `api-server` with the flag `--experimental-encryption-provider-config`. This means that all secrets are stored in Etcd in encrypted form and decrypted when accessed.
+Secret encryption is ensured by running the Kubernetes `api-server` with the flag `--encryption-provider-config`. This means that all secrets are stored in Etcd in encrypted form and decrypted when accessed.
 
 The `AES-CDC` 32 Byte encryption key used is created by a custom management service (`kubernetesd`) during cluster creation. The operator component that creates the cluster retrieves this encryption key and provides it to the `EncryptionConfig` resource for `api-server`..
 


### PR DESCRIPTION
As per [this PR](https://github.com/kubernetes/kubernetes/pull/71206) the flag has changed, which is a change that I proposed, even though we still support 1.14.

Other things may have changed since the last change to the document in 2017, so requires better review.

In addition there is a specific area for AWS. Does Azure require the same?

Towards Issue #8482