### PR TITLE
Fix development port.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ docker-run:
 
 dev:
 	docker run --rm -ti \
-	-p 8080:8080 \
+	-p 8080:80 \
 	-v ${PWD}/src:/docs/build:z \
 	$(REGISTRY)/$(COMPANY)/$(PROJECT):latest /bin/sh -c "nginx; hugo -w --destination /usr/share/nginx/html"
 


### PR DESCRIPTION
Hugo hosts the docs at port 80.

This fixes the dev makefile target so that we can actually access the hugo instance running in the container from localhost:8080.