### PR TITLE
Update docs on minimal instance type in Cluster Size and Autoscaling article

### DIFF
--- a/src/content/basics/cluster-size-autoscaling/index.md
+++ b/src/content/basics/cluster-size-autoscaling/index.md
@@ -1,7 +1,7 @@
 +++
 title = "Cluster Size and Autoscaling"
 description = "This article explains options you have for defining the size of a Kubernetes cluster with Giant Swarm, and automatically scaling it"
-date = "2019-11-14"
+date = "2020-02-17"
 weight = 120
 type = "page"
 categories = ["basics"]
@@ -44,16 +44,10 @@ Technically, while you may be able to create and run smaller clusters successful
 
 Relying on autoscaling may have an effect on the instance type you should use for your cluster, due to the way the autoscaler decides when to remove a node, as described above.
 
-With the services required to run a cluster, like DNS, kube-proxy, ingress and others, each node has a baseline utilization, even before you start your first workloads.
-With small instance types, e. g. only 1 CPU core, the utilization of an otherwise empty node can already be above {{% autoscaler_utilization_threshold %}}.
-Using such a small instance type with the default utilization threshold of {{% autoscaler_utilization_threshold %}} would result in a cluster that would never get scaled down, effectively running unused worker nodes.
+With the services required to run a cluster, like DNS, kube-proxy, ingress and others, each node has a baseline utilization, even before you start your first workloads. Hence the minimal worker node instance types on AWS are those with the `.xlarge` suffix, providing 4 CPU cores. The default instance type for worker nodes is `{{% default_aws_instance_type %}}`.
 
 For automatic down-scaling to work, utilization threshold and instance type have to fit together.
 The default worker nodes instance type for AWS (`{{% default_aws_instance_type %}}`) and the default utilization threshold ({{% autoscaler_utilization_threshold %}}) are adjusted so that down-scaling should work as expected.
-
-And similarly up-scaling is affected if you eg start a cluster with a minimum of one node. If one single node is too small for the baseline utilization of the cluster the autoscaler itself might not fit onto the node anymore and therefore the cluster won't ever get scaled.
-
-We've changed the default instance type on AWS to `{{% default_aws_instance_type %}}` and up/down-scaling will work. You can still choose `m?.large`. But there will be at least problems with scaling up a cluster since the nodes are too small.
 
 If you decide to run larger instance types, you may ask the Giant Swarm support team to adjust the utilization threshold of a particular cluster for you.
 

--- a/src/content/guides/prepare-aws-account-for-tenant-clusters/index.md
+++ b/src/content/guides/prepare-aws-account-for-tenant-clusters/index.md
@@ -64,7 +64,7 @@ These are the limit increases to be requested, grouped by limit type:
   - Auto Scaling Groups per region: **250**
   - Launch Configurations per region: **500**
 - EC2 Instances
-  - m3.large per region: **250**
+  - m4.xlarge per region: **250**
   - m4.2xlarge per region: **250**
   - m5.2xlarge per region: **250**
   - other instance types to be used as workers: increase accordingly

--- a/src/content/guides/prepare-aws-account-for-tenant-clusters/index.md
+++ b/src/content/guides/prepare-aws-account-for-tenant-clusters/index.md
@@ -69,6 +69,8 @@ These are the limit increases to be requested, grouped by limit type:
   - m5.2xlarge per region: **250**
   - other instance types to be used as workers: increase accordingly
 
+(Please extend the list of EC2 instance to also contain the types you need frequently.)
+
 When requesting a service limit increase, you will be asked for a description of your use case. You can use this text for the purpose:
 
 > We intend to run multiple Kubernetes clusters in this account, potentially used

--- a/src/content/reference/cluster-definition/_index.md
+++ b/src/content/reference/cluster-definition/_index.md
@@ -62,7 +62,7 @@ scaling:
 availability_zones: 2
 workers:
   - aws:
-      instance_type: m3.large
+      instance_type: m4.xlarge
 ```
 
 **Note:** AWS clusters defined using a v4 definition (and consequently not using node pools) restrict you to all worker nodes being of the same instance type. With v5 and node pools, you gain the flexibility to create several node pools using different instance types.
@@ -83,7 +83,7 @@ workers:
 - `cpu`: The sub-key `cores` allows to require a number of CPU cores as integer. Only usable on KVM (on-premises/bare metal) installations.
 - `storage`: The sub-key `size_gb` is used to specify the amount of local node storage in GB as an integer or decimal number. Only usable on KVM (on-premises/bare metal) installations.
 - `aws`: Settings specific to AWS based clusters
-- `aws.instance_type`: The AWS EC2 instance type to use for worker nodes, e. g. `m5.large`.
+- `aws.instance_type`: The AWS EC2 instance type to use for worker nodes, e. g. `m5.2xlarge`.
 - `azure`: Settings specific to Azure based clusters
 - `azure.vm_size`: The Azure VM size to use for worker nodes
 

--- a/src/content/reference/gsctl/info.md
+++ b/src/content/reference/gsctl/info.md
@@ -39,8 +39,8 @@ When logged in with an AWS installation, these additional details will appear:
 ```nohighlight
 ...
 Provider:                      aws
-Worker instance type options:  m3.large, m3.xlarge, m3.2xlarge, r3.large, r3.xlarge, r3.2xlarge, r3.4xlarge, r3.8xlarge, m4.large, m4.xlarge, m4.2xlarge, m4.4xlarge, m5.large, m5.xlarge, m5.2xlarge, m5.4xlarge, t2.large, t2.xlarge, t2.2xlarge, c5.2xlarge, i3.xlarge
-Default worker instance type:  m3.large
+Worker instance type options:  m3.xlarge, m3.2xlarge, r3.xlarge, r3.2xlarge, r3.4xlarge, r3.8xlarge, m4.xlarge, m4.2xlarge, m4.4xlarge, m5.xlarge, m5.2xlarge, m5.4xlarge, t2.xlarge, t2.2xlarge, c5.2xlarge, i3.xlarge
+Default worker instance type:  m4.xlarge
 Default workers per cluster:   3
 Maximum workers per cluster:   20
 ```

--- a/src/content/reference/gsctl/show-cluster.md
+++ b/src/content/reference/gsctl/show-cluster.md
@@ -30,8 +30,8 @@ Release version:               6.3.0
 Worker node scaling:           autoscaling between 6 and 10
 Desired worker node count:     7
 Worker nodes running:          8
-Worker EC2 instance type:      m5.large
-CPU cores in workers:          14
+Worker EC2 instance type:      m5.xlarge
+CPU cores in workers:          28
 RAM in worker nodes (GB):      26.5
 ```
 


### PR DESCRIPTION
Part of https://github.com/giantswarm/giantswarm/issues/8748

This PR adapts the docs to eliminate the smaller `*.large` instance types everywhere, which cannot be used any more.

The basic Autoscaling article has been stripped a bit to remove some historical info and to simplify the content.