### PR TITLE
Move linkcheck into a separate job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ jobs:
 workflows:
   version: 2
 
-  build_and_linkcheck:
+  build-and-linkcheck:
     jobs:
       - build
       - linkcheck:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,21 @@ orbs:
 
 
 jobs:
+  linkcheck:
+    machine:
+      image: "ubuntu-1604:201903-01"
+
+    steps:
+      - run:
+          name: Link check
+          command: |
+            docker run -d --rm --name docs -p 8080:8080 quay.io/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME:$CIRCLE_SHA1
+            docker run --rm -ti --name linkchecker \
+              --link docs:docs \
+              linkchecker/linkchecker \
+                http://docs:8080 \
+                --check-extern -t 2 --ignore-url="^https://docs.giantswarm.io/.*" --ignore-url=/api/
+
   build:
     machine:
       image: "ubuntu-1604:201903-01"
@@ -39,16 +54,6 @@ jobs:
             echo $CURL_OUTPUT | grep --quiet "Giant Swarm"
             docker kill docs
 
-      - run:
-          name: Linkcheck
-          command: |
-            docker run -d --rm --name docs -p 8080:8080 quay.io/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME:$CIRCLE_SHA1
-            docker run --rm -ti --name linkchecker \
-              --link docs:docs \
-              linkchecker/linkchecker \
-                http://docs:8080 \
-                --check-extern -t 2 --ignore-url="^https://docs.giantswarm.io/.*" --ignore-url=/api/
-
       - deploy:
           name: Deploy (only if branch is "master")
           command: |
@@ -58,6 +63,15 @@ jobs:
             fi
 
 workflows:
+  version: 2
+
+  build_and_linkcheck:
+    jobs:
+      - build
+      - linkcheck:
+          requires:
+            - build
+
   package-and-push-chart-on-tag:
     jobs:
       - build:

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ sitesearch-volume-data
 /vendor/
 kubernetes/secrets.yaml
 /.vscode
+/volumes


### PR DESCRIPTION
This PR attempts to make the linkcheck step optional and not be executed when releasing an app.

As a result, the other checks are much faster.