### PR TITLE
Fix broken helm docs links

### DIFF
--- a/src/content/basics/app-catalog/index.md
+++ b/src/content/basics/app-catalog/index.md
@@ -111,7 +111,7 @@ The App Catalog CR is an abstraction, it's purpose is to point to _something_
 that contains a list of Apps and the storage location of where to get those Apps.
 
 Currently the only supported format for App Catalogs are
-[Helm Chart Repositories](https://github.com/helm/helm/blob/master/docs/chart_repository.md),
+[Helm Chart Repositories](https://helm.sh/docs/topics/chart_repository/),
 however in the future we might support other ways of offering your Apps to the
 Giant Swarm App Catalog.
 

--- a/src/content/reference/web-interface/app-catalog.md
+++ b/src/content/reference/web-interface/app-catalog.md
@@ -39,4 +39,4 @@ Once you know what app you'd like to install, click on that app, and then on
 That'll bring up a modal where you can choose what cluster you want to install
 the app on, as well as some further steps allowing you to configure the app.
 
-This is also where you can provide your [values.yaml](https://github.com/helm/helm/blob/master/docs/chart_template_guide/values_files.md) with custom configuration for the app.
+This is also where you can provide your [values.yaml](https://helm.sh/docs/chart_template_guide/values_files/) with custom configuration for the app.


### PR DESCRIPTION
Thank you, @stone-z for finding this 👍 

The helm documentation was moved to a separate website some time ago.