### PR TITLE
Define the version of apiextensions we want to build crd docs from.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ build: vendor build-css
 	# Generate the Control Plane K8s API reference documentation.
 	docker run \
 		-v ${PWD}/build/content/reference/cp-k8s-api:/opt/crd-docs-generator/output \
-		quay.io/giantswarm/crd-docs-generator:latest
+		quay.io/giantswarm/crd-docs-generator:latest --apiextensions-commit-ref v0.2.1
 
 docker-build: build
 	docker build -t $(REGISTRY)/$(COMPANY)/$(PROJECT):latest .
@@ -62,7 +62,7 @@ docker-run:
 
 dev:
 	docker run --rm -ti \
-	-p 8080:80 \
+	-p 8080:8080 \
 	-v ${PWD}/src:/docs/build:z \
 	$(REGISTRY)/$(COMPANY)/$(PROJECT):latest /bin/sh -c "nginx; hugo -w --destination /usr/share/nginx/html"
 

--- a/src/content/basics/secured-access-to-clusters/index.md
+++ b/src/content/basics/secured-access-to-clusters/index.md
@@ -16,7 +16,7 @@ In this document we will explain the nature of this access and the security meas
 
 ## Intro
 
-Access to Giant Swarm clusters can be split into two parts. 
+Access to Giant Swarm clusters can be split into two parts.
 
 1. User Access - designated for Giant Swarm customers to interact with the offered services.
 
@@ -26,7 +26,7 @@ If you would like to know more about the different parts of the Giant Swarm infr
 
 ## User access
 
-User access is limited to the offered APIs for interaction with your clusters. 
+User access is limited to the offered APIs for interaction with your clusters.
 
 ### Giant Swarm API
 
@@ -47,7 +47,7 @@ VPN secured access points:
 
 * **SSH** - SSH access is based on GitHub SSO. Only users in the GitHub Giant Swarm Organization are allowed to authenticate. The following diagram describes our SSH authentication in more detail:
 
-![](./ssh_access_process.png)  
+![](./ssh_access_process.png)
 
 Customer Tenant Clusters are accessible only via SSH access to the Giant Swarm Control Plane. This Control Plane contains Giant Swarm's cluster management and operations platform, and controls our access to the underlying Tenant Clusters for diagnostic and "Day 2" operational reasons.
 
@@ -55,7 +55,7 @@ Customer Tenant Clusters are accessible only via SSH access to the Giant Swarm C
 
 ### General VPN connection schema
 
-The following schema illustrates what the VPN connection looks like in practice. 
+The following schema illustrates what the VPN connection looks like in practice.
 
 ![](./site-to-site-vpn.png)
 
@@ -72,8 +72,8 @@ Access to etcd or the Kubernetes API is secured based on certificates signed by 
 
 ## Further reading
 
-- [GitHub Vault authentication](https://www.vaultproject.io/docs/auth/github.html) 
-- [Vault SSH certificate](https://www.vaultproject.io/docs/secrets/ssh/signed-ssh-certificates.html)
+- [GitHub Vault authentication](https://www.vaultproject.io/docs/auth/github/)
+- [Vault SSH certificate](https://www.vaultproject.io/docs/secrets/ssh/signed-ssh-certificates/)
 - [Giant Swarm Operational Layers](/basics/giant-swarm-operational-layers/)
 - [Giant Swarm API](/basics/giant-swarm-operational-layers/#giant-swarm-api)
 - [Giant Swarm User Space](/basics/giant-swarm-operational-layers/#userspace): Tenant Cluster Kubernetes API


### PR DESCRIPTION
Using the new flag, this way the build should become more deterministic. (we should also probably not use `latest` of crd-docs-generator, but im ok with that for now)