### PR TITLE
Show apiextensions repository info/version on CRD detail page

### DIFF
--- a/src/layouts/_default/crd.html
+++ b/src/layouts/_default/crd.html
@@ -1,0 +1,38 @@
+{{ partial "header.html" . }}
+
+<div class="row">
+  <div class="col-xs-12">
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-md-4 col-lg-3 hidden-sm hidden-xs toc-sidebar">
+    <div>
+      <div class="toc">
+        {{ .TableOfContents }}
+      </div>
+    </div>
+  </div>
+  <div class="col-sm-12 col-md-8 col-lg-8 col-lg-offset-1">
+
+    {{ partial "breadcrumb.html" . }}
+
+    <div class="content">
+      <p class="lastmod">Last generated {{ .Date.Format "January 2, 2006" }}</p>
+
+      {{ .Content }}
+
+      <hr />
+
+      <p>This documentation page shows information based on <a href="{{ $.Param "source_repository" }}/tree/{{ $.Param "source_repository_ref" }}" target="_blank" rel="noopener noreferrer">apiextensions {{ $.Param "source_repository_ref" }}</a>.
+
+      <div class="feedback well">
+        <h5><i class="fa fa-help-outline"></i> Need help with the Control Plane Kubernetes API?</h5>
+        <p>We listen in your Slack support channel. And of course, we welcome your <a title="open this page in GitHub" href="{{ $.Param "source_repository" }}" target="_blank" rel="noopener noreferrer">pull requests</a> to improve these docs!</p>
+      </div>
+
+    </div>
+  </div>
+</div>
+
+{{ partial "footer.html" . }}

--- a/src/layouts/section/cp-k8s-api-reference.html
+++ b/src/layouts/section/cp-k8s-api-reference.html
@@ -27,8 +27,6 @@
 
     </ul>
 
-    {{ partial "feedback_reference.html" . }}
-
   </div>
 </div>
 

--- a/src/static/css/base.css
+++ b/src/static/css/base.css
@@ -803,10 +803,6 @@ a.item .hellip {
   margin-top: 20px;
   margin-bottom: 20px; }
 
-img[src$='#width-60'] {
-  max-width: 60%
-}
-
 ul.links {
   list-style-type: none;
   padding-left: 0; }


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/9945

Depends on changes in https://github.com/giantswarm/crd-docs-generator/pull/7

### Preview

Page top ("Last generated" instead of "Last modified"):

![image](https://user-images.githubusercontent.com/273727/78675221-05e59f80-78e5-11ea-8be1-b0dc0ea69a39.png)

Bottom:

![image](https://user-images.githubusercontent.com/273727/78675248-0da54400-78e5-11ea-8bb4-8aaca27e8069.png)
