### PR TITLE
Set apiextensions version to 0.3.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ build: vendor build-css
 	# Generate the Control Plane K8s API reference documentation.
 	docker run \
 		-v ${PWD}/build/content/reference/cp-k8s-api:/opt/crd-docs-generator/output \
-		quay.io/giantswarm/crd-docs-generator:latest --apiextensions-commit-ref v0.3.0
+		quay.io/giantswarm/crd-docs-generator:latest --apiextensions-commit-ref v0.3.1
 
 docker-build: build
 	docker build -t $(REGISTRY)/$(COMPANY)/$(PROJECT):latest .

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ build: vendor build-css
 	# Generate the Control Plane K8s API reference documentation.
 	docker run \
 		-v ${PWD}/build/content/reference/cp-k8s-api:/opt/crd-docs-generator/output \
-		quay.io/giantswarm/crd-docs-generator:latest --apiextensions-commit-ref v0.2.6
+		quay.io/giantswarm/crd-docs-generator:latest --apiextensions-commit-ref v0.3.0
 
 docker-build: build
 	docker build -t $(REGISTRY)/$(COMPANY)/$(PROJECT):latest .


### PR DESCRIPTION
Attempt to bring back CRD docs. Since the crd-docs-generator is now adapted to the structure of apiextensions post 0.3.0, we use that version.

As with 0.3.0 several things have changed in the repo, some CRD docs will look worse than before. On the other hand, we gain some docs we didn't have before. The WG is informed and will fill in the blanks subsequently.