### PR TITLE
Some more adjustments for the app platform naming change.

### DIFF
--- a/src/content/basics/app-platform/index.md
+++ b/src/content/basics/app-platform/index.md
@@ -91,7 +91,7 @@ This is our go-to place to create and try out things. Mainly, this contains apps
 
 Bear in mind that we do NOT support these apps and they won’t be worked on with priority. These apps might not ever make it into the Giant Swarm Catalog. What you will get, is an app at a basic maturity level at a specific point in time.
 
-We encourage you to try out the app catalog and the different apps offered there. As always, feedback is welcome.
+We encourage you to try out this playground catalog and the different apps offered there. As always, feedback is welcome.
 
 
 ### Installing your own App Catalog
@@ -110,7 +110,7 @@ It’s possible to create your own App Catalog. This is useful if you want to cr
 You can interact with the Giant Swarm App Platform through our API and
 our web interface.
 
-- [Web Interface Reference: The Giant Swarm App Catalog](/reference/web-interface/app-catalog/)
+- [Web Interface Reference: The Giant Swarm App Platform](/reference/web-interface/app-platform/)
 - [Apps and App Configs in the API reference](https://docs.giantswarm.io/api/#tag/apps)
 
 Lastly, at the end of the day, what our interfaces do, is create (or update)

--- a/src/content/guides/advanced-ingress-configuration/index.md
+++ b/src/content/guides/advanced-ingress-configuration/index.md
@@ -15,7 +15,7 @@ The [NGINX-based Ingress Controller](https://github.com/kubernetes/ingress-nginx
 - [Per-Service options](#yaml) in each Ingress' YAML definition either directly or via [Annotations](https://kubernetes.io/docs/user-guide/annotations/).
 - [Global options](#configmap) that influence all Ingresses of a cluster via a ConfigMap.
 
-**Note**: Some Giant Swarm clusters do not come with an ingress controller pre-installed. See our [guide on how to install an ingress from the app catalog](/guides/installing-optional-ingress-controller/).
+**Note**: Some Giant Swarm clusters do not come with an ingress controller pre-installed. See our [guide on how to install an ingress from the Giant Swarm Catalog](/guides/installing-optional-ingress-controller/).
 
 ## Per-Service options {#yaml}
 

--- a/src/content/reference/app-configuration/index.md
+++ b/src/content/reference/app-configuration/index.md
@@ -20,7 +20,7 @@ There are three levels of configuration:
 2. **Cluster**: Configuration provided by the cluster admin.
 3. **User**: Configuration provided by the user installing an App.
 
-Each level can overrides the previous one. As a user you are not expected to edit configuration at the `catalog` or `cluster` level. However user level configuration can override both catalog and cluster level configuration.
+Each level can override the previous one. As a user you are not expected to edit configuration at the `catalog` or `cluster` level. However user level configuration can override both catalog and cluster level configuration.
 
 Each level of configuration has two types of values that you can provide:
 

--- a/src/content/reference/app-configuration/index.md
+++ b/src/content/reference/app-configuration/index.md
@@ -7,7 +7,7 @@ type: subsection
 
 # App Configuration Reference
 
-Giant Swarm's [App Catalog](/basics/app-catalog/) allows you to easily install Apps across your entire
+Giant Swarm's [App Platform](/basics/app-platform/) allows you to easily install Apps across your entire
 fleet of clusters.
 
 Apps are packaged as Helm charts. Helm charts rely on _values_ to be set in order to fill in placeholders in _templates_. By configuring your App you set the values that become available to the templates when they are deployed.
@@ -20,7 +20,7 @@ There are three levels of configuration:
 2. **Cluster**: Configuration provided by the cluster admin.
 3. **User**: Configuration provided by the user installing an App.
 
-Each level can overrides the previous one. As a user of the App Catalog you are not expected to edit configuration at the `catalog` or `cluster` level. However user level configuration can override both catalog and cluster level configuration.
+Each level can overrides the previous one. As a user you are not expected to edit configuration at the `catalog` or `cluster` level. However user level configuration can override both catalog and cluster level configuration.
 
 Each level of configuration has two types of values that you can provide:
 
@@ -164,7 +164,7 @@ Configuration for Apps are stored as ConfigMaps and Secrets, which are
 referenced by `name` and `namespace` in various `spec` fields of the [App](/reference/cp-k8s-api/apps.application.giantswarm.io/) and [AppCatalog](/reference/cp-k8s-api/appcatalogs.application.giantswarm.io/) Custom Resource (CR).
 
 Our operators act on those resources to ensure the actual state ends up
-looking like the desired state. More information is available in our [general overview of the App Catalog](/basics/app-catalog/).
+looking like the desired state. More information is available in our [general overview of the App Platform](/basics/app-platform/).
 
 |Configuration Level|Where to set it|Fields to set|
 |---|---|---|

--- a/src/content/reference/web-interface/_index.md
+++ b/src/content/reference/web-interface/_index.md
@@ -32,7 +32,7 @@ detailed information:
 - View and manage organizations
 - Manage your own account and password
 - Learn how to get started with your Kubernetes clusters by following a guide
-- [Add, remove and configure Apps on your clusters.](app-catalog/)
+- [Add, remove and configure Apps on your clusters.](app-platform/)
 
 ## Source code
 

--- a/src/content/reference/web-interface/app-platform.md
+++ b/src/content/reference/web-interface/app-platform.md
@@ -5,6 +5,9 @@ date: 2020-04-22
 last-review-date: 2020-04-22
 layout: subsection
 weight: 10
+aliases: [
+    "/reference/web-interface/app-catalog/",
+]
 ---
 
 # The Giant Swarm App Catalog in the Web Interface
@@ -12,7 +15,7 @@ weight: 10
 This page will give you an overview of how to do some common tasks related to the
 Giant Swarm App Catalog using our Web Interface.
 
-Go here for an [overview of the Giant Swarm App Platform](/basics/app-catalog/) instead.
+Go here for an [overview of the Giant Swarm App Platform](/basics/app-platform/) instead.
 
 ### Viewing all App Catalogs
 

--- a/src/content/reference/web-interface/app-platform.md
+++ b/src/content/reference/web-interface/app-platform.md
@@ -12,10 +12,11 @@ aliases: [
 
 # The Giant Swarm App Platform in the Web Interface
 
-This page will give you an overview of how to do some common tasks related to the
-Giant Swarm App Catalog using our Web Interface.
+This page will give you an overview of what parts of the Giant Swarm App Platform
+are managable using our web interface.
 
-Go here for an [overview of the Giant Swarm App Platform](/basics/app-platform/) instead.
+If you'd like to know more about the App Platform in general, go here for an
+[overview of the Giant Swarm App Platform](/basics/app-platform/) instead.
 
 ### Viewing all App Catalogs
 

--- a/src/content/reference/web-interface/app-platform.md
+++ b/src/content/reference/web-interface/app-platform.md
@@ -1,6 +1,6 @@
 ---
-title: The Giant Swarm App Catalog in The Web Interface
-description: What the Giant Swarm App Catalog looks like on our Web Interface and how to use it.
+title: The Giant Swarm App Platform in The Web Interface
+description: What the Giant Swarm App Platform looks like on our Web Interface and how to use it.
 date: 2020-04-22
 last-review-date: 2020-04-22
 layout: subsection
@@ -10,7 +10,7 @@ aliases: [
 ]
 ---
 
-# The Giant Swarm App Catalog in the Web Interface
+# The Giant Swarm App Platform in the Web Interface
 
 This page will give you an overview of how to do some common tasks related to the
 Giant Swarm App Catalog using our Web Interface.


### PR DESCRIPTION
Hi @Oshratn , here are the other places where i thought we should adjust the language now that the concept is called App Platform.