### PR TITLE
Fix similar instance types reference

### DIFF
--- a/src/content/reference/similar-ec2-instance-types/_index.md
+++ b/src/content/reference/similar-ec2-instance-types/_index.md
@@ -18,22 +18,22 @@ aws-operator creates an Auto Scaling Group (ASG) for every node pool. If the cre
 
 ## Type mapping
 
-| Series | Selected type | Enabled types     |
-|--------|---------------|-------------------|
-| m4     | `m4.xlarge`   | `(m4|m5).xlarge`  |
-| m4     | `m4.2xlarge`  | `(m4|m5).2xlarge` |
-| m4     | `m4.4xlarge`  | `(m4|m5).4xlarge` |
-| m5     | `m5.xlarge`   | `(m4|m5).xlarge`  |
-| m5     | `m5.2xlarge`  | `(m4|m5).2xlarge` |
-| m5     | `m5.4xlarge`  | `(m4|m5).4xlarge` |
-| r4     | `r4.xlarge`   | `(r4|r5).xlarge`  |
-| r4     | `r4.2xlarge`  | `(r4|r5).2xlarge` |
-| r4     | `r4.4xlarge`  | `(r4|r5).4xlarge` |
-| r4     | `r4.8xlarge`  | `(r4|r5).8xlarge` |
-| r5     | `r5.xlarge`   | `(r4|r5).xlarge`  |
-| r5     | `r5.2xlarge`  | `(r4|r5).2xlarge` |
-| r5     | `r5.4xlarge`  | `(r4|r5).4xlarge` |
-| r5     | `r5.8xlarge`  | `(r4|r5).8xlarge` |
+| Series | Selected type | Enabled types              |
+|--------|---------------|----------------------------|
+| m4     | `m4.xlarge`   | `m4.xlarge`, `m5.xlarge`   |
+| m4     | `m4.2xlarge`  | `m4.2xlarge`, `m5.2xlarge` |
+| m4     | `m4.4xlarge`  | `m4.4xlarge`, `m5.4xlarge` |
+| m5     | `m5.xlarge`   | `m4.xlarge` , `m5.xlarge`  |
+| m5     | `m5.2xlarge`  | `m4.2xlarge`, `m5.2xlarge` |
+| m5     | `m5.4xlarge`  | `m4.4xlarge`, `m5.4xlarge` |
+| r4     | `r4.xlarge`   | `r4.xlarge`, `r5.xlarge`   |
+| r4     | `r4.2xlarge`  | `r4.2xlarge`, `r5.2xlarge` |
+| r4     | `r4.4xlarge`  | `r4.4xlarge`, `r5.4xlarge` |
+| r4     | `r4.8xlarge`  | `r4.8xlarge`, `r5.8xlarge` |
+| r5     | `r5.xlarge`   | `r4.xlarge`, `r5.xlarge`   |
+| r5     | `r5.2xlarge`  | `r4.2xlarge`, `r5.2xlarge` |
+| r5     | `r5.4xlarge`  | `r4.4xlarge`, `r5.4xlarge` |
+| r5     | `r5.8xlarge`  | `r4.8xlarge`, `r5.8xlarge` |
 
 If the type you are using for your node pool is not contained in the list above, activating the use of similar instance types has no effect.
 

--- a/src/content/reference/similar-ec2-instance-types/_index.md
+++ b/src/content/reference/similar-ec2-instance-types/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Similar AWS EC2 instance types reference
-description: Here you find our reference regarding what is considered a "similar" instance type.
-date: 2020-04-22
+description: Here you find our reference regarding what is considered a similar instance type.
+date: 2020-04-24
 layout: subsection
 weight: 500
 ---
@@ -18,22 +18,22 @@ aws-operator creates an Auto Scaling Group (ASG) for every node pool. If the cre
 
 ## Type mapping
 
-| Series | Selected type | Enabled types |
-|-|-|-|
-| m4 | `m4.xlarge`  | `(m4|m5).xlarge`  |
-| m4 | `m4.2xlarge` | `(m4|m5).2xlarge` |
-| m4 | `m4.4xlarge` | `(m4|m5).4xlarge` |
-| m5 | `m5.xlarge`  | `(m4|m5).xlarge`  |
-| m5 | `m5.2xlarge` | `(m4|m5).2xlarge` |
-| m5 | `m5.4xlarge` | `(m4|m5).4xlarge` |
-| r4 | `r4.xlarge`  | `(r4|r5).xlarge`  |
-| r4 | `r4.2xlarge` | `(r4|r5).2xlarge` |
-| r4 | `r4.4xlarge` | `(r4|r5).4xlarge` |
-| r4 | `r4.8xlarge` | `(r4|r5).8xlarge` |
-| r5 | `r5.xlarge`  | `(r4|r5).xlarge`  |
-| r5 | `r5.2xlarge` | `(r4|r5).2xlarge` |
-| r5 | `r5.4xlarge` | `(r4|r5).4xlarge` |
-| r5 | `r5.8xlarge` | `(r4|r5).8xlarge` |
+| Series | Selected type | Enabled types     |
+|--------|---------------|-------------------|
+| m4     | `m4.xlarge`   | `(m4|m5).xlarge`  |
+| m4     | `m4.2xlarge`  | `(m4|m5).2xlarge` |
+| m4     | `m4.4xlarge`  | `(m4|m5).4xlarge` |
+| m5     | `m5.xlarge`   | `(m4|m5).xlarge`  |
+| m5     | `m5.2xlarge`  | `(m4|m5).2xlarge` |
+| m5     | `m5.4xlarge`  | `(m4|m5).4xlarge` |
+| r4     | `r4.xlarge`   | `(r4|r5).xlarge`  |
+| r4     | `r4.2xlarge`  | `(r4|r5).2xlarge` |
+| r4     | `r4.4xlarge`  | `(r4|r5).4xlarge` |
+| r4     | `r4.8xlarge`  | `(r4|r5).8xlarge` |
+| r5     | `r5.xlarge`   | `(r4|r5).xlarge`  |
+| r5     | `r5.2xlarge`  | `(r4|r5).2xlarge` |
+| r5     | `r5.4xlarge`  | `(r4|r5).4xlarge` |
+| r5     | `r5.8xlarge`  | `(r4|r5).8xlarge` |
 
 If the type you are using for your node pool is not contained in the list above, activating the use of similar instance types has no effect.
 

--- a/src/layouts/section/reference.html
+++ b/src/layouts/section/reference.html
@@ -40,6 +40,11 @@
         <a href="cp-k8s-api/">Control Plane Kubernetes API <sup>PREVIEW</sub></a>
         <div class="meta">Learn what the Giant Swarm Control Plane offers via its Kubernetes API. This reference focuses on schema documentation</div>
       </li>
+
+      <li>
+        <a href="similar-ec2-instance-types/">Similar EC2 instance types</a>
+        <div class="meta">Here you find our reference regarding what is considered a similar instance type.</div>
+      </li>
     </ul>
 
     {{ partial "feedback_reference.html" . }}


### PR DESCRIPTION
This PR attempts to fix two problems with https://docs.giantswarm.io/reference/similar-ec2-instance-types/ :

1. The table rendering is broken
2. The page does not show up in the listing https://docs.giantswarm.io/reference/