### PR TITLE
Set apiextensions version to 0.3.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ build: vendor build-css
 	# Generate the Control Plane K8s API reference documentation.
 	docker run \
 		-v ${PWD}/build/content/reference/cp-k8s-api:/opt/crd-docs-generator/output \
-		quay.io/giantswarm/crd-docs-generator:latest --apiextensions-commit-ref v0.3.1
+		quay.io/giantswarm/crd-docs-generator:latest --apiextensions-commit-ref v0.3.3
 
 docker-build: build
 	docker build -t $(REGISTRY)/$(COMPANY)/$(PROJECT):latest .


### PR DESCRIPTION
To pick up latest CRD docs.

This adds docs for the upstream CRDs at

- `/reference/cp-k8s-api/machinedeployments.cluster.x-k8s.io/`
- `/reference/cp-k8s-api/clusters.cluster.x-k8s.io/`
