### PR TITLE
Skip some CRDs when publishing docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,15 @@ build: vendor build-css
 	# Generate the Control Plane K8s API reference documentation.
 	docker run \
 		-v ${PWD}/build/content/reference/cp-k8s-api:/opt/crd-docs-generator/output \
-		quay.io/giantswarm/crd-docs-generator:latest --apiextensions-commit-ref v0.3.3
+		quay.io/giantswarm/crd-docs-generator:05c847436885552917129eb9fd0e88972c830a05 \
+		  --apiextensions-commit-ref v0.3.3 \
+		  --skip-crd chartconfigs.core.giantswarm.io \
+		  --skip-crd clusters.core.giantswarm.io \
+		  --skip-crd draughtsmanconfigs.core.giantswarm.io \
+		  --skip-crd ingressconfigs.core.giantswarm.io \
+		  --skip-crd memcachedconfigs.example.giantswarm.io \
+		  --skip-crd releasecycles.release.giantswarm.io
+
 
 docker-build: build
 	docker build -t $(REGISTRY)/$(COMPANY)/$(PROJECT):latest .

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ build: vendor build-css
 	# Generate the Control Plane K8s API reference documentation.
 	docker run \
 		-v ${PWD}/build/content/reference/cp-k8s-api:/opt/crd-docs-generator/output \
-		quay.io/giantswarm/crd-docs-generator:05c847436885552917129eb9fd0e88972c830a05 \
+		quay.io/giantswarm/crd-docs-generator:latest \
 		  --apiextensions-commit-ref v0.3.3 \
 		  --skip-crd chartconfigs.core.giantswarm.io \
 		  --skip-crd clusters.core.giantswarm.io \


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/8804

For some CRDs in the apiextensions repo we don't want to publish docs.

Based on https://github.com/giantswarm/crd-docs-generator/pull/11