### PR TITLE
Add CRD metadata and reveal in index page

### DIFF
--- a/src/data/crd_metadata.yaml
+++ b/src/data/crd_metadata.yaml
@@ -1,0 +1,103 @@
+# This data file holds meta data for CRDs
+# with the purpose of providing context and filtering capabilities for end users
+# of our CRD docs.
+#
+# Schema:
+# .topics: array of strings. Possible values: "apps", "controlplane", "tenantcluster"
+# .provider: array of strings.
+appcatalogs.application.giantswarm.io:
+  topics:
+    - apps
+apps.application.giantswarm.io:
+  topics:
+    - apps
+awsclusterconfigs.core.giantswarm.io:
+  provider:
+    - aws
+  topics:
+    - tenantcluster
+awsclusters.infrastructure.giantswarm.io:
+  provider:
+    - aws
+  topics:
+    - tenantcluster
+awsconfigs.provider.giantswarm.io:
+  provider:
+    - aws
+  topics:
+    - tenantcluster
+awscontrolplanes.infrastructure.giantswarm.io:
+  provider:
+    - aws
+  topics:
+    - tenantcluster
+awsmachinedeployments.infrastructure.giantswarm.io:
+  provider:
+    - aws
+  topics:
+    - tenantcluster
+azureclusterconfigs.core.giantswarm.io:
+  provider:
+    - azure
+  topics:
+    - tenantcluster
+azureconfigs.provider.giantswarm.io:
+  provider:
+    - azure
+  topics:
+    - tenantcluster
+certconfigs.core.giantswarm.io:
+  topics:
+    - controlplane
+    - tenantcluster
+charts.application.giantswarm.io:
+  topics:
+    - apps
+clusters.cluster.x-k8s.io:
+  provider:
+    - aws
+  topics:
+    - tenantcluster
+drainerconfigs.core.giantswarm.io:
+  topics:
+    - tenantcluster
+etcdbackups.backup.giantswarm.io:
+  topics:
+    - controlplane
+    - tenantcluster
+flannelconfigs.core.giantswarm.io:
+  provider:
+    - kvm
+  topics:
+    - tenantcluster
+g8scontrolplanes.infrastructure.giantswarm.io:
+  provider:
+    - aws
+  topics:
+    - tenantcluster
+ignitions.core.giantswarm.io:
+  topics:
+    - controlplane
+    - tenantcluster
+kvmclusterconfigs.core.giantswarm.io:
+  provider:
+    - kvm
+  topics:
+    - tenantcluster
+kvmconfigs.provider.giantswarm.io:
+  provider:
+    - kvm
+  topics:
+    - tenantcluster
+machinedeployments.cluster.x-k8s.io:
+  provider:
+    - aws
+  topics:
+    - tenantcluster
+releases.release.giantswarm.io:
+  topics:
+    - controlplane
+    - tenantcluster
+storageconfigs.core.giantswarm.io:
+  topics:
+    - controlplane

--- a/src/layouts/section/cp-k8s-api-reference.html
+++ b/src/layouts/section/cp-k8s-api-reference.html
@@ -28,13 +28,13 @@
               {{ with index $.Site.Data.crd_metadata $crdName }}
                 {{ $crdMetaData := . }}
                   {{ with index $crdMetaData "provider" }}
-                    &mdash; Provider:
+                    &mdash; Provider
                     {{ range . }}
                       <span class="tag tag-provider tag-provider-{{ . }}">{{ . }}</span>
                     {{ end }}
                   {{ end }}
                   {{ with index $crdMetaData "topics" }}
-                    &mdash; Topic:
+                    &mdash; Topic
                     {{ range . }}
                       <span class="tag tag-topic tag-topic-{{ . }}">{{ . }}</span>
                     {{ end }}

--- a/src/layouts/section/cp-k8s-api-reference.html
+++ b/src/layouts/section/cp-k8s-api-reference.html
@@ -18,10 +18,32 @@
 
     <ul class="linklist crd-index">
 
-      {{ range .Data.Pages.ByWeight }}
+      {{ range .Pages.ByWeight }}
       <li>
           <a href="{{ .Permalink | relURL }}">{{ .LinkTitle }}</a>
-          <div class="meta">{{ .Description }}</div>
+          <div class="meta">
+            {{ with .Params.technical_name }}
+              {{ $crdName := . }}
+              <p><code>{{ $crdName }}</code>
+              {{ with index $.Site.Data.crd_metadata $crdName }}
+                {{ $crdMetaData := . }}
+                  {{ with index $crdMetaData "provider" }}
+                    &mdash; Provider:
+                    {{ range . }}
+                      <span class="tag tag-provider tag-provider-{{ . }}">{{ . }}</span>
+                    {{ end }}
+                  {{ end }}
+                  {{ with index $crdMetaData "topics" }}
+                    &mdash; Topic:
+                    {{ range . }}
+                      <span class="tag tag-topic tag-topic-{{ . }}">{{ . }}</span>
+                    {{ end }}
+                  {{ end }}
+              {{ end }}
+              </p>
+            {{ end }}
+            <p>{{ .Description }}</p>
+          </div>
       </li>
       {{ end }}
 

--- a/src/static/css/crd.css
+++ b/src/static/css/crd.css
@@ -5,6 +5,28 @@ ul.crd-index {
   margin-bottom: 2em;
 }
 
+.crd-index .tag {
+  background-color: #ccc;
+  padding: 2px 7px;
+  font-size: 14px;
+  border-radius: 3px;
+}
+.crd-index .tag-provider {
+  text-transform: uppercase;
+}
+.crd-index .tag-provider-aws {
+  background-color: #ed9235;
+  color: #232f3b;
+}
+.crd-index .tag-provider-azure {
+  background-color: #1773bd;
+  color: #fff;
+}
+.crd-index .tag-topic {
+  background-color: #5eaebb;
+  color: #fff;
+}
+
 dl.crd-meta {
   display: flex;
   flex-flow: row wrap;


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/8804

This adds some metadata for CRDs to the [reference](https://docs.giantswarm.io/reference/cp-k8s-api/) with the purpose:

- to give users more context on the CRDs in the index
- to allow for filtering and navigation between CRDs in a next step

Also this modifies the CRD index page in these ways:

- Add the technical CRD name for more differentiation
- Add the topics and provider tags from metadata

### To reviewers

Please check the topic assignment `tenantcluster` vs. `controlplane` for the CRDs you have good knowledge about.

### Previews

![image](https://user-images.githubusercontent.com/273727/80723467-f54dd100-8b00-11ea-8805-a13b5b425bfd.png)

![image](https://user-images.githubusercontent.com/273727/80723586-1dd5cb00-8b01-11ea-99db-444d054930bc.png)
