### PR TITLE
docs build enhancements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
                 --check-extern -t 2 \
                 --ignore-url="^https://docs.giantswarm.io/.*" \
                 --ignore-url=/api/ \
-                --ignore-url="^https://.*.example.com/.*" \
+                --ignore-url="^https://.*example.com/.*" \
                 --ignore-url="^https://my-org.github.com/.*" \
                 --ignore-url=".*gigantic\.io.*"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
       - run:
           name: Link check
           command: |
-            docker pull -q linkchecker/linkchecker
+            docker pull linkchecker/linkchecker > /dev/null
             docker run -d --rm --name docs -p 8080:8080 quay.io/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME:$CIRCLE_SHA1
             docker run --rm -ti --name linkchecker \
               --link docs:docs \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
                 --check-extern -t 2 \
                 --ignore-url="^https://docs.giantswarm.io/.*" \
                 --ignore-url=/api/ \
-                --ignore-url="^https://.+.example.com/.*" \
+                --ignore-url="^https://.*.example.com/.*" \
                 --ignore-url="^https://my-org.github.com/.*" \
                 --ignore-url=".*gigantic\.io.*"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,7 @@ jobs:
       - run:
           name: Link check
           command: |
+            docker pull -q linkchecker/linkchecker
             docker run -d --rm --name docs -p 8080:8080 quay.io/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME:$CIRCLE_SHA1
             docker run --rm -ti --name linkchecker \
               --link docs:docs \
@@ -70,7 +71,7 @@ jobs:
 workflows:
   version: 2
 
-  build-and-linkcheck:
+  build-andcheck:
     jobs:
       - build
       - linkcheck:

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ build: vendor build-css
 	# Generate the Control Plane K8s API reference documentation.
 	docker run \
 		-v ${PWD}/build/content/reference/cp-k8s-api:/opt/crd-docs-generator/output \
-		quay.io/giantswarm/crd-docs-generator:latest \
+		quay.io/giantswarm/crd-docs-generator:45a4eebf2dd3340dcce091b3f5d0ebe3dc83cd21 \
 		  --apiextensions-commit-ref v0.3.3 \
 		  --skip-crd chartconfigs.core.giantswarm.io \
 		  --skip-crd clusters.core.giantswarm.io \

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ build: vendor build-css
 	docker run \
 		-v ${PWD}/build/content/reference/cp-k8s-api:/opt/crd-docs-generator/output \
 		quay.io/giantswarm/crd-docs-generator:45a4eebf2dd3340dcce091b3f5d0ebe3dc83cd21 \
-		  --apiextensions-commit-ref v0.3.3 \
+		  --apiextensions-commit-ref v0.3.4 \
 		  --skip-crd chartconfigs.core.giantswarm.io \
 		  --skip-crd clusters.core.giantswarm.io \
 		  --skip-crd draughtsmanconfigs.core.giantswarm.io \


### PR DESCRIPTION
- use matching apiextensions and crd-docs-generator version
- Ignore all example.com links in linkchecks
- Avoid output for pulling the linkchecker image in CI