### PR TITLE
Remove the "preview" messaging for the CRD reference

### DIFF
--- a/src/content/guides/scheduling-constraints-and-resource-qos/index.md
+++ b/src/content/guides/scheduling-constraints-and-resource-qos/index.md
@@ -60,5 +60,5 @@ If `requests` and `limits` are not set for all of the resources, across all cont
 
 ## Further reading
 
-- [Managing Compute Resources](http://kubernetes.io/docs/user-guide/compute-resources/)
+- [Managing Resources for Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
 - [Pod Quality of Service in Kubernetes](https://kubernetes.io/docs/tasks/configure-pod-container/quality-service-pod/)

--- a/src/layouts/section/cp-k8s-api-reference.html
+++ b/src/layouts/section/cp-k8s-api-reference.html
@@ -4,7 +4,7 @@
   <div class="col-md-10 col-md-offset-1">
     <h1 id="title">Control Plane Kubernetes API Reference</h1>
 
-    <p>At Giant Swarm, the _control plane_ is a Kubernetes cluster that allows to create and manage the Kubernetesa clusters running your workloads (we call them _tenant clusters_).</p>
+    <p>At Giant Swarm, the _control plane_ is a Kubernetes cluster that allows to create and manage the Kubernetes clusters running your workloads (we call them _tenant clusters_).</p>
     
     <p>The Control Plane Kubernetes API gives you access to the custom resources (CR) defining your tenant clusters in your Giant Swarm installation’s control plane. Here you find schema descriptions for the custom resources in use.</p>
 

--- a/src/layouts/section/cp-k8s-api-reference.html
+++ b/src/layouts/section/cp-k8s-api-reference.html
@@ -4,11 +4,9 @@
   <div class="col-md-10 col-md-offset-1">
     <h1 id="title">Control Plane Kubernetes API Reference</h1>
 
+    <p>At Giant Swarm, the _Control Plane_ is a Kubernetes cluster that manages allows to create and manage the Kubernetesa clusters running your workloads (we call them _Tenant Clusters_).</p>
+    
     <p>The Control Plane Kubernetes API gives you access to the custom resources (CR) defining your tenant clusters in your Giant Swarm installation’s control plane. Here you find schema descriptions for the custom resources in use.</p>
-
-    <p>This is an early preview of our Control Plane Kubernetes API documentation, focusing on Custom Resource (CR)/Custom Resource Definition (CRD) schema.</p>
-
-    <p>Watch this space in the upcoming weeks to find improvements and more documented details. Feel free to give us any <strong>feedback</strong> and let us know how we could do better!</p>
 
     <hr />
 

--- a/src/layouts/section/cp-k8s-api-reference.html
+++ b/src/layouts/section/cp-k8s-api-reference.html
@@ -4,7 +4,7 @@
   <div class="col-md-10 col-md-offset-1">
     <h1 id="title">Control Plane Kubernetes API Reference</h1>
 
-    <p>At Giant Swarm, the _Control Plane_ is a Kubernetes cluster that manages allows to create and manage the Kubernetesa clusters running your workloads (we call them _Tenant Clusters_).</p>
+    <p>At Giant Swarm, the _control plane_ is a Kubernetes cluster that allows to create and manage the Kubernetesa clusters running your workloads (we call them _tenant clusters_).</p>
     
     <p>The Control Plane Kubernetes API gives you access to the custom resources (CR) defining your tenant clusters in your Giant Swarm installation’s control plane. Here you find schema descriptions for the custom resources in use.</p>
 

--- a/src/layouts/section/reference.html
+++ b/src/layouts/section/reference.html
@@ -32,13 +32,13 @@
       </li>
 
       <li>
-        <a href="kernel-settings/">Kernel specific settings</a>
-        <div class="meta">Complete list of the tuned CoreOS kernel settings for Giant Swarm clusters.</div>
+        <a href="cp-k8s-api/">Control Plane Kubernetes API</a>
+        <div class="meta">Learn what the Giant Swarm Control Plane offers via its Kubernetes API. This reference focuses on schema documentation</div>
       </li>
 
       <li>
-        <a href="cp-k8s-api/">Control Plane Kubernetes API <sup>PREVIEW</sub></a>
-        <div class="meta">Learn what the Giant Swarm Control Plane offers via its Kubernetes API. This reference focuses on schema documentation</div>
+        <a href="kernel-settings/">Kernel specific settings</a>
+        <div class="meta">Complete list of the tuned CoreOS kernel settings for Giant Swarm clusters.</div>
       </li>
 
       <li>

--- a/src/layouts/section/reference.html
+++ b/src/layouts/section/reference.html
@@ -33,7 +33,7 @@
 
       <li>
         <a href="cp-k8s-api/">Control Plane Kubernetes API</a>
-        <div class="meta">Learn what the Giant Swarm Control Plane offers via its Kubernetes API. This reference focuses on schema documentation</div>
+        <div class="meta">Learn what the Giant Swarm Control Plane offers via its Kubernetes API. This reference focuses on schema documentation.</div>
       </li>
 
       <li>


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/8804

The CRD reference is now fairly complete and mature. This removes the disclaimer regarding CRD reference being in preview.