### PR TITLE
Tenant cluster labelling gsctl

### DIFF
--- a/src/content/guides/tenant-cluster-labelling/index.md
+++ b/src/content/guides/tenant-cluster-labelling/index.md
@@ -36,7 +36,7 @@ my-org/team=upstate
 Once clusters are labelled, the output of [`gsctl list clusters`](/reference/gsctl/list-clusters/) can be augmented by setting flag `--selector` (or `-l`)
 It takes a [Kubernetes Label selector](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors) to specify requirments on cluster labels to select.
 
-The output of [`gsctl show cluster`](/reference/gsctl/show-cluster/`) will contain all labels currently attached to the selected cluster.
+The output of [`gsctl show cluster`](/reference/gsctl/show-cluster/) will contain all labels currently attached to the selected cluster.
 
 ## Working with tenant cluster labels using the Giant Swarm API
 

--- a/src/content/reference/cluster-definition/_index.md
+++ b/src/content/reference/cluster-definition/_index.md
@@ -95,6 +95,9 @@ Let's start with an example:
 api_version: "v5"
 release_version: "11.0.0"
 name: "Test cluster with two node pools"
+labels:
+  locked: "false"
+  environment: "testing"
 master:
   availability_zone: "eu-central-1a"
 nodepools:
@@ -136,6 +139,7 @@ Coming from v4, you might want to understand how v5 is different from v4:
 - `master`:
   - `availability_zone`: Name of the availability zone to use for the master node. If not set, one will be assigned randomly.
 - `nodepools`: Here you can list your node pool definitions as explained below. Note that this is not mandatory and you can also add node pools to a cluster after it has been created.
+- `labels`: Labels to be attached to this cluster.
 
 #### Node pool definition keys
 

--- a/src/content/reference/gsctl/_index.md
+++ b/src/content/reference/gsctl/_index.md
@@ -38,6 +38,7 @@ Follow the links below for detailed documentation, where available. You can also
 | `show cluster`                        | [Show cluster details](show-cluster/)
 | `show nodepool`                       | [Show node pool details](show-nodepool/)
 | `show release`                        | Show details on a release
+| `update cluster`                      | [Modify cluster labels](update-cluster/)
 | `update nodepool`                     | [Modify (rename, scale) a node pool](update-nodepool/)
 | `update organization set-credentials` | [Set provider credentials for an organization](update-org-set-credentials/)
 | `upgrade cluster`                     | [Upgrade a cluster](upgrade-cluster/)

--- a/src/content/reference/gsctl/_index.md
+++ b/src/content/reference/gsctl/_index.md
@@ -38,7 +38,7 @@ Follow the links below for detailed documentation, where available. You can also
 | `show cluster`                        | [Show cluster details](show-cluster/)
 | `show nodepool`                       | [Show node pool details](show-nodepool/)
 | `show release`                        | Show details on a release
-| `update cluster`                      | [Modify cluster labels](update-cluster/)
+| `update cluster`                      | [Modify cluster details (name, labels)](update-cluster/)
 | `update nodepool`                     | [Modify (rename, scale) a node pool](update-nodepool/)
 | `update organization set-credentials` | [Set provider credentials for an organization](update-org-set-credentials/)
 | `upgrade cluster`                     | [Upgrade a cluster](upgrade-cluster/)

--- a/src/content/reference/gsctl/list-clusters.md
+++ b/src/content/reference/gsctl/list-clusters.md
@@ -30,12 +30,12 @@ The details displayed are:
 
 ## Argument reference
 
-- `--output` or `-o`: Using this flag with the value `json`, the output can be printed in JSON format. This is convenient for use in automation. JSON representation additionally contains user defined cluster labels for clusters with node pools on AWS. The default output format is `table`, which results in an output like shown above.
+- `--output` or `-o`: Using this flag with the value `json`, the output can be printed in JSON format. This is convenient for use in automation. JSON representation additionally contains user defined cluster labels for clusters with release version 10.0.0 and above on AWS. The default output format is `table`, which results in an output like shown above.
 - `--show-deleting`: Set this flag to also list clusters that are currently being deleted and add a `DELETING SINCE` column. Has no effect with `--output json`, as JSON output contains all clusters, deleted or not.
 - `--selector` or `-l`: Label selector query to filter clusters on.
 Accepts a single string containing multiple selector requirements which are comma-separated.
 In the case of multiple requirements, all must be satisfied so the comma separator acts as a logical AND (&&) operator.
-This feature is only available for clusters with node pools on AWS.
+This feature is only available for clusters with release version 10.0.0 and above on AWS.
 
 ## Related
 

--- a/src/content/reference/gsctl/list-clusters.md
+++ b/src/content/reference/gsctl/list-clusters.md
@@ -30,9 +30,12 @@ The details displayed are:
 
 ## Argument reference
 
-- `--output` or `-o`: Using this flag with the value `json`, the output can be printed in JSON format. This is convenient for use in automation. JSON representation additionally contains user defined cluster labels. The default output format is `table`, which results in an output like shown above.
+- `--output` or `-o`: Using this flag with the value `json`, the output can be printed in JSON format. This is convenient for use in automation. JSON representation additionally contains user defined cluster labels for clusters with node pools on AWS. The default output format is `table`, which results in an output like shown above.
 - `--show-deleting`: Set this flag to also list clusters that are currently being deleted and add a `DELETING SINCE` column. Has no effect with `--output json`, as JSON output contains all clusters, deleted or not.
-- `--selector` or `-l`: Label selector query to filter clusters on. Accepts a single string containing multiple selector requirements which are comma-separated. In the case of multiple requirements, all must be satisfied so the comma separator acts as a logical AND (&&) operator.
+- `--selector` or `-l`: Label selector query to filter clusters on.
+Accepts a single string containing multiple selector requirements which are comma-separated.
+In the case of multiple requirements, all must be satisfied so the comma separator acts as a logical AND (&&) operator.
+This feature is only available for clusters with node pools on AWS.
 
 ## Related
 

--- a/src/content/reference/gsctl/list-clusters.md
+++ b/src/content/reference/gsctl/list-clusters.md
@@ -32,6 +32,7 @@ The details displayed are:
 
 - `--output` or `-o`: Using this flag with the value `json`, the output can be printed in JSON format. This is convenient for use in automation. The default output format is `table`, which results in an output like shown above.
 - `--show-deleting`: Set this flag to also list clusters that are currently being deleted and add a `DELETING SINCE` column. Has no effect with `--output json`, as JSON output contains all clusters, deleted or not.
+- `--selector` or `-l`: Label selector query to filter clusters on. Accepts a single string containing multiple selector requirements which are comma-separated. In the case of multiple requirements, all must be satisfied so the comma separator acts as a logical AND (&&) operator.
 
 ## Related
 

--- a/src/content/reference/gsctl/list-clusters.md
+++ b/src/content/reference/gsctl/list-clusters.md
@@ -28,6 +28,17 @@ The details displayed are:
 - `RELEASE`: The version number of the release used by the cluster. For older clusters, this may be `n/a`.
 - `CREATED`: The date and time when the cluster has been created (UTC).
 
+The `--selector` flag can be used to filter the output based on a set of requirements.
+
+```nohighlight
+$ gsctl list clusters --selector environment=testing
+ID     ORGANIZATION  NAME        RELEASE  CREATED
+z63so  testteam      Dan's Test  2.7.2    2017 Jun 19, 09:12 UTC
+```
+
+In this example, cluster `z63so` is the only cluster with label `environment=testing`.
+More information about possible queries can be found in the [Kubernetes Labels and Selectors documentation](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/).
+
 ## Argument reference
 
 - `--output` or `-o`: Using this flag with the value `json`, the output can be printed in JSON format. This is convenient for use in automation. JSON representation additionally contains user defined cluster labels for clusters with release version 10.0.0 and above on AWS. The default output format is `table`, which results in an output like shown above.

--- a/src/content/reference/gsctl/list-clusters.md
+++ b/src/content/reference/gsctl/list-clusters.md
@@ -30,7 +30,7 @@ The details displayed are:
 
 ## Argument reference
 
-- `--output` or `-o`: Using this flag with the value `json`, the output can be printed in JSON format. This is convenient for use in automation. The default output format is `table`, which results in an output like shown above.
+- `--output` or `-o`: Using this flag with the value `json`, the output can be printed in JSON format. This is convenient for use in automation. JSON representation additionally contains cluster labels. The default output format is `table`, which results in an output like shown above.
 - `--show-deleting`: Set this flag to also list clusters that are currently being deleted and add a `DELETING SINCE` column. Has no effect with `--output json`, as JSON output contains all clusters, deleted or not.
 - `--selector` or `-l`: Label selector query to filter clusters on. Accepts a single string containing multiple selector requirements which are comma-separated. In the case of multiple requirements, all must be satisfied so the comma separator acts as a logical AND (&&) operator.
 

--- a/src/content/reference/gsctl/list-clusters.md
+++ b/src/content/reference/gsctl/list-clusters.md
@@ -30,7 +30,7 @@ The details displayed are:
 
 ## Argument reference
 
-- `--output` or `-o`: Using this flag with the value `json`, the output can be printed in JSON format. This is convenient for use in automation. JSON representation additionally contains cluster labels. The default output format is `table`, which results in an output like shown above.
+- `--output` or `-o`: Using this flag with the value `json`, the output can be printed in JSON format. This is convenient for use in automation. JSON representation additionally contains user defined cluster labels. The default output format is `table`, which results in an output like shown above.
 - `--show-deleting`: Set this flag to also list clusters that are currently being deleted and add a `DELETING SINCE` column. Has no effect with `--output json`, as JSON output contains all clusters, deleted or not.
 - `--selector` or `-l`: Label selector query to filter clusters on. Accepts a single string containing multiple selector requirements which are comma-separated. In the case of multiple requirements, all must be satisfied so the comma separator acts as a logical AND (&&) operator.
 

--- a/src/content/reference/gsctl/list-clusters.md
+++ b/src/content/reference/gsctl/list-clusters.md
@@ -41,12 +41,12 @@ More information about possible queries can be found in the [Kubernetes Labels a
 
 ## Argument reference
 
-- `--output` or `-o`: Using this flag with the value `json`, the output can be printed in JSON format. This is convenient for use in automation. JSON representation additionally contains user defined cluster labels for clusters with release version 10.0.0 and above on AWS. The default output format is `table`, which results in an output like shown above.
+- `--output` or `-o`: Using this flag with the value `json`, the output can be printed in JSON format. This is convenient for use in automation. JSON representation additionally contains user defined cluster labels for clusters with release version {{% first_aws_nodepools_version %}} and above on AWS. The default output format is `table`, which results in an output like shown above.
 - `--show-deleting`: Set this flag to also list clusters that are currently being deleted and add a `DELETING SINCE` column. Has no effect with `--output json`, as JSON output contains all clusters, deleted or not.
 - `--selector` or `-l`: Label selector query to filter clusters on.
 Accepts a single string containing multiple selector requirements which are comma-separated.
 In the case of multiple requirements, all must be satisfied so the comma separator acts as a logical AND (&&) operator.
-This feature is only available for clusters with release version 10.0.0 and above on AWS.
+This feature is only available for clusters with release version {{% first_aws_nodepools_version %}} and above on AWS.
 
 ## Related
 

--- a/src/content/reference/gsctl/show-cluster.md
+++ b/src/content/reference/gsctl/show-cluster.md
@@ -39,8 +39,33 @@ Worker nodes running:          8
 Worker EC2 instance type:      m5.xlarge
 CPU cores in workers:          28
 RAM in worker nodes (GB):      26.5
-Labels:                        usage=staging
-                               locked=false
+```
+
+Example output for an AWS based cluster with release version 10.0.0 and above:
+
+```nohighlight
+Cluster ID:                ggf8v
+Name:                      Testing - Team upstate
+Created:                   2020 May 04, 16:54 UTC
+Organization:              acme
+Kubernetes API endpoint:   https://api.ggf8v.REDACTED.aws.gigantic.io
+Master availability zone:  region-region-1a
+Release version:           11.2.1
+Labels:                    usage=testing
+                           team=upstate
+                           locked=false
+Web UI:                    https://happa.ggf8v.REDACTED.aws.gigantic.io/organizations/acme/clusters/ggf8v
+Size:                      3 nodes in 1 node pool
+CPUs in nodes:             12
+RAM in nodes (GB):         48
+
+This cluster has node pools. For details, use
+
+    gsctl list nodepools ggf8v
+
+For details on a specific node pool, use
+
+    gsctl show nodepool ggf8v/<nodepool-id>
 ```
 
 Example output for a KVM based cluster:

--- a/src/content/reference/gsctl/show-cluster.md
+++ b/src/content/reference/gsctl/show-cluster.md
@@ -81,7 +81,7 @@ The output lines in detail:
 - **AWS account:** (_only on AWS_) If the cluster is running using non-default provider credentials, here we show the AWS account ID
 - **Azure subscription:** (_only on Azure_) If the cluster is running using non-default provider credentials, here we show the subscription ID
 - **Azure tenant:** (_only on Azure_) If the cluster is running using non-default provider credentials, here we show the tenant ID
-- **Labels** (_only on AWS_) user defined labels. Only available for clusters with node pools
+- **Labels** (_only on AWS_) user defined labels. Only available for clusters with release version 10.0.0 and above on AWS
 
 Note that some dynamic pieces of information, like the current number of workers, and the desired worker count, may take up to five minutes to be updated.
 

--- a/src/content/reference/gsctl/show-cluster.md
+++ b/src/content/reference/gsctl/show-cluster.md
@@ -39,6 +39,8 @@ Worker nodes running:          8
 Worker EC2 instance type:      m5.xlarge
 CPU cores in workers:          28
 RAM in worker nodes (GB):      26.5
+Labels:                        usage=staging
+                               locked=false
 ```
 
 Example output for a KVM based cluster:
@@ -79,6 +81,7 @@ The output lines in detail:
 - **AWS account:** (_only on AWS_) If the cluster is running using non-default provider credentials, here we show the AWS account ID
 - **Azure subscription:** (_only on Azure_) If the cluster is running using non-default provider credentials, here we show the subscription ID
 - **Azure tenant:** (_only on Azure_) If the cluster is running using non-default provider credentials, here we show the tenant ID
+- **Labels** (_only on AWS_) user defined labels. Only available for clusters with node pools
 
 Note that some dynamic pieces of information, like the current number of workers, and the desired worker count, may take up to five minutes to be updated.
 

--- a/src/content/reference/gsctl/show-cluster.md
+++ b/src/content/reference/gsctl/show-cluster.md
@@ -41,7 +41,7 @@ CPU cores in workers:          28
 RAM in worker nodes (GB):      26.5
 ```
 
-Example output for an AWS based cluster with release version 10.0.0 and above:
+Example output for an AWS based cluster with release version {{% first_aws_nodepools_version %}} and above:
 
 ```nohighlight
 Cluster ID:                ggf8v
@@ -106,7 +106,7 @@ The output lines in detail:
 - **AWS account:** (_only on AWS_) If the cluster is running using non-default provider credentials, here we show the AWS account ID
 - **Azure subscription:** (_only on Azure_) If the cluster is running using non-default provider credentials, here we show the subscription ID
 - **Azure tenant:** (_only on Azure_) If the cluster is running using non-default provider credentials, here we show the tenant ID
-- **Labels** (_only on AWS_) user defined labels. Only available for clusters with release version 10.0.0 and above on AWS
+- **Labels** (_only on AWS_) user defined labels. Only available for clusters with release version {{% first_aws_nodepools_version %}} and above on AWS
 
 Note that some dynamic pieces of information, like the current number of workers, and the desired worker count, may take up to five minutes to be updated.
 

--- a/src/content/reference/gsctl/update-cluster.md
+++ b/src/content/reference/gsctl/update-cluster.md
@@ -1,22 +1,30 @@
 ---
 title: "gsctl Command Reference: update cluster"
-description: The 'gsctl update cluster' command allows the modification of cluster labels.
-date: 2020-03-11
+description: The 'gsctl update cluster' command allows the modification of the name of a cluster and its labels.
+date: 2020-05-04
 type: page
 weight: 44
 ---
 
 # `gsctl update cluster`
 
-The `gsctl update cluster` allows the modification of cluster labels. This feature is only available for clusters with node pools on AWS.
+The `gsctl update cluster` allows the modification of the name of a cluster and its labels.
+Cluster labelling is only available for clusters with node pools on AWS.
 
 ## Usage
 
 The command is called with the cluster ID or name as a positional argument.
+The desired new name can be specified with the `--name` or `-n` flag.
 The `--label` flag is used to modify labels.
 It can receive either a JSON formatted [JSON Merge Patch, RFC 7386](https://tools.ietf.org/html/rfc7386) or a string specifying label changes.
 
-### JSON Merge Patch example
+### Name modification example
+
+```nohighlight
+$ gsctl update cluster f01r4 --name "Precious Production Cluster"
+```
+
+### Labels modification JSON Merge Patch example
 
 ```nohighlight
 $ gsctl update cluster vxvc7 --labels '{"environment": "testing", "locked": null}'
@@ -24,7 +32,7 @@ $ gsctl update cluster vxvc7 --labels '{"environment": "testing", "locked": null
 
 will update the labels of cluster `vxvc7`. It will add (or update depending on prior existence) label `environment=testing` and delete the label with key `locked`.
 
-### key=value example
+### Labels modification key=value example
 
 ```nohighlight
 $ gsctl update cluster vxvc7 --labels 'environment=testing locked-'
@@ -34,6 +42,7 @@ will update the labels of cluster `vxvc7`. It will add (or update depending on p
 
 ## Full argument reference {#arguments}
 
+- `--name` or `-n`: The new cluster name.
 - `--labels`: Specify label updates. Allows to specify label updates either as a [JSON Merge Patch, RFC 7386](https://tools.ietf.org/html/rfc7386) or in form of `'key=value anotherkey=anothervalue'`.
 Use `key-` to delete the label with key `key`.
 
@@ -41,5 +50,7 @@ Use `key-` to delete the label with key `key`.
 
 - [`gsctl create cluster`](/reference/gsctl/create-cluster/) - Add a node pool to a cluster
 - [`gsctl list clusters`](/reference/gsctl/list-clusters/) - List all node pools of a cluster
+- [API: Modify cluster (v4)](/api/#operation/modifyCluster)
+- [API: Modify cluster (v5)](/api/#operation/modifyClusterV5)
 - [API: Update cluster labels](/api/#operation/setClusterLabels)
 - [Labelling tennant clusters](/guides/tenant-cluster-labelling/)

--- a/src/content/reference/gsctl/update-cluster.md
+++ b/src/content/reference/gsctl/update-cluster.md
@@ -9,7 +9,7 @@ weight: 44
 # `gsctl update cluster`
 
 The `gsctl update cluster` allows the modification of the name of a cluster and its labels.
-Cluster labelling is only available for clusters with release version 10.0.0 and above on AWS.
+Cluster labelling is only available for clusters with release version {{% first_aws_nodepools_version %}} and above on AWS.
 
 ## Usage
 

--- a/src/content/reference/gsctl/update-cluster.md
+++ b/src/content/reference/gsctl/update-cluster.md
@@ -9,7 +9,7 @@ weight: 44
 # `gsctl update cluster`
 
 The `gsctl update cluster` allows the modification of the name of a cluster and its labels.
-Cluster labelling is only available for clusters with node pools on AWS.
+Cluster labelling is only available for clusters with release version 10.0.0 and above on AWS.
 
 ## Usage
 

--- a/src/content/reference/gsctl/update-cluster.md
+++ b/src/content/reference/gsctl/update-cluster.md
@@ -1,0 +1,43 @@
+---
+title: "gsctl Command Reference: update cluster"
+description: The 'gsctl update cluster' command allows the modification of cluster labels.
+date: 2020-03-11
+type: page
+weight: 44
+---
+
+# `gsctl update cluster`
+
+The `gsctl update cluster` allows the modification of cluster labels.
+
+## Usage
+
+The command is called with the cluster ID or name as a positional argument.
+The `--label` flag is used to modify labels.
+It can receive either a JSON formatted [JSON Merge Patch, RFC 7386](https://tools.ietf.org/html/rfc7386) or a string specifying label changes.
+
+### JSON Merge Patch example
+
+```nohighlight
+$ gsctl update cluster vxvc7 --labels '{"environment": "testing", "locked": null}'
+```
+
+will update the labels of cluster `vxvc7`. It will add (or update depending on prior existence) label `environment=testing` and delete the label with key `locked`.
+
+### key=value example
+
+```nohighlight
+$ gsctl update cluster vxvc7 --labels 'environment=testing locked-'
+```
+
+will update the labels of cluster `vxvc7`. It will add (or update depending on prior existence) label `environment=testing` and delete the label with key `locked`.
+
+## Full argument reference {#arguments}
+
+- `--labels`: Specify label updates. Allows to specify label updates either as a [JSON Merge Patch, RFC 7386](https://tools.ietf.org/html/rfc7386) or in form of `'key=value anotherkey=anothervalue'`.
+Use `key-` to delete the label with key `key`.
+
+## Related
+
+- [`gsctl create cluster`](/reference/gsctl/create-cluster/) - Add a node pool to a cluster
+- [`gsctl list clusters`](/reference/gsctl/list-clusters/) - List all node pools of a cluster

--- a/src/content/reference/gsctl/update-cluster.md
+++ b/src/content/reference/gsctl/update-cluster.md
@@ -41,3 +41,5 @@ Use `key-` to delete the label with key `key`.
 
 - [`gsctl create cluster`](/reference/gsctl/create-cluster/) - Add a node pool to a cluster
 - [`gsctl list clusters`](/reference/gsctl/list-clusters/) - List all node pools of a cluster
+- [API: Update cluster labels](/api/#operation/setClusterLabels)
+- [Labelling tennant clusters](/guides/tenant-cluster-labelling/)

--- a/src/content/reference/gsctl/update-cluster.md
+++ b/src/content/reference/gsctl/update-cluster.md
@@ -15,8 +15,8 @@ Cluster labelling is only available for clusters with release version {{% first_
 
 The command is called with the cluster ID or name as a positional argument.
 The desired new name can be specified with the `--name` or `-n` flag.
-The `--label` flag is used to modify labels.
-It can receive either a JSON formatted [JSON Merge Patch, RFC 7386](https://tools.ietf.org/html/rfc7386) or a string specifying label changes.
+The `--label` flag is used to modify a single label change.
+It can be specified multiple times in order to change multiple labels at once.
 
 ### Name modification example
 
@@ -24,18 +24,10 @@ It can receive either a JSON formatted [JSON Merge Patch, RFC 7386](https://tool
 $ gsctl update cluster f01r4 --name "Precious Production Cluster"
 ```
 
-### Labels modification JSON Merge Patch example
-
-```nohighlight
-$ gsctl update cluster vxvc7 --labels '{"environment": "testing", "locked": null}'
-```
-
-will update the labels of cluster `vxvc7`. It will add (or update depending on prior existence) label `environment=testing` and delete the label with key `locked`.
-
 ### Labels modification key=value example
 
 ```nohighlight
-$ gsctl update cluster vxvc7 --labels 'environment=testing locked-'
+$ gsctl update cluster vxvc7 --label environment=testing --label locked=
 ```
 
 will update the labels of cluster `vxvc7`. It will add (or update depending on prior existence) label `environment=testing` and delete the label with key `locked`.
@@ -43,8 +35,9 @@ will update the labels of cluster `vxvc7`. It will add (or update depending on p
 ## Full argument reference {#arguments}
 
 - `--name` or `-n`: The new cluster name.
-- `--labels`: Specify label updates. Allows to specify label updates either as a [JSON Merge Patch, RFC 7386](https://tools.ietf.org/html/rfc7386) or in form of `'key=value anotherkey=anothervalue'`.
-Use `key-` to delete the label with key `key`.
+- `--label`: Specify a single label update.
+Allowed multiple times.
+To remove a label, set its key to an empty string (`labeltodelete=`).
 
 ## Related
 

--- a/src/content/reference/gsctl/update-cluster.md
+++ b/src/content/reference/gsctl/update-cluster.md
@@ -8,7 +8,7 @@ weight: 44
 
 # `gsctl update cluster`
 
-The `gsctl update cluster` allows the modification of cluster labels.
+The `gsctl update cluster` allows the modification of cluster labels. This feature is only available for clusters with node pools on AWS.
 
 ## Usage
 


### PR DESCRIPTION
I want to use this PR to sketch out/document tenant cluster labelling using `gsctl`. Towards giantswarm/giantswarm#1693

Once this PR is approved, I'll start implemeting these changes in `gsctl`.

Here is a TL;DR of the changes/additions:

- `gsctl list cluster`
  - `-o json` additionally includes user defined cluster labels
  - `--selector` or `-l` can be used to filter the list of returned clusters
- `gsctl show cluster` returns user defined cluster labels for node pool clusters on AWS ([Example](https://github.com/giantswarm/docs/pull/481/commits/d801b975b5952f437b42bb640c81d1952b12d93a#diff-5eede8a45557a2cf5bd14b48d3fdc857R42-R43))
- `gsctl create cluster`
  - cluster labels can be specified through a `labels` object in the v5 yaml cluster definition
- **new**: `gsctl update cluster`
  - `--label` allows to specify a label change in form of `key=value`. Can be specified multiple times. Set to `key=` to delete a label
