### PR TITLE
Add intro page on APIs

### DIFF
--- a/src/content/basics/api/index.md
+++ b/src/content/basics/api/index.md
@@ -1,0 +1,69 @@
+---
+title: API Access to Giant Swarm Resources
+description: An overview of the APIs that provide you with programmatic access to
+  resources like your tenant cluster in a Giant Swarm installation. Namely the Control
+  Plane Kubernetes API and the legacy Giant Swarm Rest API.
+date: 2020-05-04
+weight: 75
+type: page
+categories: ["basics"]
+last-review-date:
+---
+
+# API Access to Giant Swarm Resources
+
+For integrating Giant Swarm with your automation, we provide programmatic access via two different APIs:
+
+- [The Control Plane Kubernetes API](#cp-k8s-api)
+
+- [The Giant Swarm Rest API](#rest-api) (deprecated)
+
+In the following sections we explain the differences and specific benefits and provide some guidance on how to get started.
+
+## The Control Plane Kubernetes API (CP-K8s-API) {#cp-k8s-api}
+
+## What it is
+
+At Giant Swarm, when we say "control plane", we talk about the Kubernetes Cluster that runs all the operational and monitoring workloads which are needed to create and manage the "tenant clusters", which are the clusters you create to run your actual workloads. This is not to be confused with how the Kubernetes project uses the same term, simply meaning the master nodes of a Kubernetes cluster.
+
+The control plane is a Kubernetes cluster. Your tenant clusters and other associated resources are represented in that cluster as custom resources. To access these, you can use the Kubernetes API of the cluster that forms the control plane, or in short, the Control Plane Kubernetes API. For the sake of brevity, we'll abbreviate this as _CP-K8s-API_.
+
+### How to gain access
+
+To access the CP-K8s-API, Giant Swarm configures access to the API via OIDC. Please contact Solution Engineer (SE) to sort out the details.
+
+Currently we normally provide read-only access by default. As we are currently working on a fine-grained way to control permissions to resources, having write access right now means fully unrestricted access and should only be granted to select individuals.
+
+TODO: Explain how setting up write is different from read and what else it requires.
+
+### How to use
+
+We recommend that you become familiar with the API via `kubectl`, navigating your resources via the CP-K8s-API. Besides general Kubernetes know-how this will require only a bit of structural knowledge:
+
+#### How we organize resources in namespaces
+
+This is quickly explained: we create one namespace for each tenant cluster, where the namespace name is equal to the tenant cluster ID. All cluster specific resources reside in the namespace of that tenant cluster.
+
+### Which custom resources we use for what purpose
+
+For this, we provide some resources that should help you:
+
+- The guide [Creating tenant clusters via the Control Plane Kubernetes API](/guides/creating-clusters-via-crs-on-aws/) explains step by step how you can create a cluster and node pools via the CP-K8s-API. Here you learn about all the custom resources a cluster comprises.
+- The [App Platform](/basics/app-platform/) introduction outlines the several custom resources involved when managing app catalogs and apps.
+- Our [Control Plane Kubernetes API Reference](https://docs.giantswarm.io/reference/cp-k8s-api/) provides detailed documentation on all the custom resources we use with the various providers and their versions and schema.
+
+### Feedback is welcome
+
+We are keen to learn from you about your experience with accessing the CP-K8s-API, with navigating the custom resources via the API, with our reference documentation and the user guides we provide. This helps us provide more and better material and improve to make the journey more seamless, more satisfactory for you.
+
+So please, don't hesitate to give your feedback in your Slack channel.
+
+## The Giant Swarm Rest API (deprecated) {#rest-api}
+
+The Rest API is an extra abstraction over the resources that reside in the Control Plane Kubernetes API. It is used by our dedicated user interfaces, the web User Interface and gsctl.
+
+It was originally designed to provide a simpler, easier access to the relevant resources for managing clusters, key pairs, etc. while keeping the internals under the hood. However at Giant Swarm we learnt that there are always more use cases emerging on your side than we could anticipate in our API design. We realized that the best we can do for you to provide full insight into the state and spec of your infrastructure is by opening up the underlying system itself.
+
+With this realization, we made the decision to phase out the development of the Rest API in favor of providing access to the [Control Plane Kubernetes API](#cp-k8s-api) instead.
+
+As of now, there is no termination date yet for the Rest API. As it might provide the much simpler and more accessible starting point, feel free to explore the [API documentation](/api/), knowing that one day you may have to switch to the Control Plane Kubernetes API.


### PR DESCRIPTION
This adds an introductory page about programmatic access at `/basics/api/`.

Main goal is to give the Control Plane API subject visibility in the docs and have a common entry point to related guides and reference.

The page is mainly about the Control Plane Kubernetes API, which we aim to make the _one_ Giant Swarm API. As long as it is still in use, the Rest API is also mentioned as a second alternative.

## For reviewers

- There should be a "Further Reading" section in the bottom. What else can we link to? Or should we simply repeat links from the content?
- The appreviation "CP-K8s-API" is not nice. But writing and reading "Control Plane Kubernetes API" many times I think is also dull. Can we find a better solution while it's not too common yet?
