### PR TITLE
Configure crd-docs-generator via config file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,14 +52,9 @@ build: vendor build-css
 	# Generate the Control Plane K8s API reference documentation.
 	docker run \
 		-v ${PWD}/build/content/reference/cp-k8s-api:/opt/crd-docs-generator/output \
-		quay.io/giantswarm/crd-docs-generator:45a4eebf2dd3340dcce091b3f5d0ebe3dc83cd21 \
-		  --apiextensions-commit-ref v0.3.4 \
-		  --skip-crd chartconfigs.core.giantswarm.io \
-		  --skip-crd clusters.core.giantswarm.io \
-		  --skip-crd draughtsmanconfigs.core.giantswarm.io \
-		  --skip-crd ingressconfigs.core.giantswarm.io \
-		  --skip-crd memcachedconfigs.example.giantswarm.io \
-		  --skip-crd releasecycles.release.giantswarm.io
+		-v ${PWD}:/opt/crd-docs-generator/config \
+		quay.io/giantswarm/crd-docs-generator:0.0.0-cce07b5b225bd1b7ad576a0e1f5ebb773397915c \
+		  --config /opt/crd-docs-generator/config/crd-docs-generator-config.yaml
 
 
 docker-build: build

--- a/crd-docs-generator-config.yaml
+++ b/crd-docs-generator-config.yaml
@@ -1,0 +1,13 @@
+# Configuration file for crd-docs-generator
+source_repository:
+  url: https://github.com/giantswarm/apiextensions
+  organization: giantswarm
+  short_name: apiextensions
+  commit_reference: v0.3.4
+skip_crds:
+  - chartconfigs.core.giantswarm.io
+  - clusters.core.giantswarm.io
+  - draughtsmanconfigs.core.giantswarm.io
+  - ingressconfigs.core.giantswarm.io
+  - memcachedconfigs.example.giantswarm.io
+  - releasecycles.release.giantswarm.io


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/10544

This uses the new crd-docs-generator way of configuring via a YAML file, as provided in https://github.com/giantswarm/crd-docs-generator/pull/13