### PR TITLE
Fix font warning on firefox

### DIFF
--- a/src/layouts/partials/header.html
+++ b/src/layouts/partials/header.html
@@ -25,7 +25,7 @@
     <link rel="stylesheet" type="text/css" href="https://s.giantswarm.io/giantswarmio/0.10.18/1/base.css">
     <link rel="stylesheet" type="text/css" href="https://s.giantswarm.io/highlightjs/9.16.2/1/solarized-dark.min.css">
     <link rel="stylesheet" type="text/css" href="/css/base.css?{{ partial "cachebreaker_css.html" . }}">
-    <script src="https://use.fortawesome.com/b5c7b73e.js"></script>
+    <link rel="stylesheet" type="text/css" href="https://use.fortawesome.com/kits/b5c7b73e/publications/latest/woff2.css">
     <script>
       window.GiantSwarmGoogleAnalyticsAccount = 'UA-52901087-2';
       window.GiantSwarmHubspotAccount = '430224';

--- a/src/layouts/partials/header.html
+++ b/src/layouts/partials/header.html
@@ -25,7 +25,7 @@
     <link rel="stylesheet" type="text/css" href="https://s.giantswarm.io/giantswarmio/0.10.18/1/base.css">
     <link rel="stylesheet" type="text/css" href="https://s.giantswarm.io/highlightjs/9.16.2/1/solarized-dark.min.css">
     <link rel="stylesheet" type="text/css" href="/css/base.css?{{ partial "cachebreaker_css.html" . }}">
-    <link rel="stylesheet" type="text/css" href="https://use.fortawesome.com/kits/b5c7b73e/publications/latest/woff2.css">
+    <link rel="stylesheet" type="text/css" href="https://use.fortawesome.com/kits/b5c7b73e/publications/latest/woff.css">
     <script>
       window.GiantSwarmGoogleAnalyticsAccount = 'UA-52901087-2';
       window.GiantSwarmHubspotAccount = '430224';


### PR DESCRIPTION
Fixes https://github.com/giantswarm/giantswarm/issues/8797

The problem was with the way FortAwesome injected the CSS for icons from the JS file. Using the CSS file directly doesn't show any warning.

The functionality is not affected, as the CSS file will be updated on FortAwesome every time we change the icons.