### PR TITLE
Update coredns docs for the app cr migration.

### DIFF
--- a/src/content/guides/advanced-coredns-configuration/index.md
+++ b/src/content/guides/advanced-coredns-configuration/index.md
@@ -9,27 +9,105 @@ tags: ["tutorial"]
 
 # Advanced CoreDNS Configuration
 
-The [CoreDNS addon](https://github.com/coredns/coredns) running inside your cluster has additional configuration options and features that can be customized.
+Your Giant Swarm installation comes with a default configuration for the [CoreDNS addon](https://github.com/coredns/coredns)
 
-You can customize two of these configuration options on a per cluster basis through a ConfigMap inside your clusters. The ConfigMap is named `coredns-user-values` and is located in the `kube-system` namespace.
+You can override these defaults in a ConfigMap named `coredns-user-values`.
 
-__Note:__ This feature is only available in more recent cluster versions. To check if your cluster version supports customization through the ConfigMap, you can check if the above-mentioned ConfigMap is present.
+## Where is the user values ConfigMap?
+
+Given the cluster you are trying to configure has id: `123ab`
+
+**Release Version 9.0.1 and greater:**
+
+If your cluster is on release version `9.0.1` or greater then you will find the `coredns-user-values` ConfigMap on the Control Plane in the `123ab` namespace:
 
 ```nohighlight
-$ kubectl -n kube-system get cm coredns-user-values
+$ kubectl -n 123ab get cm coredns-user-values --context=control-plane
 NAME                                   DATA      AGE
 coredns-user-values                    0         11m
 ```
 
-On cluster creation the ConfigMap is empty and below-mentioned defaults will be applied to the final CoreDNS deployment. To customize any of the configuration options, you just need to add the respective line(s) in the data field of the user ConfigMap.
+**Release Version 9.0.0 and below:**
 
-__Warning:__ Please do not edit any of the other CoreDNS related resources. Only the user ConfigMap is safe to edit.
+If the cluster has a release version equal to `9.0.0` or lower, then you will find the `coredns-user-values` ConfigMap on the Tenant Cluster itself in the `kube-system` namespace:
 
-## Cache settings
+```nohighlight
+$ kubectl -n kube-system get cm coredns-user-values --context=tenant-cluster
+NAME                                   DATA      AGE
+coredns-user-values         0         11m
+```
+
+-----
+
+Upgrading from `9.0.0` to a higher release will automatically migrate these user values from the Tenant Cluster to the
+Control Plane for you. If you have any automation or existing workflows you should keep this location change in mind.
+
+------
+
+__Warning:__
+
+Please do not edit any other coredns related ConfigMaps.
+
+Only the user values ConfigMap is safe to edit.
+
+------
+
+## How to set configuration options using the user values ConfigMap
+
+### 9.0.1 and greater
+
+On the Control Plane, create or edit a configmap named `coredns-user-values`
+in the Tenant Cluster namespace:
+
+```yaml
+# On the Control Plane, in the abc12 namespace
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: coredns
+    name: coredns-user-values
+    namespace: abc12
+data:
+  values: |
+    configmap:
+      cache: "60"
+
+```
+
+### 9.0.0 and below
+
+On the Tenant Cluster for which you are trying to configure coredns,
+create or edit a configmap named `coredns-user-values` in the `kube-system`
+namespace:
+
+```yaml
+# On the Tenant Cluster, in the kube-system namespace
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: coredns
+    name: coredns-user-values
+    namespace: kube-system
+data:
+  cache: "60"
+```
+
+## Configuration Reference
+
+### Cache settings
 
 By default we set the cache TTL for CoreDNS to 30 seconds. You can customize the cache settings of CoreDNS by setting the value of the cache field in the user ConfigMap like this:
 
 ```yaml
+# 9.0.1 and greater
+data:
+  values: |
+    configmap:
+      cache: "60"
+
+# 9.0.0 and below
 data:
   cache: "60"
 ```
@@ -38,11 +116,19 @@ Above setting increases the TTL to 60 seconds.
 
 The cache plugin also supports much more detailed configuration which is documented in the [upstream documentation](https://coredns.io/plugins/cache/).
 
-## Logs
+### Logs
 
 By default, we set the log level for CoreDNS to `denial` and `error`. You can tune these settings by adding a property `log` in the user ConfigMap like this:
 
 ```yaml
+# 9.0.1 and greater
+data:
+  values: |
+    configmap:
+      log: |
+        all
+
+# 9.0.0 and below
 data:
   log: |
     all
@@ -58,16 +144,35 @@ The default forward entry we set in CoreDNS is
 forward . /etc/resolv.conf
 ```
 
-You can add additional forward entries by adding a each as a line to the forward field of the user ConfigMap. They will be selected in random order.
+You can add additional forward entries by adding each as a line to the forward field of the user values ConfigMap. They will be selected in random order.
 
 You can use a simple line or multiple lines to define the upstreams of the default server block.
 
+**Simple line:**
 ```yaml
+# 9.0.1 and greater
+data:
+  values: |
+    configmap:
+      forward: . 1.1.1.1 /etc/resolv.conf
+
+# 9.0.0 and below
 data:
   forward: . 1.1.1.1 /etc/resolv.conf
 ```
 
+**Multiple lines:**
 ```yaml
+# 9.0.1 and greater
+data:
+  values: |
+    forward: |
+      .
+      1.1.1.1
+      8.8.8.8
+      /etc/resolv.conf
+
+# 9.0.0 and below
 data:
   forward: |
     .
@@ -94,23 +199,51 @@ The forward plugin also supports much more detailed configuration which is docum
 
 __Notes:__ For releases using the CoreDNS chart in versions 1.1.3 and below, the upstreams must not include `.` and `/etc/resolv.conf` as they are rendered by the chart. They can be configured using simple or multiple lines:
 
+**Simple lines:**
 ```yaml
+# 9.0.1 and greater
+data:
+  values: |
+    configmap:
+      forward: 1.1.1.1 8.8.8.8
+
+# 9.0.0 and below
 data:
   forward: 1.1.1.1 8.8.8.8
 ```
 
+**Multiple lines:**
 ```yaml
+# 9.0.1 and greater
 data:
-  forward: |
+  values: |
+    configmap:
+      forward: |
+        1.1.1.1
+        8.8.8.8
+
+# 9.0.0 and below
+data:
+  forward:
     1.1.1.1
     8.8.8.8
 ```
 
-## Advanced configuration
+### Advanced configuration
 
 In case you need to have a finer granularity you can define custom server blocks with all desired configurations. They will be parsed after the catch-all block in the Corefile. As an example, let's define a block for a `example.com` with a custom configuration:
 
 ```yaml
+# 9.0.1 and greater
+data:
+  values: |
+    custom: |
+      example.com:1053 {
+        forward . 9.9.9.9
+        cache 2000
+      }
+
+# 9.0.0 and below
 data:
   custom: |
     example.com:1053 {
@@ -119,7 +252,7 @@ data:
     }
 ```
 
-This custom configuration allows CoreDNS to resolve all `example.com` requests to a different upstream DNS resolver (9.9.9.9) than the generic one. At the same time we use a different cache TTL(2000) setting. 
+This custom configuration allows CoreDNS to resolve all `example.com` requests to a different upstream DNS resolver (9.9.9.9) than the generic one. At the same time we use a different cache TTL(2000) setting.
 
 __Warning:__ By default our clusters come with Pod Security Policies and Network Policies for managed components. This means the CoreDNS container doesn't use a privileged port and listens to `1053` instead. Please make sure you test the final `Corefile` carefully. We do not take responsibility for incorrect custom configuration that could break workload communication.
 

--- a/src/content/guides/advanced-coredns-configuration/index.md
+++ b/src/content/guides/advanced-coredns-configuration/index.md
@@ -1,7 +1,7 @@
 ---
 title: Advanced CoreDNS Configuration
 description: Here we describe how you can customize the configuration of the managed CoreDNS service in your clusters
-date: 2020-04-20
+date: 2020-05-13
 type: page
 weight: 50
 tags: ["tutorial"]


### PR DESCRIPTION
This updates coredns docs to explain where the user values configmap is (and the format) depending on the release version.

Would appreciate a fact check from anyone that knows the specifics. ping @omegas27  @rossf7 @pipo02mix

Towards: giantswarm/giantswarm#10211