### PR TITLE
Improve aside highlighting logic

### DIFF
--- a/src/static/js/aside.js
+++ b/src/static/js/aside.js
@@ -33,7 +33,9 @@
       if (!inThrottle) {
         func.apply(context, args);
         inThrottle = true;
-        setTimeout(function(){ inThrottle = false }, limit);
+        setTimeout(function() {
+          inThrottle = false;
+        }, limit);
       }
     };
   };
@@ -67,7 +69,7 @@
     this.registerScrollObserver();
 
     if (!this.activeLink) {
-      this.activateLinks(this.getInitiallyActiveElement());
+      this.activateLinks([this.getInitiallyActiveElement()]);
     }
   };
 
@@ -80,6 +82,10 @@
     }
 
     activeLink = this.getLinkWithHref(hash);
+    if (!activeLink) {
+      activeLink = this.getClosestRegisteredParentLink(hash);
+    }
+
     if (!activeLink) {
       return this.elements.links[0];
     }
@@ -101,17 +107,22 @@
 
   GSAside.prototype.handleHashChange = function() {
     var href = location.hash;
+    if (href === "") return;
+
     var linkWithHref = this.getLinkWithHref(href);
 
-    if (linkWithHref === null) return;
+    if (!linkWithHref) {
+      linkWithHref = this.getClosestRegisteredParentLink(href);
+      if (!linkWithHref) return;
+    }
 
     this.activateLinks([linkWithHref]);
   };
 
   GSAside.prototype.getLinkWithHref = function(href) {
     var newHref = href;
-    if (newHref.charAt(0) === '#') {
-      newHref  = newHref.slice(1);
+    if (newHref.charAt(0) === "#") {
+      newHref = newHref.slice(1);
     }
 
     for (var i = 0; i < this.elements.links.length; i++) {
@@ -122,6 +133,24 @@
     }
 
     return null;
+  };
+
+  GSAside.prototype.getClosestRegisteredParentLink = function(href) {
+    var foundElement = null;
+
+    var element = document.querySelector("[href='" + href + "']");
+    var validLinkSelector = this.generateLinksSelector().split(', ');
+
+    if (validLinkSelector.length === 0) return null;
+
+    var selector = validLinkSelector[validLinkSelector.length - 1].split(' > a')[0];
+    foundElement = element.closest(selector);
+    if (!foundElement) return null;
+
+    foundElement = foundElement.querySelector('a');
+    if (foundElement === element) return null;
+
+    return foundElement;
   };
 
   GSAside.prototype.generateLinksSelector = function() {

--- a/src/static/js/aside.js
+++ b/src/static/js/aside.js
@@ -33,7 +33,7 @@
       if (!inThrottle) {
         func.apply(context, args);
         inThrottle = true;
-        setTimeout(() => inThrottle = false, limit);
+        setTimeout(function(){ inThrottle = false }, limit);
       }
     };
   };

--- a/src/static/js/aside.js
+++ b/src/static/js/aside.js
@@ -85,7 +85,7 @@
     }
 
     return activeLink;
-  }
+  };
 
   GSAside.prototype.updateAsideHeight = function() {
     var targetHeight = this.elements.content.scrollHeight;
@@ -106,7 +106,7 @@
     if (linkWithHref === null) return;
 
     this.activateLinks([linkWithHref]);
-  }
+  };
 
   GSAside.prototype.getLinkWithHref = function(href) {
     var newHref = href;
@@ -122,7 +122,7 @@
     }
 
     return null;
-  }
+  };
 
   GSAside.prototype.generateLinksSelector = function() {
     var selector = "";

--- a/src/static/js/aside.js
+++ b/src/static/js/aside.js
@@ -157,8 +157,8 @@
     this.elements.headers = new Array(this.elements.links.length);
 
     for (i = 0; i < this.elements.links.length; i++) {
-      var selector = this.elements.links[i].href.split("#")[1];
-      this.elements.headers[i] = document.getElementById(selector);
+      var elemSelector = this.elements.links[i].href.split("#")[1];
+      this.elements.headers[i] = document.getElementById(elemSelector);
     }
   };
 

--- a/src/static/js/aside.js
+++ b/src/static/js/aside.js
@@ -119,7 +119,7 @@
   GSAside.prototype.registerScrollObserver = function() {
     var options = {
       rootMargin: '0px',
-      threshold: 1.0,
+      threshold: 0,
     };
 
     this.observer = new IntersectionObserver(
@@ -135,6 +135,8 @@
   };
 
   GSAside.prototype.handleScrollObserver = function(entries) {
+    var visibleEntries = [];
+
     for (var i = 0; i < entries.length; i++) {
       var entry = entries[i];
       var href = '#' + entry.target.getAttribute('id');
@@ -150,14 +152,19 @@
       }
 
       if (entry.isIntersecting) {
-        this.activateLink(correspondingLink);
-
-        break;
+        visibleEntries.push(correspondingLink);
       }
     }
+
+    this.activateLinks(visibleEntries);
   };
 
-  GSAside.prototype.activateLink = function(link) {
+  GSAside.prototype.activateLinks = function(links) {
+    var selectedLink = null;
+    if (links.length > 0) {
+      selectedLink = links[links.length - 1];
+    }
+
     for (var j = 0; j < this.elements.links.length; j++) {
       var currentLink = this.elements.links[j];
 
@@ -166,12 +173,12 @@
       currentLink.classList.remove(this.activeClassName);
     }
 
-    if (link) {
+    if (selectedLink) {
       if (this.activeLink) {
         this.activeLink.classList.remove(this.activeClassName);
       }
-      link.classList.add(this.activeClassName);
-      this.activeLink = link;
+      selectedLink.classList.add(this.activeClassName);
+      this.activeLink = selectedLink;
     }
   };
 

--- a/src/static/js/aside.js
+++ b/src/static/js/aside.js
@@ -123,6 +123,8 @@
 
       if (entry.isIntersecting) {
         this.activateLink(correspondingLink);
+
+        break;
       }
     }
   };

--- a/src/static/js/aside.js
+++ b/src/static/js/aside.js
@@ -118,8 +118,8 @@
 
   GSAside.prototype.registerScrollObserver = function() {
     var options = {
-      rootMargin: '0px',
-      threshold: 0,
+      rootMargin: '0px 0px -90%',
+      threshold: 0.5,
     };
 
     this.observer = new IntersectionObserver(
@@ -184,4 +184,3 @@
 
   window.GSAside = GSAside;
 })();
-

--- a/src/static/js/aside.js
+++ b/src/static/js/aside.js
@@ -1,12 +1,13 @@
 (function() {
   function GSAside(asideSelector, contentSelector, topOffset) {
     if (!asideSelector || !contentSelector) {
-      throw new Error("Both selectors cannot be null.");
+      throw new Error('Both selectors cannot be null.');
     }
 
     this.selectors = {
       aside: asideSelector,
       content: contentSelector,
+      mainList: 'nav > ul',
     };
 
     this.elements = {
@@ -20,7 +21,8 @@
     this.topOffset = topOffset || 0;
     this.observer = null;
     this.activeLink = null;
-    this.activeClassName = "active";
+    this.activeClassName = 'active';
+    this.numLevelsToTrack = 2;
   }
 
   GSAside.prototype.throttle = function(func, limit) {
@@ -40,23 +42,23 @@
     this.elements.aside = document.querySelector(this.selectors.aside);
     if (!this.elements.aside) {
       throw new Error(
-          "The aside with selector '" + this.selectors.aside +
-          "' could not be found!");
+          'The aside with selector \'' + this.selectors.aside +
+          '\' could not be found!');
     }
 
     var asideChildren = this.elements.aside.children;
     if (asideChildren.length < 1) {
-      throw new Error("The provided aside element has no children.");
+      throw new Error('The provided aside element has no children.');
     }
     this.elements.asideChild = asideChildren[0];
-    this.elements.asideChild.style.position = "sticky";
-    this.elements.asideChild.style.top = this.topOffset + "px";
+    this.elements.asideChild.style.position = 'sticky';
+    this.elements.asideChild.style.top = this.topOffset + 'px';
 
     this.elements.content = document.querySelector(this.selectors.content);
     if (!this.elements.content) {
       throw new Error(
-          "The content section with selector '" + this.selectors.content +
-          "' could not be found!");
+          'The content section with selector \'' + this.selectors.content +
+          '\' could not be found!');
     }
 
     this.updateAsideHeight();
@@ -67,30 +69,56 @@
 
   GSAside.prototype.updateAsideHeight = function() {
     var targetHeight = this.elements.content.scrollHeight;
-    this.elements.aside.style.height = targetHeight + "px";
+    this.elements.aside.style.height = targetHeight + 'px';
   };
 
   GSAside.prototype.registerEventListeners = function() {
     var updateAsideHeight = this.throttle(this.updateAsideHeight.bind(this),
         150);
-    window.addEventListener("resize", updateAsideHeight);
+    window.addEventListener('resize', updateAsideHeight);
+  };
+
+  GSAside.prototype.generateLinksSelector = function() {
+    var selector = '';
+    for (i = 0; i < this.numLevelsToTrack; i++) {
+      var currentSelector = this.selectors.mainList;
+
+      for (var j = 0; j < i; j++) {
+        currentSelector += ' ';
+        currentSelector += '> li > ul';
+      }
+
+      currentSelector += ' ';
+      currentSelector += '> li > a';
+
+      if (selector.length > 0) {
+        selector += ', ';
+      }
+
+      selector += currentSelector;
+    }
+
+    return selector;
   };
 
   GSAside.prototype.gatherLinksAndHeaders = function() {
+    var i = 0;
+    var selector = this.generateLinksSelector();
+
     this.elements.links = [].slice.call(
-        this.elements.asideChild.querySelectorAll("a"), 0);
+        this.elements.asideChild.querySelectorAll(selector), 0);
 
     this.elements.headers = new Array(this.elements.links.length);
 
-    for (var i = 0; i < this.elements.links.length; i++) {
-      var selector = this.elements.links[i].href.split("#")[1];
+    for (i = 0; i < this.elements.links.length; i++) {
+      var selector = this.elements.links[i].href.split('#')[1];
       this.elements.headers[i] = document.getElementById(selector);
     }
   };
 
   GSAside.prototype.registerScrollObserver = function() {
     var options = {
-      rootMargin: "0px",
+      rootMargin: '0px',
       threshold: 1.0,
     };
 
@@ -109,7 +137,7 @@
   GSAside.prototype.handleScrollObserver = function(entries) {
     for (var i = 0; i < entries.length; i++) {
       var entry = entries[i];
-      var href = "#" + entry.target.getAttribute("id");
+      var href = '#' + entry.target.getAttribute('id');
 
       var correspondingLink = null;
       for (var j = 0; j < this.elements.links.length; j++) {
@@ -145,7 +173,7 @@
       link.classList.add(this.activeClassName);
       this.activeLink = link;
     }
-  }
+  };
 
   window.GSAside = GSAside;
 })();


### PR DESCRIPTION
* Previously the aside was trying to highlight links that were not displayed (nested under 2+ levels), now there are only 2 levels supported
* If clicking on a link, that link will automatically become selected (if it is a deeply nested child, that is not registered, then the closest registered parent will be selected)
* If entering the page with a hash in the URL, that section will become selected (if it is a deeply nested child, that is not registered, then the closest registered parent will be selected)
* Only headers that are in the first 10% vertical percent of the screen will be considered active