### PR TITLE
Replace 'gsctl version' command with 'gsctl --version'

### DIFF
--- a/src/content/reference/gsctl/_index.md
+++ b/src/content/reference/gsctl/_index.md
@@ -12,7 +12,7 @@ gsctl is the command line utility to manage your Giant Swarm clusters.
 
 ## Commands {#commands}
 
-Follow the links below for detailed documentation, where available. You can also always use `gsctl <command> --help`.
+Follow the links below for a detailed documentation, where available. You can also always use `gsctl <command> --help`.
 
 | Command                               | Description
 |---------------------------------------|------------
@@ -43,7 +43,8 @@ Follow the links below for detailed documentation, where available. You can also
 | `update nodepool`                     | [Modify (rename, scale) a node pool](update-nodepool/)
 | `update organization set-credentials` | [Set provider credentials for an organization](update-org-set-credentials/)
 | `upgrade cluster`                     | [Upgrade a cluster](upgrade-cluster/)
-| `version`                             | Print version number
+
+For finding out which version of `gsctl` you currently have installed, and other useful information about the build, use the `gsctl --version` command.
 
 ## Installing and updating {#install}
 
@@ -104,7 +105,7 @@ brew install gsctl</code></pre>
 
 ## Configuration {#configuration}
 
-`gsctl` keeps it's own settings under `$HOME/.config/gsctl/`. There is a [configuration file](configuration-file) called `config.yaml`. Key pairs are stored in the `certs` subdirectory.
+`gsctl` keeps its own settings under `$HOME/.config/gsctl/`. There is a [configuration file](configuration-file) called `config.yaml`. Key pairs are stored in the `certs` subdirectory.
 
 The following environment variables can be used to affect some behavior:
 
@@ -112,7 +113,7 @@ The following environment variables can be used to affect some behavior:
 - `GSCTL_CAFILE`: If your Giant Swarm API endpoint uses a certificate signed by an authority not known to your operating system, this variable can be set to the path of a custom CA (certification authority) bundle. A CA bundle is a text file containing one or more CA certificates in PEM format.
 - `GSCTL_CAPATH`: Similar to `GSCTL_CAFILE`, but `GSCTL_CAPATH` is expected to point to a directory containing one or more PEM files.
 - `GSCTL_DISABLE_COLORS`: When this variable is set to any non-empty string, all terminal output will be monochrome.
-- `GSCTL_DISABLE_CMDLINE_TRACKING`: When this variable is set to any non-empty string, command lines won't be submitted to the API. Otherwise command lines are submitted to learn about the tool's usage and find ways to improve.
+- `GSCTL_DISABLE_CMDLINE_TRACKING`: When this variable is set to any non-empty string, command lines won't be submitted to the API. Otherwise, command lines are submitted to learn about the tool's usage and find ways to improve.
 
 In addition, [global command-line options](global-options/) are available.
 
@@ -126,4 +127,4 @@ You'll find info on changes in the [release description](https://github.com/gian
 
 ## Feedback {#feedback}
 
-We welcome your feedback on `gsctl`. If you feel like sharing openly, use the GitHub repository and create an [issue](https://github.com/giantswarm/gsctl/issues), so other users can participate. Otherwise please use the common Giant Swarm support channels.
+We welcome your feedback on `gsctl`. If you feel like sharing openly, use the GitHub repository and create an [issue](https://github.com/giantswarm/gsctl/issues), so other users can participate. Otherwise, please use the common Giant Swarm support channels.

--- a/src/content/reference/gsctl/_index.md
+++ b/src/content/reference/gsctl/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "gsctl Reference"
 description: "Documentation on gsctl, the Giant Swarm command line utility to create and delete clusters, create key pairs and more."
-date: "2020-04-15"
+date: "2020-05-14"
 layout: "subsection"
 weight: 10
 ---

--- a/src/content/reference/gsctl/configuration-file.md
+++ b/src/content/reference/gsctl/configuration-file.md
@@ -1,17 +1,17 @@
 ---
 title: "gsctl Reference: Configuration file"
 description: "Documentation of the configuration file format of gsctl"
-date: "2018-01-26"
+date: "2020-05-14"
 type: page
 weight: 1000
 ---
 
 # Configuration file
 
-gsctl by default stores it's configuration in a YAML file located at
+gsctl by default stores its configuration in a YAML file located at
 `$HOME/.config/gsctl/config.yaml`.
 
-**Warning:** gsctl frequently overwrites is's configuration file. If you
+**Warning:** gsctl frequently overwrites its configuration file. If you
 manually edit the file, some edits unknown to gsctl, like comments for example,
 will get lost.
 
@@ -47,5 +47,5 @@ updated: 2018-01-26T09:17:24+01:00
   - `token`: Authentication token used with this endpoint.
 - `selected_endpoint`: The currently selected endpoint URL. Can be empty.
 - `last_version_check`: Date and time gsctl has last checked for a newer
-  gsctl version (when calling `gsctl version`).
+  gsctl version (when calling `gsctl --version`).
 - `updated`: Date and time when the configuration file has been modified.


### PR DESCRIPTION
Related to https://github.com/giantswarm/gsctl/pull/550

`gsctl version` is deprecated (although it still works) and `gsctl --version` is the new cool kid in town