### PR TITLE
Update some docs URLs

### DIFF
--- a/src/content/basics/kubernetes-resources/index.md
+++ b/src/content/basics/kubernetes-resources/index.md
@@ -1,7 +1,7 @@
 ---
 title: Kubernetes Resources
 description: Pointers to the best resources about Kubernetes to get you up to speed with Kubernetes fast
-date: 2020-02-03
+date: 2020-05-20
 weight: 140
 type: page
 categories: ["basics"]
@@ -86,7 +86,7 @@ There are some useful tools and content out there that help you with get to know
 
 - The [Kubernetes Blog](https://kubernetes.io/blog/) is a good resource for reading up on new features, examples, and user stories around Kubernetes.
 - [Kompose](https://github.com/kubernetes-incubator/kompose) is a tool to move from `docker-compose` to Kubernetes.
-- [Helm](https://github.com/kubernetes/helm/blob/master/docs/install.md) is a package manager for Kubernetes that helps you deploy common applications to your cluster.
+- [Helm](https://helm.sh/) is a package manager for Kubernetes that helps you deploy common applications to your cluster.
 
 ## Useful blog posts
 

--- a/src/content/guides/accessing-services-from-the-outside/index.md
+++ b/src/content/guides/accessing-services-from-the-outside/index.md
@@ -53,7 +53,7 @@ To make the rest of the tutorial match your situation, please set your Ingress B
 
 ### Setting up Ingress {#setting-up-ingress}
 
-Your Giant Swarm cluster typically comes with an Ingress Controller based on [NGINX](https://github.com/kubernetes/ingress/blob/master/controllers/nginx/), which we run for you in your clusters. 
+Your Giant Swarm cluster typically comes with an Ingress Controller based on [NGINX](https://nginx.org/), which we run for you in your clusters.
 
 **Note:** If you are running on an AWS installation using release > 10.0.0, you will need to first install an Ingress Controller on your cluster.
 

--- a/src/content/guides/advanced-ingress-configuration/index.md
+++ b/src/content/guides/advanced-ingress-configuration/index.md
@@ -1,7 +1,7 @@
 ---
 title: Advanced Ingress Configuration
 description: Here we describe how you can customize and enable specific features for the NGINX-based Ingress
-date: 2020-05-13
+date: 2020-05-20
 type: page
 weight: 50
 tags:
@@ -146,7 +146,7 @@ spec:
           servicePort: <service-port>
 ```
 
-__Warning:__ When enabling `TLS` with the NGINX Ingress Controller, some more configuration settings become important. Notably [`HSTS`](https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Strict_Transport_Security_Cheat_Sheet.html) will be enabled [by default](https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/configmap.md#configuration-options) with a duration of six month for your specified domain. Once a browser retrieved these `HSTS` instructions it will refuse to read any unencrypted resource from that domain and un-setting `HSTS` on your server will not have any affect on that browser for half a year. So you might want to disable this at first to avoid [unwanted surprises](https://github.com/kubernetes/ingress-nginx/issues/549#issuecomment-291894246). Please contact our support team to find out details on how to disable HSTS in your cluster.
+__Warning:__ When enabling `TLS` with the NGINX Ingress Controller, some more configuration settings become important. Notably [`HSTS`](https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Strict_Transport_Security_Cheat_Sheet.html) will be enabled [by default](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#hsts) with a duration of six month for your specified domain. Once a browser retrieved these `HSTS` instructions it will refuse to read any unencrypted resource from that domain and un-setting `HSTS` on your server will not have any affect on that browser for half a year. So you might want to disable this at first to avoid [unwanted surprises](https://github.com/kubernetes/ingress-nginx/issues/549#issuecomment-291894246). Please contact our support team to find out details on how to disable HSTS in your cluster.
 
 __Tip:__ If you want to use [Let’s Encrypt](https://letsencrypt.org/) certificates with your domains you can automate their creation and renewal with the help of [cert-manager](https://cert-manager.io/docs/). After configuring cert-manager there is only an annotation with your Ingresses needed and your web page will be secured by a valid `TLS` certificate.
 

--- a/src/content/guides/securing-with-rbac-and-psp/index.md
+++ b/src/content/guides/securing-with-rbac-and-psp/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Securing your Cluster with RBAC and PSP"
 description: "Introduction to using RBAC and PSP to secure your cluster and manage access control."
-date: "2020-04-16"
+date: 2020-05-20
 type: page
 weight: 30
 tags: ["tutorial"]
@@ -253,7 +253,7 @@ $ kubectl auth can-i use podsecuritypolicies/privileged \
 yes
 ```
 
-You can also verfiy access for a whole group:
+You can also verify access for a whole group:
 
 ```nohighlight
 $ kubectl auth can-i get pods --as-group=system:masters
@@ -261,6 +261,8 @@ yes
 ```
 
 ## Pod Security Policies
+
+<!-- TODO: review/update this section, as the links to PSP policies don't work any more. Probably the info also needs updating. -->
 
 A `PodSecurityPolicy` object defines a set of conditions that a pod must run with in order to be accepted into the system. It governs the ability to make requests on a Pod that affect the `SecurityContext` that will be applied to a Pod and container.
 
@@ -274,7 +276,7 @@ If you need to run privileged or root containers in a Pod, you need to either us
 
 Note that your user's PSP only come into play when you directly create Pods. If you are using Deployments, Daemonsets, or other means to spawn Pods in your cluster, you need to make sure these have the right PSP by using [Service Accounts](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/).
 
-You need to either bind the already existing `privileged-psp-user` role, or create a PSP that caters specifically to your desired Security Context. Keep in mind that after creating a PSP you also need to have a role that is allowed to `use` that specifc PSP and bind that to the Service Account you're using. For an example see [Running Applications that need Privileged Access](#running-applications-that-need-privileged-access).
+You need to either bind the already existing `privileged-psp-user` role, or create a PSP that caters specifically to your desired Security Context. Keep in mind that after creating a PSP you also need to have a role that is allowed to `use` that specific PSP and bind that to the Service Account you're using. For an example see [Running Applications that need Privileged Access](#running-applications-that-need-privileged-access).
 
 For details on PSPs we defer to the [official PSP documentation](https://kubernetes.io/docs/concepts/policy/pod-security-policy/).
 


### PR DESCRIPTION
Fix some links that make the linkchecker complain.

The `pull requests` link problem is new to me and resides in the template. Since the source of these pages is in external repositories, the file is not found in the docs repo. Not sure why this pops up now. Needs further investigation.