### PR TITLE
Adjust list item line-height and margin-bottom

### DIFF
--- a/src/static/css/base.css
+++ b/src/static/css/base.css
@@ -411,6 +411,10 @@ h5 {
 p {
   line-height: 1.65em; }
 
+li {
+  line-height: 1.65em;
+  margin-bottom: 11px; }
+
 pre {
   background-color: #002b36;
   padding: 4;

--- a/src/static/css/base.sass
+++ b/src/static/css/base.sass
@@ -35,6 +35,10 @@ h5
 p
   line-height: 1.65em
 
+li
+  line-height: 1.65em
+  margin-bottom: 11px
+
 pre
   background-color: #002b36
   padding: 4


### PR DESCRIPTION
This adjust the `<li>` appearance to a normal paragraph.

## Before

![image](https://user-images.githubusercontent.com/273727/84889426-21b1b280-b099-11ea-9b93-fe999d7ad77b.png)

## After

![image](https://user-images.githubusercontent.com/273727/84890172-570ad000-b09a-11ea-99de-007814fa20ca.png)
