### PR TITLE
Add gsctl 'GSCTL_AUTH_TOKEN' env variable documentation

### DIFF
--- a/src/content/basics/kubernetes-on-giant-swarm/index.md
+++ b/src/content/basics/kubernetes-on-giant-swarm/index.md
@@ -27,8 +27,6 @@ Your clusters comes out-of-the-box as follows:
 - Monitoring
 - Storage
 
-
-
 ## What is not included
 
 There are some things not included in the cluster as managed by us:

--- a/src/content/reference/gsctl/_index.md
+++ b/src/content/reference/gsctl/_index.md
@@ -112,6 +112,7 @@ brew install gsctl</code></pre>
 The following environment variables can be used to affect some behavior:
 
 - `GSCTL_ENDPOINT`: This can be used to specify an API endpoint URL.
+- `GSCTL_AUTH_TOKEN`: This can be used to specify an authentication token.
 - `GSCTL_CAFILE`: If your Giant Swarm API endpoint uses a certificate signed by an authority not known to your operating system, this variable can be set to the path of a custom CA (certification authority) bundle. A CA bundle is a text file containing one or more CA certificates in PEM format.
 - `GSCTL_CAPATH`: Similar to `GSCTL_CAFILE`, but `GSCTL_CAPATH` is expected to point to a directory containing one or more PEM files.
 - `GSCTL_DISABLE_COLORS`: When this variable is set to any non-empty string, all terminal output will be monochrome.


### PR DESCRIPTION
This was added some time ago, but was missing from the docs.