### PR TITLE
Update guide on cluster creation via CP API for HA masters

### DIFF
--- a/src/content/basics/ha-masters/index.md
+++ b/src/content/basics/ha-masters/index.md
@@ -84,25 +84,25 @@ Single master clusters using release v{{% first_aws_ha_masters_version %}} or
 above on AWS can be converted to master node high availability in the user
 interfaces and via the APIs.
 
-## Via the web UI {#web-ui}
+### Via the web UI {#web-ui}
 
 The web UI presents information on the master node in the cluster details page.
 Next to these details you find a button _Switch to high availability…_, unless
 the cluster is currently undergoing an upgrade. Click this button and follow
 the instructions in the web UI.
 
-## Via the CLI (`gsctl`) {#gsctl}
+### Via the CLI (`gsctl`) {#gsctl}
 
 The `gsctl` CLI as of v0.23.1 provides the
 [gsctl update cluster](/reference/gsctl/update-cluster/) to change cluster details.
 Check the reference for the `--master-ha` flag.
 
-## Via the Rest API {#rest-api}
+### Via the Rest API {#rest-api}
 
 Check the [v5 cluster modification API reference](/api/#operation/modifyClusterV5)
 to find out how to convert a cluster programmatically using the Rest API.
 
-## Via the Control Plane K8s API {#cp-k8s-api}
+### Via the Control Plane K8s API {#cp-k8s-api}
 
 In order to convert a single master cluster to high availability, the cluster's
 [`G8sControlPlane`](/reference/cp-k8s-api/g8scontrolplanes.infrastructure.giantswarm.io/)

--- a/src/content/guides/creating-clusters-via-crs-on-aws/index.md
+++ b/src/content/guides/creating-clusters-via-crs-on-aws/index.md
@@ -6,33 +6,38 @@ type: page
 weight: 100
 tags: ["tutorial"]
 ---
+
 # Creating tenant clusters via the Control Plane Kubernetes API
 
-This guide will show you how to create tenant clusters by creating and applying CRs directly to the control plane.
-Previously you might have used our REST API to create clusters, however, Giant Swarm is replacing its own REST API for cluster management with the [Control Plane](https://docs.giantswarm.io/basics/aws-architecture/#giant-swarm-control-plane) Kubernetes API based on the upstream [Cluster API](https://cluster-api.sigs.k8s.io/).
-Following this strategy, the Giant Swarm API is going to be deprecated in the near feature. You can find the related roadmap issue [here](https://github.com/giantswarm/roadmap/issues/90).
+This guide will show you how to create tenant clusters by creating and applying custom resources (CRs) directly to the control plane.
+
+Previously you might have used our Rest API to create clusters, however, Giant Swarm is replacing its own REST API for cluster management with the [Control Plane Kubernetes API](/api/#cp-k8s-api)  based on the upstream [Cluster API](https://cluster-api.sigs.k8s.io/).
+The Cluster API is a Kubernetes project to bring declarative, Kubernetes-style APIs to cluster creation, configuration, and management. It provides optional, additive functionality on top of core Kubernetes.
+
+Following this strategy, the Giant Swarm Rest API is going to be deprecated at some point. Subscribe to our related [roadmap issue](https://github.com/giantswarm/roadmap/issues/90) to stay informed about the deprecation.
 
 ## How does cluster creation work now
 
 Starting from version {{% first_aws_nodepools_version %}} on AWS, Giant Swarm introduced a feature to create multiple [node pools](https://docs.giantswarm.io/basics/nodepools/) on AWS.
 Alongside node pools support, a new API version for cluster management was released.
 
-All the tenant clusters, created with release version 10.x.x+, are managed as [Cluster API](https://github.com/kubernetes-sigs/cluster-api) [custom resources](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/) in the Control Plane.
-The Cluster API is a Kubernetes project to bring declarative, Kubernetes-style APIs to cluster creation, configuration, and management. It provides optional, additive functionality on top of core Kubernetes.
+All the tenant clusters, created with release version {{% first_aws_nodepools_version %}} and newer, are managed as [custom resources](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/) in the Control Plane.
 
-At a high-level, the Cluster API is used to manage two types of CRs:
+At a high-level, the Control Plane API is used to manage the following CRs:
 
-- [Cluster](/reference/cp-k8s-api/clusters.cluster.x-k8s.io/) - represents a Kubernetes control plane.
+- [Cluster](/reference/cp-k8s-api/clusters.cluster.x-k8s.io/) - represents a Kubernetes cluster excluding worker nodes.
+- [G8sControlPlane](/reference/cp-k8s-api/g8scontrolplanes.infrastructure.giantswarm.io/) - hold configuration about the master node(s) of a cluster.
 - [MachineDeployment](/reference/cp-k8s-api/machinedeployments.cluster.x-k8s.io/) - represents a node pool.
 
 The CRs above then reference provider specific implementations. In our case, for clusters on AWS, they are:
 
-- [AWSCluster](/reference/cp-k8s-api/awsclusters.infrastructure.giantswarm.io/) - represents a tenant cluster's Kubernetes control plane.
-- [AWSMachineDeployment](/reference/cp-k8s-api/awsmachinedeployments.infrastructure.giantswarm.io/) - represents tenant cluster node pools.
+- [AWSCluster](/reference/cp-k8s-api/awsclusters.infrastructure.giantswarm.io/) - represents a tenant cluster.
+- [AWSControlPlane](/reference/cp-k8s-api/awscontrolplanes.infrastructure.giantswarm.io/) - configures the AWS-specific details of the worker node(s).
+- [AWSMachineDeployment](/reference/cp-k8s-api/awsmachinedeployments.infrastructure.giantswarm.io/) - configures the AWS-specific details of worker nodes in a node pool.
 
-## Cluster CRs
+## Example CRs
 
-*Cluster* CR object example:
+### `Cluster`
 
 ```yaml
 apiVersion: cluster.x-k8s.io/v1alpha2
@@ -40,10 +45,10 @@ kind: Cluster
 metadata:
   generation: 1
   labels:
-    cluster-operator.giantswarm.io/version: 2.1.1
+    cluster-operator.giantswarm.io/version: 2.3.0
     giantswarm.io/cluster: nzr5z
-    giantswarm.io/organization: giantswarm
-    release.giantswarm.io/version: 11.0.1
+    giantswarm.io/organization: acme
+    release.giantswarm.io/version: 11.4.0
   name: nzr5z
   namespace: default
 spec:
@@ -54,39 +59,95 @@ spec:
     namespace: default
 ```
 
-*AWSCluster* CR object example:
+### `AWSCluster`
 
 ```yaml
 apiVersion: infrastructure.giantswarm.io/v1alpha2
-kind: AWSMachineDeployment
+kind: AWSCluster
 metadata:
+  generation: 1
   labels:
-    aws-operator.giantswarm.io/version: 8.1.1
+    aws-operator.giantswarm.io/version: 8.7.0
     giantswarm.io/cluster: nzr5z
-    giantswarm.io/machine-deployment: pv7ps
-    giantswarm.io/organization: giantswarm
-    release.giantswarm.io/version: 11.0.1
-  name: pv7ps
+    giantswarm.io/organization: acme
+    release.giantswarm.io/version: 11.4.0
+  name: nzr5z
   namespace: default
 spec:
-  nodePool:
-    description: np1
-    machine:
-      dockerVolumeSizeGB: 100
-      kubeletVolumeSizeGB: 100
-    scaling:
-      max: 10
-      min: 3
+  cluster:
+    description: Demo cluster
+    dns:
+      domain: gorilla.eu-central-1.aws.gigantic.io
+    oidc:
+      claims: {}
   provider:
-    availabilityZones:
-    - eu-central-1a
-    worker:
-      instanceType: m4.xlarge
+    credentialSecret:
+      name: credential-default
+      namespace: giantswarm
+    master:
+      availabilityZone: ""
+      instanceType: ""
+    pods:
+      cidrBlock: 10.7.0.0/16
+    region: eu-central-1
+status:
+  cluster:
+    id: nzr5z
+  provider:
+    network:
+      cidr: 10.6.0.0/24
 ```
 
-## MachineDeployment CRs
+### `G8sControlPlane`
 
-*MachineDeployment* CR object example:
+```yaml
+apiVersion: infrastructure.giantswarm.io/v1alpha2
+kind: G8sControlPlane
+metadata:
+  generation: 2
+  labels:
+    cluster-operator.giantswarm.io/version: 2.3.0
+    giantswarm.io/cluster: nzr5z
+    giantswarm.io/control-plane: 2m0kh
+    giantswarm.io/organization: acme
+    release.giantswarm.io/version: 11.4.0
+  name: 2m0kh
+  namespace: default
+spec:
+  infrastructureRef:
+    apiVersion: infrastructure.giantswarm.io/v1alpha2
+    kind: AWSControlPlane
+    name: 2m0kh
+    namespace: default
+    resourceVersion: "100323111"
+    uid: 370a5c2d-d0d4-4ffd-825f-ec28f9d2957c
+  replicas: 3
+```
+
+### `AWSControlPlane`
+
+```yaml
+apiVersion: infrastructure.giantswarm.io/v1alpha2
+kind: AWSControlPlane
+metadata:
+  generation: 1
+  labels:
+    aws-operator.giantswarm.io/version: 8.7.0
+    giantswarm.io/cluster: nzr5z
+    giantswarm.io/control-plane: 2m0kh
+    giantswarm.io/organization: giantswarm-production
+    release.giantswarm.io/version: 11.4.0
+  name: 2m0kh
+  namespace: default
+spec:
+  availabilityZones:
+  - eu-central-1a
+  - eu-central-1b
+  - eu-central-1c
+  instanceType: m5.xlarge
+```
+
+### `MachineDeployment`
 
 ```yaml
 apiVersion: cluster.x-k8s.io/v1alpha2
@@ -96,8 +157,8 @@ metadata:
     cluster-operator.giantswarm.io/version: 2.1.1
     giantswarm.io/cluster: nzr5z
     giantswarm.io/machine-deployment: pv7ps
-    giantswarm.io/organization: giantswarm
-    release.giantswarm.io/version: 11.0.1
+    giantswarm.io/organization: acme
+    release.giantswarm.io/version: 11.4.0
   name: pv7ps
   namespace: default
 spec:
@@ -114,7 +175,7 @@ spec:
       metadata: {}
 ```
 
-*AWSMachineDeployment* CR object example:
+### `AWSMachineDeployment`
 
 ```yaml
 apiVersion: infrastructure.giantswarm.io/v1alpha2
@@ -147,15 +208,17 @@ spec:
 ## How to create a cluster using Cluster API
 
 All the CRs, mentioned above, have strict spec and important requirements to be considered valid.
-There is no cluster or node pool CR validation available in the Control Plane for now.
+There is very limited CR validation available in the Control Plane for now.
 Therefore, if you create a CR with wrong field values, that can result in a broken tenant cluster.
-That's why we've developed a simple [kubectl gs plugin](https://github.com/giantswarm/kubectl-gs), which helps to template valid CRs.
+That's why we've developed a simple [CLI utility](https://github.com/giantswarm/kubectl-gs), which helps to template valid CRs.
 
-Plugin supports rendering CRs:
+The utility supports rendering CRs:
 
-- Tenant control-plane (AWS only):
+- Tenant clusters (AWS only):
   - `Cluster` (API version `cluster.x-k8s.io/v1alpha2`)
   - `AWSCluster` (API version `infrastructure.giantswarm.io/v1alpha2`)
+  - `G8sControlPlane` (API version `infrastructure.giantswarm.io/v1alpha2`)
+  - `AWSControlPlane` (API version `infrastructure.giantswarm.io/v1alpha2`)
 - Node pool (AWS only):
   - `MachineDeployment` (API version `cluster.x-k8s.io/v1alpha2`)
   - `AWSMachineDeployment` (API version `infrastructure.giantswarm.io/v1alpha2`)
@@ -163,8 +226,8 @@ Plugin supports rendering CRs:
 - `App`
 
 The installation procedure is described in [README](https://github.com/giantswarm/kubectl-gs#how-to-install-plugin).
-There is also a [document](https://github.com/giantswarm/kubectl-gs/blob/master/docs/template-cluster-cr.md), describing the templating process in detail.
+There is also a [document](https://github.com/giantswarm/kubectl-gs/blob/master/docs/template-cluster-cr.md) describing the templating process in detail.
 
-As a result of rendering the CRs ([sample](https://github.com/giantswarm/kubectl-gs/blob/master/docs/template-cluster-cr.md#example)), a user will get a *yaml* file containing valid CRs that can create a tenant cluster and its node pools.
-The tenant cluster can be created by applying the cluster manifest file to the Control Plane, .e.g. `kubectl create -f <cluster manifest file>.yaml`.
+As a result of rendering the CRs ([sample](https://github.com/giantswarm/kubectl-gs/blob/master/docs/template-cluster-cr.md#example)), a user will get YAML manifests containing valid CRs that can create a tenant cluster and its node pools.
+The resources can then be created by applying the manifest files to the Control Plane, e.g. `kubectl create -f <cluster manifest file>.yaml`.
 Of course, that requires the user to be authorized towards Kubernetes Control Plane API.

--- a/src/content/guides/creating-clusters-via-crs-on-aws/index.md
+++ b/src/content/guides/creating-clusters-via-crs-on-aws/index.md
@@ -1,7 +1,7 @@
 ---
 title: Creating tenant clusters on AWS via Control Plane Kubernetes API
 description: This guide will walk you through the process of tenant cluster creation via Control Plane Kubernetes.
-date: 2020-04-01
+date: 2020-06-19
 type: page
 weight: 100
 tags: ["tutorial"]

--- a/src/content/guides/creating-clusters-via-crs-on-aws/index.md
+++ b/src/content/guides/creating-clusters-via-crs-on-aws/index.md
@@ -84,9 +84,6 @@ spec:
     credentialSecret:
       name: credential-default
       namespace: giantswarm
-    master:
-      availabilityZone: ""
-      instanceType: ""
     pods:
       cidrBlock: 10.7.0.0/16
     region: eu-central-1


### PR DESCRIPTION
For https://github.com/giantswarm/giantswarm/issues/8346

- Adds information on the G8sControlPlane and AWSControlPlane resources
- Improves language and readability
- Fixes a CR example where we showed an AWSMachineDeployment instead of AWSCluster
- Fixes headline levels in HA masters intro page