### PR TITLE
Update crd-docs-generator and apiextensions version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ COMPANY=giantswarm
 REGISTRY=quay.io
 SHELL=bash
 MARKDOWNLINT_IMAGE=06kellyjac/markdownlint-cli:0.21.0
-CRD_DOCS_GENERATOR_VERSION=0.1.0-7008fd99c501c1bf4a3f94afdb34e4d008142579
+CRD_DOCS_GENERATOR_VERSION=0.1.1
 
 default: docker-build
 

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ COMPANY=giantswarm
 REGISTRY=quay.io
 SHELL=bash
 MARKDOWNLINT_IMAGE=06kellyjac/markdownlint-cli:0.21.0
+CRD_DOCS_GENERATOR_VERSION=0.1.0-7008fd99c501c1bf4a3f94afdb34e4d008142579
 
 default: docker-build
 
@@ -54,7 +55,7 @@ build: vendor build-css
 	docker run \
 		-v ${PWD}/build/content/reference/cp-k8s-api:/opt/crd-docs-generator/output \
 		-v ${PWD}:/opt/crd-docs-generator/config \
-		quay.io/giantswarm/crd-docs-generator:0.0.0-cce07b5b225bd1b7ad576a0e1f5ebb773397915c \
+		quay.io/giantswarm/crd-docs-generator:$(CRD_DOCS_GENERATOR_VERSION) \
 		  --config /opt/crd-docs-generator/config/crd-docs-generator-config.yaml
 
 lint:

--- a/crd-docs-generator-config.yaml
+++ b/crd-docs-generator-config.yaml
@@ -3,7 +3,7 @@ source_repository:
   url: https://github.com/giantswarm/apiextensions
   organization: giantswarm
   short_name: apiextensions
-  commit_reference: v0.4.7
+  commit_reference: v0.4.8
 skip_crds:
   - chartconfigs.core.giantswarm.io
   - clusters.core.giantswarm.io


### PR DESCRIPTION
This makes CRD attributes linkable and pulls in the latest apiextensions version.