### PR TITLE
Don't throw an error if the sidebar element doesn't exist

### DIFF
--- a/src/static/js/base.js
+++ b/src/static/js/base.js
@@ -293,6 +293,9 @@ $(document).ready(function(){
 window.addEventListener("load", function() {
   if (!window.GSAside) return;
 
-  var g = new GSAside(".toc-sidebar", ".base-content", 60);
+  var asideSelector = ".toc-sidebar";
+  if (!document.querySelector(asideSelector)) return;
+
+  var g = new GSAside(asideSelector, ".base-content", 60);
   g.init();
 });


### PR DESCRIPTION
As seen on https://gigantic.slack.com/archives/CQ465CFG8/p1593500674000700

This came back to kill me :( 