### PR TITLE
Separate external from internal link checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,7 @@ jobs:
               linkchecker/linkchecker \
                 http://docs:8080 \
                 --no-status \
+                --check-extern \
                 -t 2 \
                 --ignore-url="^https://docs\.giantswarm\.io/.*" \
                 --ignore-url=/api/ \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,7 +106,7 @@ workflows:
             - build
       - linkcheck-external:
           type: approval
-          requites:
+          requires:
             - build
 
   package-and-push-chart-on-tag:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,25 +5,6 @@ orbs:
 
 
 jobs:
-  linkcheck-internal:
-    machine:
-      image: "ubuntu-1604:201903-01"
-
-    steps:
-      - run:
-          name: Internal link check
-          command: |
-            docker pull linkchecker/linkchecker > /dev/null
-            docker run -d --rm --name docs1 -p 8080:8080 quay.io/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME:$CIRCLE_SHA1
-            docker run --rm -ti --name linkchecker \
-              --link docs1:docs1 \
-              linkchecker/linkchecker \
-                http://docs1:8080 \
-                -t 4 \
-                --ignore-url="^https://docs\.giantswarm\.io/.*" \
-                --ignore-url=/api/
-            docker kill docs1 || echo "Container 'docs1' not running"
-
   linkcheck:
     machine:
       image: "ubuntu-1604:201903-01"
@@ -85,7 +66,19 @@ jobs:
             docker run -d --rm --name docs -p 8080:8080 quay.io/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME:$CIRCLE_SHA1
             CURL_OUTPUT=$(curl --no-buffer -s http://localhost:8080)
             echo $CURL_OUTPUT | grep --quiet "Giant Swarm"
-            docker kill docs
+      
+      - run:
+          name: Internal link check
+          command: |
+            docker pull linkchecker/linkchecker > /dev/null
+            docker run --rm -ti --name linkchecker \
+              --link docs:docs \
+              linkchecker/linkchecker \
+                http://docs:8080 \
+                -t 4 \
+                --ignore-url="^https://docs\.giantswarm\.io/.*" \
+                --ignore-url=/api/
+            docker kill docs || echo "Container 'docs' not running"
 
       - deploy:
           name: Deploy (only if branch is "master")

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,6 @@ jobs:
               --link docs:docs \
               linkchecker/linkchecker \
                 http://docs:8081 \
-                --no-status \
                 -t 4 \
                 --ignore-url="^https://docs\.giantswarm\.io/.*" \
                 --ignore-url=/api/
@@ -39,7 +38,6 @@ jobs:
               --link docs:docs \
               linkchecker/linkchecker \
                 http://docs:8082 \
-                --no-status \
                 --check-extern \
                 -t 2 \
                 --ignore-url="^https://docs\.giantswarm\.io/.*" \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,9 +94,6 @@ workflows:
   build-and-check:
     jobs:
       - build
-      - linkcheck-internal:
-          requires:
-            - build
       - linkcheck-external:
           type: approval
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,9 +16,9 @@ jobs:
             docker pull linkchecker/linkchecker > /dev/null
             docker run -d --rm --name docs1 -p 8081:8080 quay.io/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME:$CIRCLE_SHA1
             docker run --rm -ti --name linkchecker \
-              --link docs1:docs \
+              --link docs1:docs1 \
               linkchecker/linkchecker \
-                http://docs:8081 \
+                http://docs1:8081 \
                 -t 4 \
                 --ignore-url="^https://docs\.giantswarm\.io/.*" \
                 --ignore-url=/api/
@@ -35,9 +35,9 @@ jobs:
             docker pull linkchecker/linkchecker > /dev/null
             docker run -d --rm --name docs2 -p 8082:8080 quay.io/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME:$CIRCLE_SHA1
             docker run --rm -ti --name linkchecker \
-              --link docs2:docs \
+              --link docs2:docs2 \
               linkchecker/linkchecker \
-                http://docs:8082 \
+                http://docs2:8082 \
                 --check-extern \
                 -t 2 \
                 --ignore-url="^https://docs\.giantswarm\.io/.*" \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,13 +5,13 @@ orbs:
 
 
 jobs:
-  linkcheck:
+  linkcheck-internal:
     machine:
       image: "ubuntu-1604:201903-01"
 
     steps:
       - run:
-          name: Link check
+          name: Internal link check
           command: |
             docker pull linkchecker/linkchecker > /dev/null
             docker run -d --rm --name docs -p 8080:8080 quay.io/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME:$CIRCLE_SHA1
@@ -19,12 +19,33 @@ jobs:
               --link docs:docs \
               linkchecker/linkchecker \
                 http://docs:8080 \
-                --check-extern -t 2 \
-                --ignore-url="^https://docs.giantswarm.io/.*" \
+                --no-status \
+                -t 4 \
+                --ignore-url="^https://docs\.giantswarm\.io/.*" \
+                --ignore-url=/api/
+
+  linkcheck:
+    machine:
+      image: "ubuntu-1604:201903-01"
+
+    steps:
+      - run:
+          name: Link check including external
+          command: |
+            docker pull linkchecker/linkchecker > /dev/null
+            docker run -d --rm --name docs -p 8080:8080 quay.io/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME:$CIRCLE_SHA1
+            docker run --rm -ti --name linkchecker \
+              --link docs:docs \
+              linkchecker/linkchecker \
+                http://docs:8080 \
+                --no-status \
+                -t 2 \
+                --ignore-url="^https://docs\.giantswarm\.io/.*" \
                 --ignore-url=/api/ \
-                --ignore-url="^https://.*example.com/.*" \
-                --ignore-url="^https://my-org.github.com/.*" \
+                --ignore-url="^https://.*example\.com/.*" \
+                --ignore-url="^https://my-org\.github\.com/.*" \
                 --ignore-url=".*gigantic\.io.*"
+
 
   build:
     machine:
@@ -78,8 +99,12 @@ workflows:
   build-andcheck:
     jobs:
       - build
-      - linkcheck:
+      - linkcheck-internal:
           requires:
+            - build
+      - linkcheck-external:
+          type: approval
+          requites:
             - build
 
   package-and-push-chart-on-tag:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,15 +14,16 @@ jobs:
           name: Internal link check
           command: |
             docker pull linkchecker/linkchecker > /dev/null
-            docker run -d --rm --name docs -p 8080:8080 quay.io/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME:$CIRCLE_SHA1
+            docker run -d --rm --name docs1 -p 8081:8080 quay.io/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME:$CIRCLE_SHA1
             docker run --rm -ti --name linkchecker \
               --link docs:docs \
               linkchecker/linkchecker \
-                http://docs:8080 \
+                http://docs:8081 \
                 --no-status \
                 -t 4 \
                 --ignore-url="^https://docs\.giantswarm\.io/.*" \
                 --ignore-url=/api/
+            docker kill docs1 || echo "Container 'docs1' not running"
 
   linkcheck:
     machine:
@@ -33,11 +34,11 @@ jobs:
           name: Link check including external
           command: |
             docker pull linkchecker/linkchecker > /dev/null
-            docker run -d --rm --name docs -p 8080:8080 quay.io/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME:$CIRCLE_SHA1
+            docker run -d --rm --name docs2 -p 8082:8080 quay.io/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME:$CIRCLE_SHA1
             docker run --rm -ti --name linkchecker \
               --link docs:docs \
               linkchecker/linkchecker \
-                http://docs:8080 \
+                http://docs:8082 \
                 --no-status \
                 --check-extern \
                 -t 2 \
@@ -47,6 +48,7 @@ jobs:
                 --ignore-url="^https://my-org\.github\.com/.*" \
                 --ignore-url=".*gigantic\.io.*" \
                 --ignore-url="^https://github\.com/giantswarm/giantswarm/.*"
+            docker kill docs2 || echo "Container 'docs2' not running"
 
 
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,7 +98,7 @@ jobs:
 workflows:
   version: 2
 
-  build-andcheck:
+  build-and-check:
     jobs:
       - build
       - linkcheck-internal:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
             docker pull linkchecker/linkchecker > /dev/null
             docker run -d --rm --name docs1 -p 8081:8080 quay.io/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME:$CIRCLE_SHA1
             docker run --rm -ti --name linkchecker \
-              --link docs:docs \
+              --link docs1:docs \
               linkchecker/linkchecker \
                 http://docs:8081 \
                 -t 4 \
@@ -35,7 +35,7 @@ jobs:
             docker pull linkchecker/linkchecker > /dev/null
             docker run -d --rm --name docs2 -p 8082:8080 quay.io/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME:$CIRCLE_SHA1
             docker run --rm -ti --name linkchecker \
-              --link docs:docs \
+              --link docs2:docs \
               linkchecker/linkchecker \
                 http://docs:8082 \
                 --check-extern \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,11 +14,11 @@ jobs:
           name: Internal link check
           command: |
             docker pull linkchecker/linkchecker > /dev/null
-            docker run -d --rm --name docs1 -p 8081:8080 quay.io/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME:$CIRCLE_SHA1
+            docker run -d --rm --name docs1 -p 8080:8080 quay.io/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME:$CIRCLE_SHA1
             docker run --rm -ti --name linkchecker \
               --link docs1:docs1 \
               linkchecker/linkchecker \
-                http://docs1:8081 \
+                http://docs1:8080 \
                 -t 4 \
                 --ignore-url="^https://docs\.giantswarm\.io/.*" \
                 --ignore-url=/api/

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ COMPANY=giantswarm
 REGISTRY=quay.io
 SHELL=bash
 MARKDOWNLINT_IMAGE=06kellyjac/markdownlint-cli:0.21.0
+CRD_DOCS_GENERATOR_VERSION=0.1.1
 
 default: docker-build
 
@@ -54,7 +55,7 @@ build: vendor build-css
 	docker run \
 		-v ${PWD}/build/content/reference/cp-k8s-api:/opt/crd-docs-generator/output \
 		-v ${PWD}:/opt/crd-docs-generator/config \
-		quay.io/giantswarm/crd-docs-generator:0.0.0-cce07b5b225bd1b7ad576a0e1f5ebb773397915c \
+		quay.io/giantswarm/crd-docs-generator:$(CRD_DOCS_GENERATOR_VERSION) \
 		  --config /opt/crd-docs-generator/config/crd-docs-generator-config.yaml
 
 lint:

--- a/Makefile
+++ b/Makefile
@@ -85,8 +85,9 @@ clean:
 	rm -rf vendor
 	rm -rf .sass-cache
 
-# Verify links.
+# Verify internal links
 linkcheck:
+	@echo "Checking internal links only\n"
 	docker run -d --rm --name server -p 8080:8080 -P $(REGISTRY)/$(COMPANY)/$(PROJECT):latest
 	sleep 2
 
@@ -96,6 +97,32 @@ linkcheck:
 		--link server:server \
 		linkchecker/linkchecker \
 		http://server:8080 \
-		--check-extern -t 5 --ignore-url="^https://docs.giantswarm.io/.*" --ignore-url=/api/ --ignore-url="^https://.+.example.com/.*"
-	docker ps --filter name=server && docker kill server
-	docker ps --filter name=linkchecker && docker kill linkchecker
+		-t 5 \
+		--no-status \
+		--ignore-url="^https://docs\.giantswarm\.io/.*" \
+		--ignore-url=/api/
+	docker kill server
+	docker kill linkchecker
+
+# Verify internal and external links
+linkcheck:
+	@echo "Checking all links\n"
+	docker run -d --rm --name server -p 8080:8080 -P $(REGISTRY)/$(COMPANY)/$(PROJECT):latest
+	sleep 2
+
+	docker run --rm -ti --name linkchecker \
+		--link server:server \
+		linkchecker/linkchecker \
+		http://server:8080 \
+		-t 2 \
+		--check-extern \
+		--no-status \
+		--ignore-url="^https://docs.giantswarm.io/.*" \
+		--ignore-url=/api/ \
+		--ignore-url="^https://.+.example.com/.*" \
+		--ignore-url=".*gigantic\.io.*" \
+		--ignore-url="^https://my-org\.github\.com/.*" \
+		--ignore-url="^https://github\.com/giantswarm/giantswarm/.*"
+
+	docker kill server
+	docker kill linkchecker

--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ clean:
 	rm -rf .sass-cache
 
 # Verify internal links
-linkcheck:
+linkcheck-external:
 	@echo "Checking internal links only\n"
 	docker run -d --rm --name server -p 8080:8080 -P $(REGISTRY)/$(COMPANY)/$(PROJECT):latest
 	sleep 2

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ gsctl create cluster \
   --create-default-nodepool false
 ```
 
-### Linting
+### Linting and validation
 
 Many style rules are checked automatically in CI. You can also execute the check locally
 before pushing commits using the `make lint` command.
@@ -231,6 +231,10 @@ before pushing commits using the `make lint` command.
 For a reference of all rules please check the [DavidAnson/markdownlint documentation](https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md).
 
 There is a project specific configuration in place via the `.markdownlint.yaml` file.
+
+To check locally whether all internal links are correct, use `make linkcheck`.
+
+To check both internal and external links, use `make linkcheck-external`.
 
 ## License
 

--- a/crd-docs-generator-config.yaml
+++ b/crd-docs-generator-config.yaml
@@ -3,7 +3,7 @@ source_repository:
   url: https://github.com/giantswarm/apiextensions
   organization: giantswarm
   short_name: apiextensions
-  commit_reference: v0.4.7
+  commit_reference: v0.4.8
 skip_crds:
   - chartconfigs.core.giantswarm.io
   - clusters.core.giantswarm.io


### PR DESCRIPTION
The goal here is to have internal link checks as a mandatory check, while external links checks can be triggered manually.

The result is visible below, underneath a too long list of commits.

![image](https://user-images.githubusercontent.com/273727/86132882-d57a5f80-bae7-11ea-8f1d-738d00071545.png)

