### PR TITLE
Fix h5 top margin inside well

### DIFF
--- a/src/static/css/base.css
+++ b/src/static/css/base.css
@@ -408,6 +408,9 @@ h5 {
   font-size: 16px;
   margin-top: 45px; }
 
+.well h5:first-child {
+  margin-top: 18px; }
+
 p {
   line-height: 1.65em; }
 

--- a/src/static/css/base.sass
+++ b/src/static/css/base.sass
@@ -32,6 +32,9 @@ h5
   font-size: 16px
   margin-top: 45px
 
+.well h5:first-child
+  margin-top: 18px
+
 p
   line-height: 1.65em
 


### PR DESCRIPTION
Reported by Marian: https://gigantic.slack.com/archives/CQ465CFG8/p1595576148005000

This fixes too much margin on the h5 headers inside of a 'well'