### PR TITLE
Update docs for Kubernetes 1.17

### DIFF
--- a/src/content/basics/multiaz/index.md
+++ b/src/content/basics/multiaz/index.md
@@ -1,7 +1,7 @@
 ---
 title: Clusters Over Multiple Availability Zones
 description: Using multiple availability zones both for worker and for master nodes increases the resilience for clusters. Here we explain some details regarding support on different cloud providers and in different releases. And we give basic information on how to configure workloads to leverage multiple availability zones.
-date: 2020-06-17
+date: 2020-07-31
 weight: 100
 type: page
 categories: ["basics"]
@@ -36,7 +36,7 @@ This enables use cases such as:
 
 - Availability zones get selected randomly by the Giant Swarm control plane. You only need to specify the required number of availability zones.
 
-- Nodes will get distributed evenly across availability zones. There is currently no way to determine which or how many nodes should be started in a particular availability zone. But the nodes will have a label `failure-domain.beta.kubernetes.io/zone` that indicates which availability zone the node is running in.
+- Nodes will get distributed evenly across availability zones. There is currently no way to determine which or how many nodes should be started in a particular availability zone. But the nodes will have a label `topology.kubernetes.io/zone` (or in Kubernetes before 1.17: `failure-domain.beta.kubernetes.io/zone`) that indicates which availability zone the node is running in.
 
 - Single availability zone clusters start in a random availability zone too. This is a means to minimize the risk of all your clusters becoming unavailable due to a failure in one particular AZ.
 

--- a/src/content/basics/nodepools/index.md
+++ b/src/content/basics/nodepools/index.md
@@ -1,7 +1,7 @@
 ---
 title: Node Pools
 description: A general description of node pools as a concept, it's benefits, and some details you should be aware of.
-date: 2020-07-01
+date: 2020-07-31
 weight: 130
 type: page
 categories: ["basics"]
@@ -90,9 +90,9 @@ spec:
 You can assign workloads to node pools in a more indirect way too. This is achieved by using other node attributes which are
 specified via the node pool and which are exposed as node labels.
 
-For example: In a case where you have node pools with one instance type. Using a `nodeSelector` with the label `beta.kubernetes.io/instance-type` you can assign workloads to matching nodes only.
+For example: In a case where you have node pools with one instance type. Using a `nodeSelector` with the label `node.kubernetes.io/instance-type` (or in Kubernetes before v1.17: `beta.kubernetes.io/instance-type`) you can assign workloads to matching nodes only.
 
-Another example: In a case where you have different node pools using different availability zones. With a `nodeSelector` using the label `failure-domain.beta.kubernetes.io/zone` you can assign your workload to the nodes in a particular availability zone.
+Another example: In a case where you have different node pools using different availability zones. With a `nodeSelector` using the label `topology.kubernetes.io/zone` (or in Kubernetes before v1.17: `failure-domain.beta.kubernetes.io/zone`) you can assign your workload to the nodes in a particular availability zone.
 
 ## Node pool deletion
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/8560

This changes node labels in two articles, to match the changes brought with Kubernetes v1.17.x.

- Clusters Over Multiple Availability Zones
- Node Pools