### PR TITLE
Document json output for gsctl create cluster, delete cluster and create kubeconfig

### DIFF
--- a/src/content/reference/gsctl/create-cluster.md
+++ b/src/content/reference/gsctl/create-cluster.md
@@ -65,6 +65,7 @@ EOF
 Passing flag `--output` with value `json` to `gsctl create cluster` changes the printed output to be formatted as a JSON object.
 
 **Example success output:**
+
 ```nohighlight
 {
   "result": "created",
@@ -75,6 +76,7 @@ Passing flag `--output` with value `json` to `gsctl create cluster` changes the 
 When requesting cluster creation with release version {{% first_aws_nodepools_version %}} on AWS, it is possible to recieve `created-with-errors` as value for the `result` key. This indicates some problem with either node pool creation or label attachment.
 
 **Example error output:**
+
 ```nohighlight
 {
   "result": "error",

--- a/src/content/reference/gsctl/create-cluster.md
+++ b/src/content/reference/gsctl/create-cluster.md
@@ -38,6 +38,7 @@ Note that command line flags take precedence over values in the definition. This
 - `--release`, `-r`: Specific release version number to use. Defaults to the latest active release. See [list releases](/reference/gsctl/list-releases/) for details on releases.
 - `--create-default-nodepool`: Where node pools are supported (AWS since release v{{% first_aws_nodepools_version %}}), setting this to `false` allows to suppress the creation of a default node pool. A default node pools would otherwise be created automatically if no cluster definition is given specifying any node pools details, to get you started quickly.
 - `--masters-ha`: Where supported, this is `true` by default, which means that the cluster will have three master nodes. Available on AWS since release v{{% first_aws_ha_masters_version %}}. Set this to `false` to have only one master node in the cluster (recommended only for test clusters).
+- `--output`: By specifying this flag with value `json`, the output can be printed in JSON format. This is convenient for use in automation. See [JSON output](#json-output) for examples.
 
 ## Passing the cluster definition via standard input {#stdin}
 
@@ -57,6 +58,41 @@ owner: acme
 name: Dev cluster
 release: 7.1.1
 EOF
+```
+
+## JSON output {#json-output}
+
+Passing flag `--output` with value `json` to `gsctl create cluster` changes the printed output to be formatted as a JSON object.
+
+**Example success output:**
+```nohighlight
+{
+  "result": "created",
+  "id": "f01r4"
+}
+```
+
+When requesting cluster creation with release version {{% first_aws_nodepools_version %}} on AWS, it is possible to recieve `created-with-errors` as value for the `result` key. This indicates some problem with either node pool creation or label attachment.
+
+**Example error output:**
+```nohighlight
+{
+  "result": "error",
+  "error": {
+    "kind": "unknown",
+    "annotation": "Unauthorized",
+    "stack": [
+      {
+        "file": "/go/src/giantswarm/gsctl/commands/create/cluster/v5.go",
+        "line": 140
+      },
+      {
+        "file": "/go/src/giantswarm/gsctl/commands/create/cluster/command.go",
+        "line": 632
+      }
+    ]
+  }
+}
 ```
 
 ## Related

--- a/src/content/reference/gsctl/create-kubeconfig.md
+++ b/src/content/reference/gsctl/create-kubeconfig.md
@@ -167,6 +167,7 @@ resources to your cluster.
 Passing flag `--output` with value `json` to `gsctl create kubeconfig` changes the printed output to be formatted as a JSON object.
 
 **Example success output:**
+
 ```nohighlight
 {
   "result": "ok",
@@ -175,6 +176,7 @@ Passing flag `--output` with value `json` to `gsctl create kubeconfig` changes t
 ```
 
 **Example error output:**
+
 ```nohighlight
 {
   "result": "error",

--- a/src/content/reference/gsctl/create-kubeconfig.md
+++ b/src/content/reference/gsctl/create-kubeconfig.md
@@ -114,6 +114,7 @@ gsctl create kubeconfig --cluster w6wn8 \
   Note that only the characters `a-z`, `0-9` and `-` can be used.
 - `--certificate-organizations`: A comma separated list of organizations for the
   issued certificate's 'O' fields.
+- `--output`: By specifying this flag with value `json`, the output can be printed in JSON format. This is convenient for use in automation. See [JSON output](#json-output) for examples.
 
 ## Key pair expiry {#expiry}
 
@@ -160,6 +161,39 @@ memberships respectively. This will let you set up fine grained permissions for
 the certificates that you issue by applying
 [RBAC authorization](https://kubernetes.io/docs/reference/access-authn-authz/rbac/)
 resources to your cluster.
+
+## JSON output {#json-output}
+
+Passing flag `--output` with value `json` to `gsctl create kubeconfig` changes the printed output to be formatted as a JSON object.
+
+**Example success output:**
+```nohighlight
+{
+  "result": "ok",
+  "kubeconfig": "apiVersion: v1\nkind: Config\nclusters:\n- name: giantswarm-f01r4\n  cluster: ..."
+}
+```
+
+**Example error output:**
+```nohighlight
+{
+  "result": "error",
+  "error": {
+    "kind": "unknown",
+    "annotation": "Unauthorized",
+    "stack": [
+      {
+        "file": "/go/src/giantswarm/gsctl/commands/create/kubeconfig/command.go",
+        "line": 466
+      },
+      {
+        "file": "/go/src/giantswarm/gsctl/commands/create/kubeconfig/command.go",
+        "line": 489
+      }
+    ]
+  }
+}
+```
 
 ## Related
 

--- a/src/content/reference/gsctl/delete-cluster.md
+++ b/src/content/reference/gsctl/delete-cluster.md
@@ -34,6 +34,41 @@ To prevent the interactive confirmation, you can use the `--force` flag. This wi
 gsctl delete cluster --force --cluster f01r4
 ```
 
+## Argument reference {#arguments}
+
+- `--force`: Disable any confirmations.
+- `--output`: By specifying this flag with value `json`, the output can be printed in JSON format. Disables any confirmations. This is convenient for use in automation. See [JSON output](#json-output) for examples.
+
+## JSON output {#json-output}
+
+Passing flag `--output` with value `json` to `gsctl create kubeconfig` changes the printed output to be formatted as a JSON object.
+
+**Example success output:**
+```nohighlight
+{
+  "result": "deletion scheduled",
+  "id": "f01r4"
+}
+```
+
+**Example error output:**
+```nohighlight
+{
+  "result": "error",
+  "id": "",
+  "error": {
+    "kind": "CouldNotDeleteClusterError",
+    "annotation": "Unauthorized",
+    "stack": [
+      {
+        "file": "/go/src/giantswarm/gsctl/commands/delete/cluster/command.go",
+        "line": 295
+      }
+    ]
+  }
+}
+```
+
 ## Related
 
 - [`gsctl scale cluster`](../scale-cluster/)

--- a/src/content/reference/gsctl/delete-cluster.md
+++ b/src/content/reference/gsctl/delete-cluster.md
@@ -44,6 +44,7 @@ gsctl delete cluster --force --cluster f01r4
 Passing flag `--output` with value `json` to `gsctl delete cluster` changes the printed output to be formatted as a JSON object.
 
 **Example success output:**
+
 ```nohighlight
 {
   "result": "deletion scheduled",
@@ -52,6 +53,7 @@ Passing flag `--output` with value `json` to `gsctl delete cluster` changes the 
 ```
 
 **Example error output:**
+
 ```nohighlight
 {
   "result": "error",

--- a/src/content/reference/gsctl/delete-cluster.md
+++ b/src/content/reference/gsctl/delete-cluster.md
@@ -41,7 +41,7 @@ gsctl delete cluster --force --cluster f01r4
 
 ## JSON output {#json-output}
 
-Passing flag `--output` with value `json` to `gsctl create kubeconfig` changes the printed output to be formatted as a JSON object.
+Passing flag `--output` with value `json` to `gsctl delete cluster` changes the printed output to be formatted as a JSON object.
 
 **Example success output:**
 ```nohighlight


### PR DESCRIPTION
This documents the changes in giantswarm/gsctl#580 to `gsctl create cluster`, `gsctl create kubeconfig` and `gsctl delete cluster`.

After this PR has been approved, I'll craft a gsctl release, update this PR to update the gsctl version and release docs with the changes.