### PR TITLE
Update apiextensions commit reference to latest release

### DIFF
--- a/crd-docs-generator-config.yaml
+++ b/crd-docs-generator-config.yaml
@@ -3,7 +3,7 @@ source_repository:
   url: https://github.com/giantswarm/apiextensions
   organization: giantswarm
   short_name: apiextensions
-  commit_reference: v0.4.19
+  commit_reference: v2.5.1
 skip_crds:
   - chartconfigs.core.giantswarm.io
   - clusters.core.giantswarm.io


### PR DESCRIPTION
Latest apiextensions release drops CRDs for managed AKS tenant clusters
which is not a thing we use nor support.