### PR TITLE
Add breadcrumb label for the web interface reference

### DIFF
--- a/src/data/navtitles.yaml
+++ b/src/data/navtitles.yaml
@@ -1,3 +1,4 @@
 basics: Basics
 guides: User Guides
 reference: Reference
+web-interface: Web Interface


### PR DESCRIPTION
For pages under https://docs.giantswarm.io/reference/web-interface/, e. g. https://docs.giantswarm.io/reference/web-interface/app-platform/

Before:

![image](https://user-images.githubusercontent.com/273727/94242909-fe5b9680-ff16-11ea-894a-c80fff27cb97.png)

After:

![image](https://user-images.githubusercontent.com/273727/94243528-cef95980-ff17-11ea-9fe3-a5fc45fea947.png)

