### PR TITLE
External links check October 2020

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,8 @@ jobs:
                 --ignore-url="^https://.*example\.com/.*" \
                 --ignore-url="^https://my-org\.github\.com/.*" \
                 --ignore-url=".*gigantic\.io.*" \
-                --ignore-url="^https://github\.com/giantswarm/giantswarm/.*"
+                --ignore-url="^https://github\.com/giantswarm/giantswarm/.*" \
+                --ignore-url="^https://sysdig\.com/.*"
             docker kill docs || echo "Container 'docs' not running"
 
 


### PR DESCRIPTION
This PR mainly exists to run the link check in CI.

However, it surfaced that due to certificate chain problems, we had to add `sysdig.com` to the ignored URLs list.

One broken external link has been identified and fixed.