### PR TITLE
Updates for the release versions reference

### DIFF
--- a/src/content/reference/release-versions/_index.md
+++ b/src/content/reference/release-versions/_index.md
@@ -38,7 +38,6 @@ We generally try to increment our Major version only when there is a new Kuberne
 | **12.x.x** | 1.17.x | Available |
 | **13.x.x** | 1.18.x | Available soon |
 
-
 \*) On AWS, **v9.2.0** and **v9.3.x** and up includes **Kubernetes 1.16.x**.
 
 ## Versions that support node pools

--- a/src/content/reference/release-versions/_index.md
+++ b/src/content/reference/release-versions/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Release Versions
 description: Here you find our reference regarding our release versions
-date: 2020-09-23
+date: 2020-10-05
 layout: subsection
 weight: 500
 ---
@@ -24,23 +24,22 @@ and create new clusters with the added or fixed functionality.
 
 ## Conventions around release versioning
 
-We've had to break these conventions in some cases, but we're trying to re-align
+We've had to break these conventions in some cases, but we're re-aligning
 things as time goes on and customers no longer use older versions.
 
 ### Major versions increment on Kubernetes releases
 
 We generally try to increment our Major version only when there is a new Kubernetes release.
 
-||||
-|-----------|------------|-----|
-|**v9.0.x** | Kubernetes 1.15.x ||
-|**v11.x.x** | Kubernetes 1.16.x ||
-|**v12.x.x** | Kubernetes 1.17.x ||
-|**v13.x.x** | Kubernetes 1.18.x | not yet available|
+| Giant Swarm release version | Kubernetes version | Status |
+|:-----------:|:------------:|:-----:|
+| **9.x.x** | 1.15.x\* | Available |
+| **11.x.x** | 1.16.x | Available |
+| **12.x.x** | 1.17.x | Available |
+| **13.x.x** | 1.18.x | Available soon |
 
-#### Exceptions
 
-On AWS, **v9.2.0** and up contains **Kubernetes 1.16.x**
+\*) On AWS, **v9.2.0** and **v9.3.x** and up includes **Kubernetes 1.16.x**.
 
 ## Versions that support node pools
 
@@ -59,84 +58,15 @@ cluster.
 Generally all active releases are available with Flatcar Container Linux as
 the operating system.
 
-Look for the latest patch version.
+This table shows which releases first introduces Flatcar Container Linux on various providers and minor releases:
 
--------------
-
-### AWS
-
-||||
-|-----------|------------|-----|
-|**v9.3.0** | Kubernetes 1.16.x | Flatcar Container Linux|
-|**v11.3.0** | Kubernetes 1.16.x | Flatcar Container Linux with Nodepools|
-
--------------
-
-### KVM
-
-|            |                    |                        |
-|------------|--------------------|------------------------|
-|**v9.0.3**  | Kubernetes 1.15.x  | Flatcar Container Linux|
-|**v11.3.x** | Kubernetes 1.16.x  | Flatcar Container Linux|
-
--------------
-
-### Azure
-
-||||
-|-----------|------------|-----|
-|**v11.3.x** | Kubernetes 1.16.x | Flatcar Container Linux|
-
-## Versions that use the App Platform
-
-Any version greater than 9.0.0 uses the App Platform to manage the apps that get
-installed on tenant clusters. When upgrading from `9.0.0` to `9.0.x` or any higher
-version there are some notable changes to be aware of:
-
-You must modify existing automation or processes that manage the configuration of
-`coredns`, `nginx-ingress-controller`, or `cluster-autoscaler` to work with the
-changed location and format of the `*-user-values` configmaps.
-
-1. The `*-user-values` configmaps have moved from `kube-system` on the tenant cluster to a namespace on the control plane.
-2. The format of the `*-user-values` configmaps has changed as well. (Configuration is now nested in `data.values.configmap`)
-
-**Before:**
-
-```yaml
-# On the Tenant Cluster, in the kube-system namespace
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  labels:
-    app: coredns
-    name: coredns-user-values
-    namespace: kube-system
-data:
-  cache: "60"
-```
-
-**After:**
-
-```yaml
-# On the Control Plane, in the abc12 namespace
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  labels:
-    app: coredns
-    name: coredns-user-values
-    namespace: abc12
-data:
-  values: |
-    configmap:
-      cache: "60"
-```
-
-The guides below show before and after examples for each case:
-
-- [NGINX Ingress Controller](/guides/advanced-ingress-configuration/)
-- [CoreDNS](/guides/advanced-coredns-configuration/)
-- [Cluster Autoscaler](/guides/advanced-cluster-autoscaler-configuration/)
+| Provider |Giant Swarm minor release | Kubernetes version |
+|:-:|:-:|:-:|
+| AWS | **v9.3.0** | 1.16.x |
+| AWS | **v11.3.0** | 1.16.x |
+| Azure | **v11.3.x** | 1.16.x |
+| KVM | **v9.0.3**  | 1.15.x  |
+| KVM | **v11.3.x** | 1.16.x  |
 
 ## Latest release information
 


### PR DESCRIPTION
Several changes to https://docs.giantswarm.io/reference/release-versions/

- Attempt to make the table in *Major versions increment on Kubernetes releases* easier to read
- Combine three tables for flatcar into one
- Remove section mentioning releases before 9.0.0 and upgrading to 9.0.0
