### PR TITLE
Turn off built-in highlighting (for now)

### DIFF
--- a/src/config.toml
+++ b/src/config.toml
@@ -9,8 +9,12 @@ pluralizeListTitles = false
     endLevel = 5
     startLevel = 1
 
-[markup.goldmark.renderer]
-  unsafe = true
+  [markup.goldmark]
+    [markup.goldmark.renderer]
+      unsafe = true
+
+  [markup.highlight]
+    codeFences = false  # Disable Hugo's code highlighter, as we use highlight.js
 
 [[menu.main]]
     name = "Basics and Concepts"


### PR DESCRIPTION
Closes https://github.com/giantswarm/giantswarm/issues/13645

With the HUGO version we use, built-in syntax highlighting is turned on by default, causing extra styling to be applied.

Since we have highlight.js in use, we turn built-in highlighting off to have the appearance again we would expect.