### PR TITLE
Don't mention Azure supporting cluster autoscaling

### DIFF
--- a/src/content/basics/cluster-size-autoscaling/index.md
+++ b/src/content/basics/cluster-size-autoscaling/index.md
@@ -5,15 +5,14 @@ date: 2020-02-17
 weight: 120
 type: page
 categories: ["basics"]
-last-review-date: 2020-09-23
+last-review-date: 2020-10-07
 ---
 
 # Cluster Size and Autoscaling
 
-Starting with release version {{% first_aws_autoscaling_version %}} for AWS and {{% first_azure_autoscaling_version %}} for Azure you can leverage the benefits of the
-[Kubernetes autoscaler](https://github.com/kubernetes/autoscaler) to define the number of worker nodes in a cluster based on demand.
+Starting with release version {{% first_aws_autoscaling_version %}} for AWS you can leverage the benefits of the [Kubernetes autoscaler](https://github.com/kubernetes/autoscaler) to define the number of worker nodes in a cluster based on demand.
 
-On Giant Swarm installations on bare-metal, and on older versions on AWS and Azure, the cluster size would be defined statically.
+On Giant Swarm installations on Azure, on bare-metal, and on AWS prior to version {{% first_aws_autoscaling_version %}}, the cluster size would be defined statically.
 
 ## Setting scaling limits
 
@@ -37,7 +36,7 @@ If the utilization is below the threshold, the autoscaler decides to remove the 
 
 ## Minimal and default cluster size
 
-When creating a cluster without specifying the number of worker nodes, {{% default_cluster_size_worker_nodes %}} worker nodes will be created. On AWS starting with release version {{% first_aws_autoscaling_version %}} and Azure since release {{% first_azure_autoscaling_version %}}, when not specified, the maximum number of worker nodes is also set to {{% default_cluster_size_worker_nodes %}}.
+When creating a cluster without specifying the number of worker nodes, {{% default_cluster_size_worker_nodes %}} worker nodes will be created. On AWS starting with release version {{% first_aws_autoscaling_version %}}, when not specified, the maximum number of worker nodes is also set to {{% default_cluster_size_worker_nodes %}}.
 
 Technically, while you may be able to create and run smaller clusters successfully, we don't encourage this due to reduced resilience.
 

--- a/src/content/reference/gsctl/scale-cluster.md
+++ b/src/content/reference/gsctl/scale-cluster.md
@@ -1,7 +1,7 @@
 ---
 title: "gsctl Command Reference: scale cluster"
 description: "The 'gsctl scale cluster' command allows to add or remove worker nodes to reach a desired number."
-date: "2020-09-23"
+date: 2020-10-07
 type: page
 weight: 53
 ---
@@ -38,7 +38,7 @@ gsctl scale cluster "Cluster name" --num-workers 5
 
 Where **autoscaling** is available, you can specify a range within which the autoscaler can scale the number of worker nodes.
 
-Note that autoscaling is currently available on AWS in release version 6.3.0 or newer and Azure in release version {{% first_azure_autoscaling_version %}} or newer.
+Note that autoscaling is currently available on AWS in release version {{% first_aws_autoscaling_version %}} or newer.
 
 Example:
 
@@ -64,7 +64,7 @@ When adding worker nodes, no such confirmation is required.
 ## Full argument reference {#arguments}
 
 - `-w`, `--num-workers`: Shorthand to set `--workers-min` and `--workers-max` to the same value. Note that where autoscaling is available, this effectively disables autoscaling.
-- `--workers-min`, `--workers-max`: Minimum and maximum number of worker nodes. For autoscaling clusters (available on AWS and Azure since release {{% first_azure_autoscaling_version %}}) this specifies the range within the autoscaler can scale the number of worker nodes. For releases not supporting autoscaling, both values must be set to the same number.
+- `--workers-min`, `--workers-max`: Minimum and maximum number of worker nodes. For autoscaling clusters (available on AWS since release {{% first_aws_autoscaling_version %}}) this specifies the range within the autoscaler can scale the number of worker nodes. For releases not supporting autoscaling, both values must be set to the same number.
 - `--force`: If set, no confirmation is required when reducing the number of workers. You should only use this argument in automations when you are sure that reducing the number of workers is desired.
 
 Use `gsctl scale cluster --help` for a additional (global) arguments.


### PR DESCRIPTION
While working on https://github.com/giantswarm/docs/pull/598 I noticed that in the docs we say that Azure clusters support autoscaling, which isn't true. We only support node pool autoscaling.

WDYT?