### PR TITLE
Remove highlight.js from docs, use server-side syntax highlighting

### DIFF
--- a/src/config.toml
+++ b/src/config.toml
@@ -12,9 +12,12 @@ pluralizeListTitles = false
   [markup.goldmark]
     [markup.goldmark.renderer]
       unsafe = true
-
-  [markup.highlight]
-    codeFences = false  # Disable Hugo's code highlighter, as we use highlight.js
+    [markup.highlight]
+      codeFences = true
+      style = "solarized-dark"
+      guessSyntax = false
+      tabWidth = 4
+      lineNos = false
 
 [[menu.main]]
     name = "Basics and Concepts"

--- a/src/layouts/partials/scripts.html
+++ b/src/layouts/partials/scripts.html
@@ -6,6 +6,5 @@
 <script type="text/javascript" src="https://s.giantswarm.io/jquery/3.3.1/1/jquery.min.js"></script>
 <script type="text/javascript" src="https://s.giantswarm.io/privacy/7/privacy.js"></script>
 <script type="text/javascript" src="https://s.giantswarm.io/giantswarmio/0.10.18/1/bootstrap.min.js"></script>
-<script type="text/javascript" src="https://s.giantswarm.io/highlightjs/9.16.2/1/highlight.min.js"></script>
 <script type="text/javascript" src="/js/polyfill/IntersectionObserver.js"></script>
 <script type="text/javascript" src="{{ $secureJS.RelPermalink }}" integrity="{{ htmlUnescape $secureJS.Data.Integrity }}"></script>

--- a/src/layouts/partials/styles.html
+++ b/src/layouts/partials/styles.html
@@ -6,6 +6,5 @@
 <link rel="stylesheet" type="text/css" href="//fonts.googleapis.com/css?family=Roboto+Slab:300,700|Roboto:300,700,300italic|Inconsolata:400,700">
 <link rel="stylesheet" type="text/css" href="https://s.giantswarm.io/giantswarmio/0.10.18/1/bootstrap.min.css">
 <link rel="stylesheet" type="text/css" href="https://s.giantswarm.io/giantswarmio/0.10.18/1/base.css">
-<link rel="stylesheet" type="text/css" href="https://s.giantswarm.io/highlightjs/9.16.2/1/solarized-dark.min.css">
 <link rel="stylesheet" type="text/css" href="{{ $css.RelPermalink }}" integrity="{{ htmlUnescape $css.Data.Integrity }}">
 <link rel="stylesheet" type="text/css" href="https://use.fortawesome.com/kits/b5c7b73e/publications/latest/woff.css">


### PR DESCRIPTION
Closes https://github.com/giantswarm/giantswarm/issues/13766

This removes highlight.js and activates server-side syntax highlighting.

Note: Although both are named `solarized-dark`, the theme colors differ between Chroma (used by HUGO) and highlight.js.

## Preview

### Before (highlight.js)

![image](https://user-images.githubusercontent.com/273727/95988019-8d7a1100-0e28-11eb-993c-a17eaae2e4b2.png)


### After (Chroma)

![image](https://user-images.githubusercontent.com/273727/95988058-9b2f9680-0e28-11eb-852a-05ec1d13fc2c.png)
