### PR TITLE
remove mentions of the ssh public key parameter for kubectl-gs

### DIFF
--- a/src/content/reference/kubectl-gs/template-cluster.md
+++ b/src/content/reference/kubectl-gs/template-cluster.md
@@ -57,10 +57,6 @@ It supports the following flags:
 - `--external-snat` - AWS CNI configuration to disable (is enabled by default) the [external source network address translation](https://docs.aws.amazon.com/eks/latest/userguide/external-snat.html). Only versions *11.3.1+ support this feature.
 - `--region` - tenant cluster AWS region. Must be configured with installation region.
 
-### Azure specific
-
-- `--azure-public-ssh-key` - Azure master machines Base64-encoded public key used for SSH.
-
 ## Example
 
 Example command for an AWS cluster:

--- a/src/content/reference/kubectl-gs/template-nodepool.md
+++ b/src/content/reference/kubectl-gs/template-nodepool.md
@@ -55,7 +55,6 @@ Can be retrieved with `gsctl list releases` for your installation. Only versions
 ### Azure specific
 
 - `--azure-vm-size` - Azure VM size to use for workers (e.g. *Standard_D4s_v3*).
-- `--azure-public-ssh-key` - Azure master machines Base64-encoded public key used for SSH.
 
 ## Example
 


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/13783

The parameter will be removed soon.