### PR TITLE
Add kgs reference link

### DIFF
--- a/src/layouts/index.html
+++ b/src/layouts/index.html
@@ -104,6 +104,7 @@
       <h2>Reference Documentation</h2>
       <ul class="linklist linklist-compact">
         <li><a href="/reference/gsctl/">gsctl - The Giant Swarm command line utility</a></li>
+        <li><a href="/reference/kubectl-gs/">kubectl gs - The Giant Swarm kubectl plugin</a></li>
         <li><a href="/reference/cluster-definition/">Cluster definition YAML reference</a></li>
         <li><a href="/reference/cluster-upgrades/">Cluster upgrades</a></li>
         <li><a href="/api/">The Giant Swarm API</a></li>

--- a/src/layouts/index.html
+++ b/src/layouts/index.html
@@ -103,8 +103,8 @@
     <div class="col-sm-12">
       <h2>Reference Documentation</h2>
       <ul class="linklist linklist-compact">
-        <li><a href="/reference/gsctl/">gsctl - The Giant Swarm command line utility</a></li>
-        <li><a href="/reference/kubectl-gs/">kubectl gs - The Giant Swarm kubectl plugin</a></li>
+        <li><a href="/reference/gsctl/">gsctl &ndash; The Giant Swarm command line utility</a></li>
+        <li><a href="/reference/kubectl-gs/">kubectl gs &ndash; The Giant Swarm kubectl plugin</a></li>
         <li><a href="/reference/cluster-definition/">Cluster definition YAML reference</a></li>
         <li><a href="/reference/cluster-upgrades/">Cluster upgrades</a></li>
         <li><a href="/api/">The Giant Swarm API</a></li>


### PR DESCRIPTION
Closes https://github.com/giantswarm/giantswarm/issues/13468 finally by adding a link to the docs front page pointing to the kubectl gs reference.

## Preview

![image](https://user-images.githubusercontent.com/273727/96973066-b0d34900-1517-11eb-9c8b-e9887071a392.png)

