### PR TITLE
Update markdownlint to 0.23.0-alpine

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ PROJECT=docs
 COMPANY=giantswarm
 REGISTRY=quay.io
 SHELL=bash
-MARKDOWNLINT_IMAGE=06kellyjac/markdownlint-cli:0.21.0
+MARKDOWNLINT_IMAGE=06kellyjac/markdownlint-cli:0.23.0-alpine
 CRD_DOCS_GENERATOR_VERSION=0.1.2
 
 default: docker-build


### PR DESCRIPTION
This updates the markdownlint docker image and uses the Alpine version, which is pulled faster.