### PR TITLE
Move kubectl gs template cluster '--master-az' flag to the 'Common' zone

### DIFF
--- a/src/content/reference/kubectl-gs/template-cluster.md
+++ b/src/content/reference/kubectl-gs/template-cluster.md
@@ -44,15 +44,19 @@ It supports the following flags:
 - `--label` - tenant cluster label in the form of `key=value`. Can be specified multiple times. Only clusters with release version above *10.x.x*+ support tenant cluster labels.
 - `--cluster-id` (optional) - Unique cluster identifier. Must me 5 characters in length, must contain numbers and letters, and match the regular expression `[a-z0-9]{5}`. If not given, an ID will be generated.
 - `--release-branch` (optional) - The Giant Swarm [releases repository](https://github.com/giantswarm/releases) branch to use to look up the release set via the `--release` flag (default: `master`).
+- `--master-az` - Availability zone(s) of master instance.
+
+  On AWS, it must be configured with AZ of the installation region. E.g. for region *eu-central-1* valid value is *eu-central-1a*.
+
+  On Azure, it can be any of the 3 zones: `1`, `2`, `3`.
+
+  Use the flag once with a single value to create a cluster with one master node (on both Azure and AWS). For master node high availability,
+  specify three distinct availability zones instead (AWS only). This can be done by separating AZ names with comma or using the flag
+  three times with a single AZ name.
 
 ### AWS specific
 
 - `--domain` - base domain of your installation. Customer solution engineer can provide this value.
-- `--master-az` - AWS availability zone(s) of master instance.
-  Must be configured with AZ of the installation region. E.g. for region *eu-central-1* valid value is *eu-central-1a*.
-  Use the flag once with a single value to create a cluster with one master node. For master node high availability,
-  specify three distinct availability zones instead. This can be done by separating AZ names with comma or using the flag
-  three times with a single AZ name.
 - `--credential` - AWS cloud credentials that point to the AWS account used to spin up the cluster resources. To get this info run against the Control Plane API `kubectl -n giantswarm get secret -oyaml | grep ORG_NAME -A2 | tail -n 1 | awk '{print $2}'` replacing `ORG_NAME` for the name of the organization selected.
 - `--external-snat` - AWS CNI configuration to disable (is enabled by default) the [external source network address translation](https://docs.aws.amazon.com/eks/latest/userguide/external-snat.html). Only versions *11.3.1+ support this feature.
 


### PR DESCRIPTION
As seen in this card https://github.com/orgs/giantswarm/projects/82#card-48705179

This PR moves the flag to the `Common` flag zone, and adds info about how it works for `azure` 