### PR TITLE
Fix lots of whitespace below the footer.

### DIFF
--- a/src/assets/styles/base.sass
+++ b/src/assets/styles/base.sass
@@ -6,7 +6,6 @@
 body
   margin-top: 120px
 
-
 h1, h2, h3, h4, h5, h6
   text-align: left
   line-height: 1.3em

--- a/src/assets/styles/base.sass
+++ b/src/assets/styles/base.sass
@@ -1,4 +1,3 @@
-@import footer.css
 @import header
 @import consent_dialog
 
@@ -6,6 +5,7 @@
 
 body
   margin-top: 120px
+
 
 h1, h2, h3, h4, h5, h6
   text-align: left

--- a/src/layouts/partials/gs_styles.html
+++ b/src/layouts/partials/gs_styles.html
@@ -155,4 +155,9 @@ a { text-decoration: underline; color: rgb(56, 118, 150); }
   .open .menu-trigger__icon {
     background-color: transparent;
   }
+
+  /* Create some space between the footer and the end of the content */
+  .site-footer {
+    margin-top: 100px;
+  }
 </style>

--- a/src/layouts/partials/styles.html
+++ b/src/layouts/partials/styles.html
@@ -5,6 +5,5 @@
 
 <link rel="stylesheet" type="text/css" href="//fonts.googleapis.com/css?family=Roboto+Slab:300,700|Roboto:300,700,300italic|Inconsolata:400,700">
 <link rel="stylesheet" type="text/css" href="https://s.giantswarm.io/giantswarmio/0.10.18/1/bootstrap.min.css">
-<link rel="stylesheet" type="text/css" href="https://s.giantswarm.io/giantswarmio/0.10.18/1/base.css">
 <link rel="stylesheet" type="text/css" href="{{ $css.RelPermalink }}" integrity="{{ htmlUnescape $css.Data.Integrity }}">
 <link rel="stylesheet" type="text/css" href="https://use.fortawesome.com/kits/b5c7b73e/publications/latest/woff.css">


### PR DESCRIPTION
This fixes a bunch of whitespace that appeared below the footer. It was coming from the base.css file we stored in the web assets repo. I don't think we need that in here at all anymore.

I think it was there originally to bring in the header and footer styles from the very old giant swarm website. When we changed the website, we removed the headers and footers, but kept referencing this file. I removed it, and I don't see anything breaking. 

------------------------------

before:

<img width="1384" alt="Screenshot 2020-11-24 at 10 33 20 PM" src="https://user-images.githubusercontent.com/455309/100107864-157e1c80-2ea5-11eb-9045-e09838c7f8ba.png">


after:

<img width="1123" alt="Screenshot 2020-11-24 at 10 38 06 PM" src="https://user-images.githubusercontent.com/455309/100108444-bec51280-2ea5-11eb-8436-931b045bd99a.png">
