### PR TITLE
Reference web interface labelling guide in TC labelling guide

### DIFF
--- a/src/content/guides/tenant-cluster-labelling/index.md
+++ b/src/content/guides/tenant-cluster-labelling/index.md
@@ -18,6 +18,8 @@ Label keys and values are freely modifiable except labels with keys containing `
 Working with tenant cluster labels works likewise as working with Kubernetes labels.
 More information about Kubernetes Labels can be found in the [Kubernetes Labels and Selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) and our [cluster labels API documentation](/api/#tag/cluster-labels).
 
+Note: You can also [manage cluster labels directly through `happa`](/reference/web-interface/tenant-cluster-labelling/), our web user interface.
+
 ## Working with tenant cluster labels using `gsctl`
 
 With `gsctl`, our [CLI](https://github.com/giantswarm/gsctl), cluster labels can be modified by executing [`gsctl update cluster`](/reference/gsctl/update-cluster/) by setting label changes using one or multiple `--label` flag.


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/14713

Adds a reference to the web UI labeling page in the general TC labeling page. There is already a link in the opposite direction.