### PR TITLE
Fix help icon in CRD page footer

### DIFF
--- a/src/layouts/_default/crd.html
+++ b/src/layouts/_default/crd.html
@@ -27,7 +27,7 @@
       <p>This documentation page shows information based on <a href="{{ $.Param "source_repository" }}/tree/{{ $.Param "source_repository_ref" }}" target="_blank" rel="noopener noreferrer">apiextensions {{ $.Param "source_repository_ref" }}</a>.
 
       <div class="feedback well">
-        <h5><i class="fa fa-question-circle"></i> Need help with the Control Plane Kubernetes API?</h5>
+        <h5><i class="fa fa-help-outline"></i> Need help with the Control Plane Kubernetes API?</h5>
         <p>We listen in your Slack support channel. And of course, we welcome your <a title="open this page in GitHub" href="{{ $.Param "source_repository" }}" target="_blank" rel="noopener noreferrer">pull requests</a> to improve these docs!</p>
       </div>
 


### PR DESCRIPTION
Minor fix to mitigate this:

![image](https://user-images.githubusercontent.com/273727/101896898-fa502400-3ba9-11eb-8aab-40f8ed24fdb9.png)
