### PR TITLE
Add metadata for Spark CRD

### DIFF
--- a/src/data/crd_metadata.yaml
+++ b/src/data/crd_metadata.yaml
@@ -136,6 +136,11 @@ releases.release.giantswarm.io:
 silences.monitoring.giantswarm.io:
   topics:
     - controlplane
+sparks.core.giantswarm.io:
+  provider:
+    - azure
+  topics:
+    - tenantcluster
 storageconfigs.core.giantswarm.io:
   topics:
     - controlplane


### PR DESCRIPTION
This PR adds metadata for the Spark CRD, so that the tags `tenantcluster` and `AZURE` appear.

@tuommaki We also have a `controlplane` tag, and we could add both of both would make sense. I can't judge this, so your call.