### PR TITLE
Adjust TOC styles

### DIFF
--- a/src/assets/styles/base.sass
+++ b/src/assets/styles/base.sass
@@ -354,48 +354,47 @@ ul.notype li
   a
     font-size: 16px
 
-
 #TableOfContents
   font-size: 14px
+  *
+    font-size: 14px
   border: 1px solid #ddd
   padding: 10px 0px 10px 0px
 
-#TableOfContents ul
-  list-style-type: none
-  margin: 0
-  padding: 0
+  ul
+    list-style-type: none
+    margin: 0
+    padding: 0
 
-#TableOfContents li a
-  margin: 0
-  padding: 5px 14px 5px 18px
-  line-height: 23px
-  display: block
-  border-left: 2px solid #fff
-  transition: .2s ease-out
+    ul
+      // second level entries
+      a
+        padding-left: 32px
+      
+      ul
+        // third level entries
+        a
+          display: none
 
-#TableOfContents li a.active
-  background-color: #ddd
-  border-left-color: #234a61
+  li
+    margin-bottom: 0
 
-// second level entries
-#TableOfContents ul ul a
-  padding-left: 32px
+    a
+      margin: 0
+      padding: 5px 14px 5px 18px
+      line-height: 20px
+      display: block
+      border-left: 2px solid #fff
+      transition: .2s ease-out
 
-// third level entries
-#TableOfContents ul ul ul a
-  display: none
+    a.active
+      background-color: #ddd
+      border-left-color: #234a61
 
-#TableOfContents ul ul ul a
-  padding-left: 42px
-  padding-top: 2px
-  padding-bottom: 2px
-  font-size: 12px
-  line-height: 18px
-
-#TableOfContents li a:hover
-  background-color: #eee
-  border-left-color: #234a61
-  text-decoration: none
+    a:hover
+      background-color: #eee
+      border-left-color: #234a61
+      text-decoration: none
 
 // Search
 form.search-full


### PR DESCRIPTION
As the styles imported for header and footer also affect the TOC, the fonts are too big currently.

This PR adjust the size to 14px and also arranges the Sass code hierarchically.

### Before

![image](https://user-images.githubusercontent.com/273727/106269713-26dcff80-622d-11eb-9cfb-58de72bb6c12.png)

### After

![image](https://user-images.githubusercontent.com/273727/106269815-512ebd00-622d-11eb-9572-51393795817d.png)
