### PR TITLE
Fix syntax highlighting in config

### DIFF
--- a/src/config.yaml
+++ b/src/config.yaml
@@ -14,12 +14,12 @@ markup:
   goldmark:
     renderer:
       unsafe: true
-    highlight:
-      codeFences: true
-      style: solarized-dark
-      guessSyntax: false
-      tabWidth: 4
-      lineNos: false
+  highlight:
+    codeFences: true
+    style: solarized-dark
+    guessSyntax: false
+    tabWidth: 4
+    lineNos: false
 
 menu:
   main:


### PR DESCRIPTION
I got the indentation wrong in https://github.com/giantswarm/docs/pull/767 which caused HUGO to ignore our highlighting settings