### PR TITLE
Include External DNS in Changes and Releases

### DIFF
--- a/scripts/aggregate-changelogs/config.yaml
+++ b/scripts/aggregate-changelogs/config.yaml
@@ -42,6 +42,8 @@ repositories:
     category: Managed Apps
   giantswarm/loki-app:
     category: Managed Apps
+  giantswarm/external-dns-app:
+    category: Managed Apps
 
   giantswarm/app-mesh-app:
     category: Playground Apps


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/132

In addition to being a managed preinstalled app, external dns can now be used as a managed optional app.