### PR TITLE
Update gsctl docs for spot instances on Azure

### DIFF
--- a/src/content/ui-api/gsctl/create-nodepool.md
+++ b/src/content/ui-api/gsctl/create-nodepool.md
@@ -67,7 +67,7 @@ $ gsctl create nodepool f01r4 \
     --azure-spot-instances
 ```
 
-Here is how you can set a maximum price that a single node pool VM instance can reach before it is deallocated:
+Here is how you can set a maximum hourly price in USD that a single node pool VM instance can reach before it is deallocated:
 
 ```nohighlight
 $ gsctl create nodepool f01r4 \

--- a/src/content/ui-api/gsctl/create-nodepool.md
+++ b/src/content/ui-api/gsctl/create-nodepool.md
@@ -42,7 +42,11 @@ $ gsctl create nodepool "Cluster name" \
     --nodes-max 20
 ```
 
-To request spot instances in your node pool, you have to set the percentage of worker nodes to be using spot instances via the `--aws-spot-percentage` flag. Optionally you can also define a number of workers that will be guaranteed to use on-demand instances, using the flag `--aws-on-demand-base-capacity`. Here is an example with 3 on-demand instances as a base capacity and 50 percent spot instances above that:
+### Spot instances
+
+#### AWS
+
+To request spot instances in your node pool on AWS, you have to set the percentage of worker nodes to be using spot instances via the `--aws-spot-percentage` flag. Optionally you can also define a number of workers that will be guaranteed to use on-demand instances, using the flag `--aws-on-demand-base-capacity`. Here is an example with 3 on-demand instances as a base capacity and 50 percent spot instances above that:
 
 ```nohighlight
 $ gsctl create nodepool "Cluster name" \
@@ -53,6 +57,27 @@ $ gsctl create nodepool "Cluster name" \
     --aws-spot-percentage 50
 ```
 
+#### Azure
+
+In order to use spot instances, specify the flag, like this:
+
+```nohighlight
+$ gsctl create nodepool f01r4 \
+    --name "Production" \
+    --azure-spot-instances
+```
+
+Here is how you can set a maximum price that a single node pool VM instance can reach before it is deallocated:
+
+```nohighlight
+$ gsctl create nodepool f01r4 \
+    --name "Production" \
+    --azure-spot-instances \
+    --azure-spot-instances-max-price 0.00315
+```
+
+By setting the `--azure-spot-instances-max-price` flag to '0', the maximum price will be set to the on-demand price of the instance.
+
 ### Options
 
 - `-n, --name`: Name or purpose description of the node pool. Defaults to "Unnamed node pool".
@@ -62,6 +87,8 @@ $ gsctl create nodepool "Cluster name" \
 - `--aws-on-demand-base-capacity`: Number of on-demand instances that this node pool needs to have until spot instances are used. Defaults to `0`.
 - `--aws-spot-percentage`: Percentage of spot instances used once the on-demand base capacity is fulfilled. A number of 40 would mean that 60% will be on-demand and 40% will be spot instances. Defaults to `0`.
 - `--aws-use-alike-instance-types`: Use similar instance type in your node pool. This list is maintained by Giant Swarm at the moment. Eg if you select m5.xlarge then the node pool can fall back on m4.xlarge too.
+- `--azure-spot-instances`: Whether the node pool must use spot instances or on-demand.
+- `--azure-spot-instances-max-price`: Max bid hourly price (in USD) for a single instance. `0` means on-demand price.
 - `--azure-vm-size`: VM Size to use for workers, e.g. `Standard_D4s_v3`.
 - `--nodes-min`: Minimum number of worker nodes for the node pool. Defaults to `3`.
 - `--nodes-max`: Maximum number of worker nodes for the node pool. Defaults to `10`.

--- a/src/content/ui-api/gsctl/list-nodepools.md
+++ b/src/content/ui-api/gsctl/list-nodepools.md
@@ -34,19 +34,20 @@ gsctl list nodepools "Cluster name"
 
 The result will be a table of all node pools of a specific cluster with the following details in columns:
 
-- `ID`:              Node pool identifier (unique within the cluster)
-- `NAME`:            Name specified for the node pool, usually indicating the purpose
-- `AZ`:              Availability zone letters used by the node pool, separated by comma
-- `INSTANCE TYPE`:   EC2 instance type used for worker nodes
-- `ALIKE`:           Whether similar instance types are used within this node pool (e. g. if `m5.xlarge` is defined also `m4.xlarge` is possible)
-- `ON-DEMAND-BASE`:  Number of on-demand instances that this node pool needs to have until spot instances are used
-- `SPOT-PERCENTAGE`: Percentage of spot instances used once the on-demand base capacity is fulfilled. A number of 40 would mean that 40% will be spot and 60% will be on-demand instances.
-- `NODES MIN/MAX`:   The minimum and maximum number of worker nodes in this pool
-- `NODES DESIRED`:   Current desired number of nodes as determined by the autoscaler
-- `NODES READY`:     Number of nodes that are in the Ready state in kubernetes
-- `SPOT INSTANCES`:  Number of nodes using spot instances
-- `CPUS`:            Sum of CPU cores in nodes that are in state Ready
-- `RAM (GB)`:        Sum of memory in GB of all nodes that are in state Ready
+- `ID`:                    Node pool identifier (unique within the cluster)
+- `NAME`:                  Name specified for the node pool, usually indicating the purpose
+- `AZ`:                    Availability zone letters used by the node pool, separated by comma
+- `INSTANCE TYPE`:         EC2 instance type used for worker nodes
+- `ALIKE`:                 Whether similar instance types are used within this node pool (e. g. if `m5.xlarge` is defined also `m4.xlarge` is possible)
+- `ON-DEMAND-BASE`:        Number of on-demand instances that this node pool needs to have until spot instances are used
+- `SPOT-PERCENTAGE`:       Percentage of spot instances used once the on-demand base capacity is fulfilled. A number of 40 would mean that 40% will be spot and 60% will be on-demand instances.
+- `NODES MIN/MAX`:         The minimum and maximum number of worker nodes in this pool
+- `NODES DESIRED`:         Current desired number of nodes as determined by the autoscaler
+- `NODES READY`:           Number of nodes that are in the Ready state in kubernetes
+- `SPOT INSTANCES`:        Whether spot instances are used or not.
+- `SPOT INSTANCES COUNT`:  Number of nodes using spot instances
+- `CPUS`:                  Sum of CPU cores in nodes that are in state Ready
+- `RAM (GB)`:              Sum of memory in GB of all nodes that are in state Ready
 
 ## Argument reference
 

--- a/src/content/ui-api/gsctl/show-nodepool.md
+++ b/src/content/ui-api/gsctl/show-nodepool.md
@@ -68,7 +68,9 @@ Description of output rows:
 - **Node scaling**:                        Current scaling setting of the node pool. When the lower and upper end of the scaling range are the same number, the pool size is "Pinned" at  certain number of worker nodes. Otherwise the node pool uses the Kubernetes autoscaler to set the amount of worker nodes within the configured range.
 - **Nodes desired**:                       The expected number of nodes. With auto-scaling active, this is the number determined by the autoscaler.
 - **Nodes in state Ready**:                The current number of worker nodes which are in state `Ready`.
-- **Spot instances**:                      The current number of worker nodes using spot instances.
+- **Spot instances**:                      Whether spot instances are used or not.
+- **Spot instances count**:                The current number of worker nodes using spot instances.
+- **Spot instances max price**:            The maximum price per hour (in USD) that a single node pool VM instance can reach before it is deallocated (0 means that the maximum price will be fixed to the on-demand price of the instance).
 - **CPUs**:                                The total number of CPU cores in this node pool.
 - **RAM**:                                 The total amount of memory in this node pool.
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/15310

This PR adds `gsctl` documentation for Spot instances on Azure