### PR TITLE
Added samples for Azure CAPI types

### DIFF
--- a/scripts/update-crd-reference/config.yaml
+++ b/scripts/update-crd-reference/config.yaml
@@ -15,3 +15,5 @@ skip_crds:
   - drainerconfigs.core.giantswarm.io
   - storageconfigs.core.giantswarm.io
   - etcdbackups.backup.giantswarm.io
+  - core.giantswarm.io_v1alpha1_azureclusterconfig
+  - provider.giantswarm.io_v1alpha1_azureconfig

--- a/src/content/ui-api/management-api/crd/azureclusters.infrastructure.cluster.x-k8s.io.md
+++ b/src/content/ui-api/management-api/crd/azureclusters.infrastructure.cluster.x-k8s.io.md
@@ -36,6 +36,53 @@ aliases:
 <h2 id="v1alpha3">Version v1alpha3</h2>
 
 
+<h3 id="crd-example-v1alpha1">Example CR</h3>
+
+```yaml
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+kind: AzureCluster
+metadata:
+  labels:
+    azure-operator.giantswarm.io/version: 5.3.1
+    cluster-operator.giantswarm.io/version: 0.23.22
+    cluster.x-k8s.io/cluster-name: mmh5x
+    giantswarm.io/cluster: mmh5x
+    giantswarm.io/organization: giantswarm
+    release.giantswarm.io/version: 14.1.0
+  name: mmh5x
+  namespace: org-giantswarm
+spec:
+  controlPlaneEndpoint:
+    host: api.mmh5x.k8s.ghost.westeurope.azure.gigantic.io
+    port: 443
+  location: westeurope
+  networkSpec:
+    apiServerLB:
+      frontendIPs:
+      - name: mmh5x-API-PublicLoadBalancer-Frontend
+      name: mmh5x-API-PublicLoadBalancer
+      sku: Standard
+      type: Public
+    subnets:
+    - cidrBlocks:
+      - 10.3.3.0/24
+      id: /subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/mmh5x/providers/Microsoft.Network/virtualNetworks/mmh5x-VirtualNetwork/subnets/w86vu
+      name: w86vu
+      role: node
+      routeTable: {}
+      securityGroup: {}
+    - name: mmh5x-VirtualNetwork-MasterSubnet
+      role: control-plane
+      routeTable: {}
+      securityGroup: {}
+    vnet:
+      cidrBlocks:
+      - 10.3.0.0/16
+      name: mmh5x-VirtualNetwork
+      resourceGroup: mmh5x
+  resourceGroup: mmh5x
+```
+
 
 <h3 id="property-details-v1alpha3">Properties</h3>
 

--- a/src/content/ui-api/management-api/crd/azuremachinepools.exp.infrastructure.cluster.x-k8s.io.md
+++ b/src/content/ui-api/management-api/crd/azuremachinepools.exp.infrastructure.cluster.x-k8s.io.md
@@ -35,6 +35,45 @@ aliases:
 <div class="crd-schema-version">
 <h2 id="v1alpha3">Version v1alpha3</h2>
 
+<h3 id="crd-example-v1alpha1">Example CR</h3>
+
+```yaml
+apiVersion: exp.infrastructure.cluster.x-k8s.io/v1alpha3
+kind: AzureMachinePool
+metadata:
+  labels:
+    azure-operator.giantswarm.io/version: 5.3.1
+    cluster.x-k8s.io/cluster-name: mmh5x
+    giantswarm.io/cluster: mmh5x
+    giantswarm.io/machine-pool: w86vu
+    giantswarm.io/organization: giantswarm
+    release.giantswarm.io/version: 14.1.0
+  name: w86vu
+  namespace: org-giantswarm
+spec:
+  identity: None
+  location: westeurope
+  providerID: azure:///subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/mmh5x/providers/Microsoft.Compute/virtualMachineScaleSets/nodepool-w86vu
+  providerIDList:
+    - azure:///subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/mmh5x/providers/Microsoft.Compute/virtualMachineScaleSets/nodepool-w86vu/virtualMachines/0
+    - azure:///subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/mmh5x/providers/Microsoft.Compute/virtualMachineScaleSets/nodepool-w86vu/virtualMachines/1
+    - azure:///subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/mmh5x/providers/Microsoft.Compute/virtualMachineScaleSets/nodepool-w86vu/virtualMachines/2
+  template:
+    dataDisks:
+      - diskSizeGB: 100
+        lun: 21
+        nameSuffix: docker
+      - diskSizeGB: 100
+        lun: 22
+        nameSuffix: kubelet
+    osDisk:
+      diskSizeGB: 0
+      managedDisk:
+        storageAccountType: Premium_LRS
+      osType: ""
+    sshPublicKey: ""
+    vmSize: Standard_D4s_v3
+```
 
 
 <h3 id="property-details-v1alpha3">Properties</h3>

--- a/src/content/ui-api/management-api/crd/azuremachines.infrastructure.cluster.x-k8s.io.md
+++ b/src/content/ui-api/management-api/crd/azuremachines.infrastructure.cluster.x-k8s.io.md
@@ -36,6 +36,43 @@ aliases:
 <h2 id="v1alpha3">Version v1alpha3</h2>
 
 
+<h3 id="crd-example-v1alpha1">Example CR</h3>
+
+```yaml
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+kind: AzureMachine
+metadata:
+  labels:
+    azure-operator.giantswarm.io/version: 5.3.1
+    cluster.x-k8s.io/cluster-name: mmh5x
+    cluster.x-k8s.io/control-plane: "true"
+    giantswarm.io/cluster: mmh5x
+    giantswarm.io/organization: giantswarm
+    release.giantswarm.io/version: 14.1.0
+  name: mmh5x-master-0
+  namespace: org-giantswarm
+spec:
+  availabilityZone: {}
+  failureDomain: "3"
+  identity: None
+  image:
+    marketplace:
+      offer: flatcar-container-linux-free
+      publisher: kinvolk
+      sku: stable
+      thirdPartyImage: false
+      version: 2345.3.1
+  location: westeurope
+  osDisk:
+    cachingType: ReadWrite
+    diskSizeGB: 50
+    managedDisk:
+      storageAccountType: Premium_LRS
+    osType: Linux
+  sshPublicKey: ""
+  vmSize: Standard_D4s_v3
+```
+
 
 <h3 id="property-details-v1alpha3">Properties</h3>
 


### PR DESCRIPTION
This PR adds 3 more CRD examples related to Azure CAPI CRDs.
It also disables publication of CRD documentation for the legacy Azure CRDs AzureConfig and AzureClusterConfig (the customer don't have access to those CRs anyway.

### Please remember to

- [X] Give the PR a meaningful title -- it will be shown in the release notes
- [X] Add (or remove) [user questions](https://github.com/giantswarm/docs/blob/master/CONTRIBUTING.md#front-matter) associated with any updated docs
