### PR TITLE
Remove -ti flag from docker run command in a script

### DIFF
--- a/scripts/update-crd-reference/main.sh
+++ b/scripts/update-crd-reference/main.sh
@@ -9,7 +9,7 @@ DESTINATION=src/content/ui-api/management-api/crd
 find ${DESTINATION} -type f -not -name "_index.md" | xargs rm
 
 # Determine apiextensions version
-VERSION=$(docker run --rm -ti --entrypoint /bin/sh quay.io/giantswarm/docs-scriptrunner -c "curl --silent https://api.github.com/repos/giantswarm/apiextensions/releases/latest|jq -r .tag_name|tr -d '\n'")
+VERSION=$(docker run --rm --entrypoint /bin/sh quay.io/giantswarm/docs-scriptrunner -c "curl --silent https://api.github.com/repos/giantswarm/apiextensions/releases/latest|jq -r .tag_name|tr -d '\n'")
 
 echo "Version: ${VERSION}"
 


### PR DESCRIPTION
... to enable running this script in Github actions. Currently this fails with `the input device is not a TTY`.

### Please remember to

- [x] Give the PR a meaningful title -- it will be shown in the release notes
- [ ] Add (or remove) [user questions](https://github.com/giantswarm/docs/blob/master/CONTRIBUTING.md#front-matter) associated with any updated docs
