### PR TITLE
Modify link to workload cluster release notes

### DIFF
--- a/src/content/general/releases/index.md
+++ b/src/content/general/releases/index.md
@@ -16,6 +16,7 @@ user_questions:
   - How long are workload cluster releases supported?
   - What does it mean when a workload cluster release is deprecated?
   - How soon does Giant Swarm provide new Kubernetes versions?
+  - How are workload cluster releases announced?
 aliases:
   - /reference/release-versions/
   - /reference/tenant-cluster-release-versions/
@@ -96,7 +97,7 @@ Once deprecated, you can still continue to use the workload cluster release with
 
 You have several options to inspect workload cluster release details:
 
-- All workload cluster releases are defined in code in the [giantswarm/releases](https://github.com/giantswarm/releases) GitHub repository. Here you also find comprehensive release notes.
+- We announce new workload cluster releases in your Slack support channel. There you will find a link to the according release notes in our [changes and releases]({{< relref "/changes" >}}) section here in the docs site. Here you also find comprehensive release notes.
 
 - In the [web UI]({{< relref "/ui-api/web/" >}}), the cluster overview and the cluster details page show the release version number of the workload cluster. In the cluster details page you can click the release version number to get more information about a workload cluster release. Additionally, the web UI will soon provide more ways to browse workload cluster releases and inspect changes between versions.
 

--- a/src/content/general/releases/index.md
+++ b/src/content/general/releases/index.md
@@ -97,7 +97,7 @@ Once deprecated, you can still continue to use the workload cluster release with
 
 You have several options to inspect workload cluster release details:
 
-- We announce new workload cluster releases in your Slack support channel. There you will find a link to the according release notes in our [changes and releases]({{< relref "/changes" >}}) section here in the docs site. Here you also find comprehensive release notes.
+- We announce new workload cluster releases in your Slack support channel. In each announcement, you will find a link to the corresponding release notes in our [changes and releases]({{< relref "/changes" >}}) section here on the docs site, where you also find comprehensive release notes.
 
 - In the [web UI]({{< relref "/ui-api/web/" >}}), the cluster overview and the cluster details page show the release version number of the workload cluster. In the cluster details page you can click the release version number to get more information about a workload cluster release. Additionally, the web UI will soon provide more ways to browse workload cluster releases and inspect changes between versions.
 


### PR DESCRIPTION
This PR modifies the link from https://docs.giantswarm.io/general/releases/#inspecting to detailed release notes, in order to point to the Changes and releases section in docs instead of the giantswarm/releases Github repo.

### Please remember to

- [x] Give the PR a meaningful title -- it will be shown in the release notes
- [x] Add (or remove) [user questions](https://github.com/giantswarm/docs/blob/master/CONTRIBUTING.md#front-matter) associated with any updated docs
