### PR TITLE
Remove mention of the "kgs" alias

### DIFF
--- a/src/content/ui-api/kubectl-gs/_index.md
+++ b/src/content/ui-api/kubectl-gs/_index.md
@@ -1,7 +1,7 @@
 ---
 linkTitle: kubectl gs
 title: kubectl gs plugin reference
-description: User manual for kubectl-gs (also known as kgs), the Giant Swarm kubectl plugin.
+description: User manual for kubectl gs, the Giant Swarm kubectl plugin.
 weight: 40
 menu:
   main:
@@ -17,7 +17,7 @@ owner:
 
 # `kubectl gs` plugin reference
 
-`kubectl gs`, also known as `kgs`, is a [kubectl](https://kubernetes.io/docs/reference/kubectl/kubectl/) plugin for the Giant Swarm [Management API]({{< relref "/ui-api/management-api" >}}).
+`kubectl gs` is a [kubectl](https://kubernetes.io/docs/reference/kubectl/kubectl/) plugin for the Giant Swarm [Management API]({{< relref "/ui-api/management-api" >}}).
 
 **Note that Management API access is currently in a preview stage.** Supported functionality depends on the provider and the workload cluster release used. Please pay attention to the compatibility information given on the individual command reference pages.
 
@@ -40,8 +40,7 @@ With [Krew](https://krew.sigs.k8s.io/) installed, here is a synopsis:
 
 ```nohighlight
 kubectl krew install gs
-alias kgs="kubectl gs"
-kgs
+kubectl gs
 ```
 
 Find out more details in our [installation docs]({{< relref "/ui-api/kubectl-gs/installation" >}}).

--- a/src/content/ui-api/kubectl-gs/get-clusters.md
+++ b/src/content/ui-api/kubectl-gs/get-clusters.md
@@ -17,8 +17,6 @@ user_questions:
 
 # `kubectl gs get clusters`
 
-{{% kgs_alias_assumption %}}
-
 Like with all `get` commands in `kubectl`, this command can be used to get details on one item, a cluster in this case, or list several of them.
 
 ## Usage
@@ -28,7 +26,7 @@ Like with all `get` commands in `kubectl`, this command can be used to get detai
 Simply execute
 
 ```nohighlight
-kgs get clusters
+kubectl gs get clusters
 ```
 
 to list some information on all clusters available to you in the current installation.
@@ -45,7 +43,7 @@ ID      CREATED                         CONDITION   RELEASE   ORGANIZATION   DES
 When used with a cluster ID as additional argument, the command will show details for a single cluster. Example:
 
 ```nohighlight
-kgs get clusters ab12c
+kubectl gs get clusters ab12c
 ```
 
 Note: As an alternative to `get clusters`, `get cluster` will also work.
@@ -68,11 +66,11 @@ The standard tabular output format features these columns:
 
 ## Flags {#flags}
 
-Here we document the flags that have a particular meaning for the `get clusters` command. Use `kgs get clusters --help` for a full list.
+Here we document the flags that have a particular meaning for the `get clusters` command. Use `kubectl gs get clusters --help` for a full list.
 
 ### `--output/-o` {#flags-output}
 
-`kubectl` commonly allows to specify the output format for all `get` subcommands. `kgs get clusters` is no different.
+`kubectl` commonly allows to specify the output format for all `get` subcommands. `kubectl gs get clusters` is no different.
 
 #### YAML output {#yaml}
 
@@ -81,13 +79,13 @@ To inspect a cluster's main custom resource in YAML notation, add the `--output 
 The following example command would print the main resource for cluster `ab12c`. It would return the [Cluster]({{< relref "/ui-api/management-api/crd/clusters.cluster.x-k8s.io.md" >}}) resource.
 
 ```nohighlight
-kgs get clusters ab12c --output yaml
+kubectl gs get clusters ab12c --output yaml
 ```
 
 When applied without a cluster ID argument, the output will be a list of resources. Example:
 
 ```nohighlight
-$ kgs get clusters --output yaml
+$ kubectl gs get clusters --output yaml
 apiVersion: v1
 kind: List
 items:

--- a/src/content/ui-api/kubectl-gs/get-nodepools.md
+++ b/src/content/ui-api/kubectl-gs/get-nodepools.md
@@ -17,8 +17,6 @@ user_questions:
 
 # `kubectl gs get nodepools`
 
-{{% kgs_alias_assumption %}}
-
 Like with all `get` commands in `kubectl`, this command can be used to get details on one item, a node pool in this case, or list several of them.
 
 ## Usage
@@ -28,7 +26,7 @@ Like with all `get` commands in `kubectl`, this command can be used to get detai
 Simply execute
 
 ```nohighlight
-kgs get nodepools
+kubectl gs get nodepools
 ```
 
 to list some information on all node pools available to you in the current installation.
@@ -45,7 +43,7 @@ ab12c   s921a        2021-01-02 15:04:32 +0000 UTC   READY       3/10           
 When used with a node pool ID as additional argument, the command will show details for a single node pool. Example:
 
 ```nohighlight
-kgs get nodepool ab12c
+kubectl gs get nodepool ab12c
 ```
 
 Note: As an alternative to `get nodepools`, `get nodepool` will also work.
@@ -65,7 +63,7 @@ The standard tabular output format features these columns:
 
 ## Flags {#flags}
 
-Here we document the flags that have a particular meaning for the `get nodepools` command. Use `kgs get nodepools --help` for a full list.
+Here we document the flags that have a particular meaning for the `get nodepools` command. Use `kubectl gs get nodepools --help` for a full list.
 
 ### `--cluster-id/-c` {#flags-output}
 
@@ -73,8 +71,8 @@ If present, list the node pools that belong to this given workload cluster.
 
 ### `--output/-o` {#flags-output}
 
-`kubectl` commonly allows to specify the output format for all `get` subcommands. `kgs get nodepools` is no different.
-Similar to other `get` subcommands, you can specify the output format of `kgs get nodepools` using the `--output` flag.
+`kubectl` commonly allows to specify the output format for all `get` subcommands. `kubectl gs get nodepools` is no different.
+Similar to other `get` subcommands, you can specify the output format of `kubectl gs get nodepools` using the `--output` flag.
 
 #### YAML output {#yaml}
 
@@ -83,13 +81,13 @@ To inspect a node pool's main custom resource in YAML notation, add the `--outpu
 The following example command would print the main resource for node pool `ab12c`. On AWS that would be the [MachineDeployment]({{< relref "/ui-api/management-api/crd/machinedeployments.cluster.x-k8s.io.md" >}}) resource printed. On Azure, it would return the [MachinePool]({{< relref "/ui-api/management-api/crd/machinepools.exp.cluster.x-k8s.io.md" >}}) resource.
 
 ```nohighlight
-kgs get nodepool ab12c --output yaml
+kubectl gs get nodepool ab12c --output yaml
 ```
 
 When applied without a node pool ID argument, the output will be a list of resources. Example:
 
 ```nohighlight
-$ kgs get nodepools --output yaml
+$ kubectl gs get nodepools --output yaml
 apiVersion: v1
 kind: List
 items:

--- a/src/content/ui-api/kubectl-gs/installation.md
+++ b/src/content/ui-api/kubectl-gs/installation.md
@@ -1,7 +1,7 @@
 ---
 linkTitle: Installation
 title: kubectl gs installation
-description: How to obtain kubectl gs, the Giant Swarm kubectl plugin (aka 'kgs') and how to keep it up to date.
+description: How to obtain kubectl gs, the Giant Swarm kubectl plugin and how to keep it up to date.
 weight: 10
 menu:
   main:
@@ -14,8 +14,8 @@ user_questions:
   - Where can I find the Giant Swarm plugin for kubectl?
   - How can I install the Giant Swarm plugin for kubectl?
   - How can I keep the Giant Swarm plugin for kubectl up to date?
-  - What is kgs?
-  - How can I install kgs?
+  - What is kubectl gs?
+  - How can I install kubectl gs?
 ---
 
 # Installing the kubcetl gs plugin
@@ -36,18 +36,10 @@ To install the `gs` plug-in, simply execute this command:
 kubectl krew install gs
 ```
 
-We highly recommend to set up the `kgs` shorthand as well:
-
-```nohighlight
-alias kgs="kubectl gs"
-```
-
-(Best add this to your shell profile or config file.)
-
 Lastly, let's check that the plug-in is working as it's supposed to.
 
 ```nohighlight
-kgs
+kubectl gs
 ```
 
 You should see information regarding the commands available.
@@ -65,8 +57,7 @@ The platform-agnostic description:
 1. Download the [latest release](https://github.com/giantswarm/kubectl-gs/releases/latest) archive for your platform
 2. Unpack the archive
 3. Copy the executable to a location included in your `$PATH`
-4. Create an alias `kgs` for `kubectl gs`
-5. Check if it's working by executing `kgs`
+4. Check if it's working by executing `kubectl gs`
 
 ### Linux
 
@@ -83,11 +74,8 @@ tar xzf kubectl-gs-${VERSION}-linux-amd64.tar.gz
 # Copy to a dir in $PATH
 cp kubectl-gs-${VERSION}-linux-amd64/kubectl-gs /usr/local/bin/
 
-# Set up alias
-alias kgs="kubectl gs"
-
 # Check
-kgs
+kubectl gs
 ```
 
 ### Mac OS
@@ -105,9 +93,6 @@ tar xzf kubectl-gs-${VERSION}-darwin-amd64.tar.gz
 # Copy to a dir in $PATH
 cp kubectl-gs-${VERSION}-darwin-amd64/kubectl-gs /usr/local/bin/
 
-# Set up alias
-alias kgs="kubectl gs"
-
 # Check
-kgs
+kubectl gs
 ```

--- a/src/content/ui-api/kubectl-gs/login.md
+++ b/src/content/ui-api/kubectl-gs/login.md
@@ -17,8 +17,6 @@ user_questions:
 
 # `kubectl gs login`
 
-{{% kgs_alias_assumption %}}
-
 This command allows to ensure an authenticated kubectl context is selected.
 
 ## Usage

--- a/src/content/ui-api/kubectl-gs/template-app.md
+++ b/src/content/ui-api/kubectl-gs/template-app.md
@@ -14,15 +14,13 @@ owner:
 
 # `kubectl gs template app`
 
-{{% kgs_alias_assumption %}}
-
 In order to create an App using custom resources, `kubectl gs` will help you create manifests for the resource type:
 
 - [App]({{< relref "/ui-api/management-api/crd/apps.application.giantswarm.io.md" >}}) (API group/version `application.giantswarm.io/v1alpha1`) - holds the base App specification.
 
 ## Usage
 
-The command to execute is `kgs template app`.
+The command to execute is `kubectl gs template app`.
 
 It supports the following flags:
 
@@ -35,7 +33,7 @@ It supports the following flags:
 The example command
 
 ```nohighlight
-kgs template app \
+kubectl gs template app \
   --catalog pipo-catalog \
   --name my-app \
   --namespace default \

--- a/src/content/ui-api/kubectl-gs/template-appcatalog.md
+++ b/src/content/ui-api/kubectl-gs/template-appcatalog.md
@@ -14,8 +14,6 @@ owner:
 
 # `kubectl gs template appcatalog`
 
-{{% kgs_alias_assumption %}}
-
 In order to create an [App Catalog]({{< relref "/app-platform" >}}) using custom resources, `kubectl-gs` will help you create manifests for the resource type:
 
 - [`AppCatalog`]({{< relref "/ui-api/management-api/crd/appcatalogs.application.giantswarm.io.md" >}}) (API group/version `application.giantswarm.io/v1alpha1`) - holds the base AppCatalog specification.

--- a/src/content/ui-api/kubectl-gs/template-cluster.md
+++ b/src/content/ui-api/kubectl-gs/template-cluster.md
@@ -16,8 +16,6 @@ user_questions:
 
 # `kubectl gs template cluster`
 
-{{% kgs_alias_assumption %}}
-
 This command helps with creating a cluster by producing a manifest based on user input. This manifest can then optionally be modified and finally be applied to the Management API to create a cluster.
 
 The outcome depends on the provider, set via the `--provider` flag:
@@ -71,7 +69,7 @@ It supports the following flags:
 Example command for an AWS cluster:
 
 ```nohighlight
-kgs template cluster \
+kubectl gs template cluster \
   --provider aws
   --master-az eu-central-1a \
   --external-snat true \

--- a/src/content/ui-api/kubectl-gs/template-nodepool.md
+++ b/src/content/ui-api/kubectl-gs/template-nodepool.md
@@ -16,8 +16,6 @@ user_questions:
 
 # `kubectl gs template nodepool`
 
-{{% kgs_alias_assumption %}}
-
 Node pools are groups of worker nodes sharing common configuration. In terms of custom resources they consist of custom resources of type
 
 The outcome depends on the provider, set via the `--provider` flag:
@@ -38,7 +36,7 @@ For Azure (`--provider azure`):
 To create the manifests for a new node pool, use this command:
 
 ```nohighlight
-kgs template nodepool
+kubectl gs template nodepool
 ```
 
 Here are the supported flags:
@@ -63,7 +61,7 @@ Here are the supported flags:
 ## Example
 
 ```nohighlight
-kgs template nodepool \
+kubectl gs template nodepool \
   --provider aws \
   --cluster-id a1b2c \
   --nodepool-name "General purpose" \

--- a/src/layouts/shortcodes/kgs_alias_assumption.html
+++ b/src/layouts/shortcodes/kgs_alias_assumption.html
@@ -1,1 +1,0 @@
-<div class="well"><i class="fa fa-shell"></i> We assume that you have the alias <code>kgs</code> set up for the command <code>kubectl gs</code>.</div>


### PR DESCRIPTION
We got feedback that it feels strange that we try to push using a specific alias on users, especially as it may clash with other aliases the user has set up already. Example: `k` for `kubectl`, resulting in a quite handy `k gs` command.

This PR removes all recommendations regarding the alias and simply leaves it to the user to decide how to invoke the tool.