### PR TITLE
Remove ranking function by 'published' field to bring back hits from docs

### DIFF
--- a/src/assets/scripts/base.js
+++ b/src/assets/scripts/base.js
@@ -71,15 +71,6 @@ function doSearch(q) {
           {
             "filter": {"term": {"breadcrumb_1": "blog"}},
             "weight": 0.8
-          },
-          // Blog posts rank lower the older they are
-          {
-            "linear": {
-              "published": {
-                "scale": "100d",
-                "decay": 0.2
-              }
-            }
           }
         ]
       }


### PR DESCRIPTION
This PR removes a ranking function that intended to rank down older blog posts, using the `published` field. This caused a failure in search, because the docs index (in contrast to the blog index) does not carry the `published` field.

As a consequence, no results from `docs` would show up.

### Please remember to

- [x] Give the PR a meaningful title -- it will be shown in the release notes
- [ ] Add (or remove) [user questions](https://github.com/giantswarm/docs/blob/master/CONTRIBUTING.md#front-matter) associated with any updated docs
