### PR TITLE
Link to VPN reference from provider architecture pages

### DIFF
--- a/src/content/general/architcture/aws/index.md
+++ b/src/content/general/architcture/aws/index.md
@@ -122,3 +122,4 @@ Please note, while this document went into extensive details with regards to how
 
 - [Giant Swarm support model]({{< relref "/general/support" >}})
 - [Giant Swarm operational layers]({{< relref "/security/operational-layers" >}})
+- [Giant Swarm VPN and secure cluster access]({{< relref "/security/cluster-access" >}})

--- a/src/content/general/architcture/azure/index.md
+++ b/src/content/general/architcture/azure/index.md
@@ -115,3 +115,4 @@ Please note, while this document went into extensive details with regards to how
 - [Giant Swarm support model]({{< relref "/general/support" >}})
 - [Giant Swarm operational layers]({{< relref "/security/operational-layers" >}})
 - [Giant Swarm App Catalog]({{< relref "/app-platform" >}})
+- [Giant Swarm VPN and secure cluster access]({{< relref "/security/cluster-access" >}})

--- a/src/content/general/architcture/on-premises/index.md
+++ b/src/content/general/architcture/on-premises/index.md
@@ -6,7 +6,7 @@ weight: 30
 menu:
   main:
     parent: general-architecture
-last_review_date: 2021-01-28
+last_review_date: 2021-05-05
 user_questions:
   - Do you run on bare metal?
   - Can you run on virtual machines (e.g. VMWare)?

--- a/src/content/general/architcture/on-premises/index.md
+++ b/src/content/general/architcture/on-premises/index.md
@@ -24,31 +24,31 @@ owner:
 
 # The Giant Swarm on-premises architecture
 
-Giant Swarm's architecture is split into two logical parts. One describes the management cluster and the other describes one or more workload clusters. We prefer running on bare metal machines, but can also work with virtualized infrastructure (e.g. VMWare) in case nested virtualization is possible.
+Giant Swarm's architecture is split into two logical parts. One describes the management cluster and the other describes one or more workload clusters. We prefer running on bare metal machines, but can also work with virtualized infrastructure (e.g. VMWare) in cases where nested virtualization is possible.
 
-We require VPN and SSH access to all machines, as well as outbound Internet connectivity from the machines (this can be limited to specific targets), to download images of various forms to automatically build and update the cluster. All machines are to be configured with one PXE Boot network and a production network (separate VLANs). The machines will be started by us via an ILO-Interface, to boot from the PXE Boot Server in the network for bootstrap, and then restarted into the production network.
+We require VPN and SSH access to all machines, as well as outbound Internet connectivity from the machines (this can be limited to specific targets), to download images of various forms to automatically provision and update the cluster. All machines are to be configured with one PXE Boot network and a production network (separate VLANs). The machines will be started by us via an ILO-Interface, to boot from the PXE Boot Server in the network for bootstrap, and then restarted into the production network.
 
 ## Giant Swarm on-premises management cluster
 
 ![On-premises Control Plane architecture](architecture-onprem-control-plane.png)
 
-Think of the management cluster as the Giant Swarm team’s Kubernetes cluster. The worker nodes are where your workload clusters will end up on, controlled by our [kvm-operator](https://github.com/giantswarm/kvm-operator/) running inside the management cluster. The diagram above shows our proof-of-concept setup. As such it keeps the management cluster (including monitoring) on 3 machines. Based on the number and sizes of workload clusters, we recommend having distinct monitoring machines once we go into production. We further recommend having at least 5 worker machines. Any additional machines will also be set up as worker nodes and made available for workload clusters to be used by end users.
+Think of the management cluster as the Giant Swarm team’s Kubernetes cluster. The worker nodes of this cluster are where your workload clusters will be run. Workload cluster nodes are deployed as separate virtual machine instances and controlled by our [kvm-operator](https://github.com/giantswarm/kvm-operator/) running inside the management cluster. The diagram above shows the conceptual setup. Depending on the node's available resources, in most environments, the management cluster components (including monitoring) fit on 3 or fewer machines. Based on the number and sizes of workload clusters, our management cluster adapts accordingly and will deploy or remove monitoring or management components as needed. As a matter of best practice, we recommend having at least 5 worker machines to host your workload clusters. Any additional machines will also be set up as worker nodes and made available for workload clusters to be used by end users.
 
-We access all machines, as well as the Kubernetes API of the management cluster, through VPN (and optionally via a bastion host). We connect your load balancer for access to the Giant Swarm REST API, our Web User Interface, and our Monitoring, optionally adding your Identity Management System for authentication. Traffic towards all workload clusters is routed via the management cluster first, as it knows where exactly all the workload clusters are at any point in time.
+We access all machines, as well as the Kubernetes API of the management cluster, through VPN (and optionally via a bastion host). Your load balancer is configured to allow access to the Giant Swarm REST API, our Web User Interface, and our monitoring components, optionally adding your Identity Management System for authentication. Traffic towards all workload clusters is routed via the management cluster first, as it knows exactly where all the workload clusters are at any point in time.
 
 ## Giant Swarm on-premises workload cluster
 
 ![On-premises workload cluster architecture](architecture-onprem-tenant-cluster.png)
 
-Using the Giant Swarm REST API, our [CLI](https://github.com/giantswarm/gsctl), or our Web UI, you can start workload clusters of different sizes. You choose the amount of vCores and RAM you want per Node of your workload cluster and click “Create Cluster”. Moments later your cluster will be ready to use. It will be running on the worker nodes of the management cluster, within KVM VMs networked together through a Flannel network. Each workload cluster is separated from the other workload clusters by a Flannel VXLAN bridge. Inside of that bridge, the containers are networked with Calico BGP.
+Using the Giant Swarm REST API, our [CLI](https://github.com/giantswarm/gsctl), or our Web UI, you can start workload clusters of different sizes. You choose the amount of vCores and RAM you want per Node of your workload cluster and click “Create Cluster”. Moments later your cluster will be ready to use. It will be running on the worker nodes of the management cluster, within KVM VMs networked together through a Flannel network. Each workload cluster is separated from the other workload clusters by a Flannel VXLAN bridge. Inside of that bridge, containers are networked with Calico BGP.
 
-Access to the Kubernetes API goes through the management cluster. We can connect your load balancer for Ingress access. This load balancer can be either statically configured with health checks or controlled via an API. Depending on the data center setup, there are different options that need to be evaluated.
+Access to the Kubernetes API goes through the management cluster. We can connect your load balancer for Ingress access. This load balancer can be either statically configured with health checks or controlled via an API. Depending on the data center setup, there may be multiple options which our engineers will evaluate with your infrastructure team.
 
 ## Service architecture
 
 ![Service Architecture](architecture-onprem-services.png)
 
-To make your life easier, we have developed a lot of different services within our management cluster that allow both our operations team and you as users of our API and interfaces to easily manage Kubernetes clusters. Most of these services should be self explanatory.
+To make your life easier, we have developed numerous automated services within our management cluster that allow both our operations team and you as a user to easily manage your Kubernetes clusters. Most of these services should be self explanatory.
 
 We have three main parts:
 
@@ -57,3 +57,7 @@ We have three main parts:
 * Workload clusters running your application workloads
 
 All of these are geared towards enabling you to run multiple projects independently and consistently in your data centers.
+
+## Further Reading
+
+- [Giant Swarm VPN and secure cluster access]({{< relref "/security/cluster-access" >}})

--- a/src/content/general/architcture/on-premises/index.md
+++ b/src/content/general/architcture/on-premises/index.md
@@ -60,4 +60,4 @@ All of these are geared towards enabling you to run multiple projects independen
 
 ## Further Reading
 
-- [Giant Swarm VPN and secure cluster access]({{< relref "/security/cluster-access" >}})
+* [Giant Swarm VPN and secure cluster access]({{< relref "/security/cluster-access" >}})


### PR DESCRIPTION
Fixes https://github.com/giantswarm/giantswarm/issues/16745

Adds a link to the VPN description to each provider architecture page, as requested by a customer. Also includes a little revision for the on-premises page.

### Please remember to

- [x] Give the PR a meaningful title -- it will be shown in the release notes
- [x] Add (or remove) [user questions](https://github.com/giantswarm/docs/blob/master/CONTRIBUTING.md#front-matter) associated with any updated docs
