### PR TITLE
Add giantswarm/dashboards repo and Dashboards category to changes and releases

### DIFF
--- a/scripts/aggregate-changelogs/config.yaml
+++ b/scripts/aggregate-changelogs/config.yaml
@@ -22,6 +22,8 @@ repositories:
     category: Managed Apps
   giantswarm/cert-manager-app:
     category: Managed Apps
+  giantswarm/dashboards:
+    category: Dashboards
   giantswarm/docs:
     category: Documentation
   giantswarm/efk-stack-app:
@@ -103,6 +105,8 @@ repositories:
 categories:
   - name: Management API
     color: "#b47fb0"
+  - name: Dashboards
+    color: "#e461a9"
   - name: Documentation
     color: "#9aa48e"
   - name: gsctl


### PR DESCRIPTION
This PR adds the giantswarm/dashboards repo to the aggregated changes page in https://docs.giantswarm.io/changes/

Currently there are no releases yet, but as soon as they are, they will be picked up by our automation.