### PR TITLE
Add Monitoring page to menu

### DIFF
--- a/src/content/ui-api/monitoring/index.md
+++ b/src/content/ui-api/monitoring/index.md
@@ -2,6 +2,11 @@
 linkTitle: Monitoring
 title: Monitoring and dashboards
 description: Giant Swarm runs a monitoring stack in each installation, comprising Prometheus, Grafana, and more. Learn how to get access to the data we collect.
+menu:
+  main:
+    identifier: uiapi-monitoring
+    parent: ui-api
+weight: 50
 last_review_date: 2021-06-28
 user_questions:
   - How can I access Grafana for my installation?

--- a/src/content/ui-api/rest-api/index.md
+++ b/src/content/ui-api/rest-api/index.md
@@ -4,7 +4,7 @@ title: The Giant Swarm REST API
 description: An overview of the APIs that provide you with programmatic access to
   resources like your workload clusters in a Giant Swarm installation. Namely the Rest
   API and the Management API.
-weight: 50
+weight: 60
 menu:
   main:
     parent: ui-api


### PR DESCRIPTION
This adds the new "Monitoring and dashboards" page to the menu, which I forgot when creating it