### PR TITLE
Naming update for Azure spot virtual machines (VMs)

### DIFF
--- a/src/content/advanced/node-pools/index.md
+++ b/src/content/advanced/node-pools/index.md
@@ -143,9 +143,9 @@ See the [`gsctl delete nodepool`]({{< relref "/ui-api/gsctl/delete-nodepool" >}}
 
 ## On-demand and spot instances {#on-demand-spot}
 
-As of workload cluster release v{{% first_aws_spotinstances_version %}} for AWS, node pools can contain a mix of [on-demand](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-on-demand-instances.html) and [spot instances](https://aws.amazon.com/ec2/spot/) that will allow you to optimize your cost.
+As of workload cluster release v{{% first_aws_spotinstances_version %}} for AWS and v{{% first_azure_spotinstances_version %}} for Azure, node pools can contain a mix of [on-demand](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-on-demand-instances.html) and [spot instances/VMs](https://aws.amazon.com/ec2/spot/) that will allow you to optimize your cost.
 
-[Here]({{< relref "/advanced/spot-instances" >}}) you can find more detailed information on using Spot Instances in AWS clusters.
+Please check our dedicated [section on spot instances/VMs]({{< relref "/advanced/spot-instances" >}}) to learn more about using them in your clusters.
 
 ## Using similar instance types {#similar-instance-types}
 

--- a/src/content/advanced/spot-instances/_index.md
+++ b/src/content/advanced/spot-instances/_index.md
@@ -9,6 +9,9 @@ menu:
     parent: advanced
 aliases:
   - /basics/spot-instances/
+owner:
+  - https://github.com/orgs/giantswarm/teams/team-celestial
+  - https://github.com/orgs/giantswarm/teams/team-firecracker
 ---
 
 {{< platform_support_table aws="ga=v11.2.0" azure="ga=v14.1.0" >}}

--- a/src/content/advanced/spot-instances/_index.md
+++ b/src/content/advanced/spot-instances/_index.md
@@ -1,7 +1,7 @@
 ---
-linkTitle: Spot instances
-title: Spot instances and spot VMs
-description: Spot instances (also called low-priority VMs on Azure) are a simple way to save on compute cost, if your use case permits it. Here you find documentation for using them with Giant Swarm Kubernetes clusters, both on AWS and Microsoft Azure.
+linkTitle: Spot instances/VMs
+title: Spot instances and spot virtual machines
+description: AWS spot instances and Azure spot virtual machines are a simple way to save on compute cost, if your use case permits it. Here you find documentation for using them with Giant Swarm Kubernetes clusters.
 weight: 40
 menu:
   main:

--- a/src/content/advanced/spot-instances/aws/_index.md
+++ b/src/content/advanced/spot-instances/aws/_index.md
@@ -10,3 +10,5 @@ menu:
 owner:
   - https://github.com/orgs/giantswarm/teams/team-firecracker
 ---
+
+{{< platform_support_table aws="ga=v11.2.0" >}}

--- a/src/content/advanced/spot-instances/aws/ondemand-fallback/index.md
+++ b/src/content/advanced/spot-instances/aws/ondemand-fallback/index.md
@@ -17,6 +17,8 @@ owner:
 
 # Using on-demand instances as fall-back when spot instances are unavailable
 
+{{< platform_support_table aws="ga=v11.2.0" >}}
+
 As of workload cluster release v{{% first_aws_spotinstances_version %}} for AWS, node pools can use [spot instances]({{< relref "/advanced/spot-instances/aws/overview  " >}}). Users can select for each node pool which percentage of nodes should be covered by spot instances and by on-demand instances respectively. And users can define a base amount of on-demand instances that will be used, to ensure at least a certain amount of worker nodes are available at any time.
 
 However, it is still possible that the node pool is in need of more worker nodes and there are just no spot instances available matching the request, based on the availability zone and the instance type(s). In this case the node pool cannot be scaled up. As a result, workloads will likely remain unscheduled.

--- a/src/content/advanced/spot-instances/aws/overview/index.md
+++ b/src/content/advanced/spot-instances/aws/overview/index.md
@@ -7,6 +7,10 @@ menu:
   main:
     identifier: advanced-spotinstances-aws-overview
     parent: advanced-spotinstances-aws
+user_questions:
+  - How can I use EC2 spot instances in my clusters?
+  - As of which release are AWS EC2 spot instances supported?
+  - What's the difference between spot instances and on-demand instances on AWS?
 owner:
   - https://github.com/orgs/giantswarm/teams/team-firecracker
 ---

--- a/src/content/advanced/spot-instances/aws/overview/index.md
+++ b/src/content/advanced/spot-instances/aws/overview/index.md
@@ -13,6 +13,8 @@ owner:
 
 # Overview on spot instances on AWS
 
+{{< platform_support_table aws="ga=v11.2.0" >}}
+
 ## Introduction
 
 As of workload cluster release v{{% first_aws_spotinstances_version %}} for AWS, it is possible to use spot instances in clusters that will allow you to optimize your cost.

--- a/src/content/advanced/spot-instances/azure/_index.md
+++ b/src/content/advanced/spot-instances/azure/_index.md
@@ -10,3 +10,5 @@ menu:
 owner:
   - https://github.com/orgs/giantswarm/teams/team-celestial
 ---
+
+{{< platform_support_table azure="ga=v14.1.0" >}}

--- a/src/content/advanced/spot-instances/azure/_index.md
+++ b/src/content/advanced/spot-instances/azure/_index.md
@@ -1,7 +1,7 @@
 ---
 linkTitle: Azure
-title: Spot instances on Azure
-description: Documentation for using spot instances (also known as low-priority VMs) with Kubernetes clusters on Microsoft Azure.
+title: Spot virtual machines on Azure
+description: Documentation for using spot virtual machines or spot VMs with Kubernetes clusters on Microsoft Azure.
 weight: 20
 menu:
   main:

--- a/src/content/advanced/spot-instances/azure/ondemand-fallback/index.md
+++ b/src/content/advanced/spot-instances/azure/ondemand-fallback/index.md
@@ -1,29 +1,31 @@
 ---
 linkTitle: Using on-demand as fall-back
-title: Using on-demand instances as fall-back when spot instances are unavailable on Azure
-description: When using spot instances in a node pool on Azure, it can happen that the node pool cannot be scaled up as not enough spot instances are available. This guide shows you how to configure cluster-autoscaler in a way to provide on-demand instances as a back-up automatically.
+title: Using on-demand VMs as fall-back when spot VMs are unavailable on Azure
+description: When using spot VMs in a node pool on Azure, it can happen that the node pool cannot be scaled up as not enough spot VMs are available. This guide shows you how to configure cluster-autoscaler in a way to provide on-demand VMs as a back-up automatically.
 weight: 30
 menu:
   main:
     identifier: advanced-spotinstances-azure-ondemandfallback
     parent: advanced-spotinstances-azure
 user_questions:
-  - How can I use VM spot instances and fall back to on-demand if no spot instances are available?
+  - How can I use Azure spot VMs and fall back to on-demand if spot is unavailable?
 aliases:
   - /advanced/spot-instances/azure/on-demand-fallback/
 owner:
   - https://github.com/orgs/giantswarm/teams/team-celestial
 ---
 
-# Using on-demand instances as fall-back when spot instances are unavailable
+# Using on-demand VMs as fall-back when spot VMs are unavailable on Azure
 
-As of workload cluster release v{{% first_azure_spotinstances_version %}} for Azure, node pools can use [spot instances]({{< relref "/advanced/spot-instances/azure/overview" >}}). Users can select for each node pool whether nodes should be covered by spot instances or by on-demand instances respectively. It is also possible to create a node pool with a dynamic price going up to the price of standard VMs.
+{{< platform_support_table azure="ga=v14.1.0" >}}
 
-However, it is still possible that the node pool is in need of more worker nodes and there are just no spot instances available matching the request, based on the availability zone and the instance type(s). In this case the node pool cannot be scaled up. As a result, workloads will likely remain unscheduled.
+As of workload cluster release v{{% first_azure_spotinstances_version %}} for Azure, node pools can use [spot virtual machines]({{< relref "/advanced/spot-instances/azure/overview" >}}) (VMs). Users can select for each node pool whether nodes should be covered by spot VMs or by on-demand VMs respectively. It is also possible to create a node pool with a dynamic price going up to the price of standard VMs.
+
+However, it is still possible that the node pool is in need of more worker nodes and there are just no spot VMs available matching the request, based on the availability zone and the VM size(s). In this case the node pool cannot be scaled up. As a result, workloads will likely remain unscheduled.
 
 To ensure enough capacity in a cluster, this guide presents a solution where
 
-- two node pools exist: one configured to only use spot instances, the other one to only use on-demand instances.
+- two node pools exist: one configured to only use spot VMs, the other one to only use on-demand VMs.
 - cluster-autoscaler is configured to scale up the spot node pool first, and only if that fails, scale up the on-demand node pool.
 
 Credit where credit is due: this solution has been proposed [in a blog post by Nir Forer](https://blog.doit-intl.com/running-eks-workloads-on-spot-instances-with-on-demand-instances-fallback-14bef39ce689). We adapt it here to match exactly the situation of Giant Swarm workload clusters on Azure.
@@ -37,13 +39,13 @@ First, create a cluster with at least version 14.1.x for the purpose of this tut
 Next, create two node pools.
 
 1. Name: Spot,
-   Enable spot instances: yes,
+   Enable spot VMs: yes,
    Spot maximum price per hour: set your value for max price or use current on-demand pricing as max,
    Scaling range: min=1
 
 2. Name: On-Demand,
-   Instance type: the same as selected for the "Spot" node pool,
-   Enable spot instances: no,
+   VM size: the same as selected for the "Spot" node pool,
+   Enable spot VMs: no,
    Scaling range: min=1
 
 If it is important to you that the nodes in both node pools run in the same availability zone(s), you have to select the matching zones manually for each node pool.

--- a/src/content/advanced/spot-instances/azure/overview/index.md
+++ b/src/content/advanced/spot-instances/azure/overview/index.md
@@ -7,6 +7,11 @@ menu:
   main:
     identifier: advanced-spotinstances-azure-overview
     parent: advanced-spotinstances-azure
+user_questions:
+  - How can I use Azure spot VMs in my clusters?
+  - How can I use Azure spot virtual machines in my clusters?
+  - As of which release are Azure spot VMs supported?
+  - What's the difference between spot VMs and on-demand VMs on Azure?
 owner:
   - https://github.com/orgs/giantswarm/teams/team-celestial
 ---

--- a/src/content/advanced/spot-instances/azure/overview/index.md
+++ b/src/content/advanced/spot-instances/azure/overview/index.md
@@ -1,6 +1,6 @@
 ---
 linkTitle: Overview
-title: Overview on spot instances on Azure
+title: Overview on spot virtual machines on Azure
 description: A general description of spot instances, it's benefits, usage and differences from on-demand instance types.
 weight: 10
 menu:
@@ -11,26 +11,28 @@ owner:
   - https://github.com/orgs/giantswarm/teams/team-celestial
 ---
 
-# Overview on spot instances on Azure
+# Overview on spot VMs on Azure
+
+{{< platform_support_table azure="ga=v14.1.0" >}}
 
 ## Introduction
 
-As of workload cluster release v{{% first_azure_spotinstances_version %}} for Azure, it is possible to use spot virtual machines in clusters that will allow you to optimize your cost.
+As of workload cluster release v{{% first_azure_spotinstances_version %}} for Azure, it is possible to use spot virtual machines (VMs) in clusters that will allow you to optimize your cost.
 
-The main differences between spot and on-demand instances are that spot instances can be terminated any time by Microsoft Azure. They are also more frequently unavailable.
+The main differences between spot and on-demand VMs are that spot VMs can be terminated any time by Microsoft Azure. They are also more frequently unavailable.
 
 By default at Giant Swarm you can create node pool with spot VMs that will be dynamically billed up to the max price of the on-demand VMs. This is the generic [Azure feature](https://docs.microsoft.com/en-us/azure/virtual-machines/spot-vms#pricing) and the value is set as `-1` by default at creation for the max price.
 
-Instead of default behaviour you can also set the hourly max price for a spot instance which is determined by Azure through a bidding system. The resulting price varies over time and is usually much lower than the cost of the same instance type when booked as on-demand instance.
+Instead of default behavior you can also set the hourly max price for a spot VM which is determined by Azure through a bidding system. The resulting price varies over time and is usually much lower than the cost of the same VM size when booked as on-demand VM.
 
-On Azure it is not supported to have mixed node pools having on-demand and spot instances at the same time.
+On Azure it is not supported to have mixed node pools having on-demand and spot VMs at the same time.
 
-## Notes on using spot instances
+## Notes on using spot VMs
 
-Since the availability of spot instances is volatile, there are a few things you can consider:
+Since the availability of spot VMs is volatile, there are a few things you can consider:
 
-- The more availability zones you cover with your node pool, the higher the likelihood that spot instances are available when required.
-- When no spot instances are available, missing spot instances are _not_ replaced by on-demand instances. The affected node pool will fail in deployment on Azure, probably leaving some pods unscheduled. For a solution to this, check our guide on [using on-demand instances as fall-back when spot instances are unavailable]({{< relref "/advanced/spot-instances/azure/ondemand-fallback" >}}).
-- It is not possible to change the defined max price for existing Node Pool, if there is a need for a lower price, it has to be recreated.
-- To optimize your costs further, you can add reservations for spot VMs via the portal same as for on-demand machines.
-- Before first deployment of spot instances, please remember to increase the quotas for spot virtual machines for the given subscription.
+- The more availability zones you cover with your node pool, the higher the likelihood that spot VMs are available when required.
+- When no spot VMs are available, missing spot VMs are _not_ replaced by on-demand VMs. The affected node pool will fail in deployment on Azure, probably leaving some pods unscheduled. For a solution to this, check our guide on [using on-demand VMs as fall-back when spot VMs are unavailable]({{< relref "/advanced/spot-instances/azure/ondemand-fallback" >}}).
+- It is not possible to change the defined max price for an existing Node Pool. If you want to lower the price limit, please create a new node pool.
+- To optimize your costs further, you can add reservations for spot VMs via the portal, just as for on-demand VMs.
+- Before the first deployment of spot VMs, please remember to increase the quotas for spot virtual machines for the given subscription.


### PR DESCRIPTION
Microsoft has aligned their own communication now to use the term "spot VMs" or "spot virtual machine(s)" consistently.

Since we want to use the provider's terminology where we make provider functionality available, we change the naming from "spot instances" to "spot VMs" / "spot virtual machines" consistently in docs and UIs.

Note: the upstream docs now also clarify that the term "low priority VM" was the name for a feature that has been phased out meanwhile.

![image](https://user-images.githubusercontent.com/273727/124910948-7a2d5800-dfec-11eb-876c-ab73d88eae6c.png)

Source: https://azure.microsoft.com/en-us/services/virtual-machines/spot/#faq

In addition, the platform support table is added to the provider-specific sub pages.