### PR TITLE
Add missing flags explanation for the `kubectl gs template nodepool` command

### DIFF
--- a/src/content/reference/similar-ec2-instance-types/index.md
+++ b/src/content/reference/similar-ec2-instance-types/index.md
@@ -14,6 +14,8 @@ owner:
 
 # Similar EC2 Instance Types
 
+{{< platform_support_table aws="ga=11.2.0" >}}
+
 ## Introduction
 
 Handling of similar instance types is done in [aws-operator](https://github.com/giantswarm/aws-operator) since version 8.3.1, which has been introduced with workload cluster release v{{% first_aws_spotinstances_version %}} for AWS.

--- a/src/content/ui-api/kubectl-gs/template-nodepool.md
+++ b/src/content/ui-api/kubectl-gs/template-nodepool.md
@@ -8,6 +8,7 @@ menu:
     parent: uiapi-kubectlgs
 aliases:
   - /reference/kubectl-gs/template-nodepool/
+last_review_date: 2021-07-08
 owner:
   - https://github.com/orgs/giantswarm/teams/sig-ux
 user_questions:
@@ -47,11 +48,16 @@ Here are the supported flags:
 - `--nodepool-name` - node pool name or purpose description of the node pool. (default *Unnamed node pool*)
 - `--nodes-max` - maximum number of worker nodes for the node pool. (default 10)
 - `--nodes-min` - minimum number of worker nodes for the node pool. (default 3)
+- `--output` - Sets a file path to write the output to. If not set, standard output will be used.
 - `--owner` - organization, owning workload cluster. Must be configured with existing organization in installation.
 
 ### AWS specific
 
-- `--aws-instance-type`- EC2 instance type to use for workers, e. g. *m5.2xlarge*. (default *m5.xlarge*)
+- `--aws-instance-type` - EC2 instance type to use for workers, e. g. *m5.2xlarge*. (default *m5.xlarge*)
+- `--use-alike-instance-types` - Enables the use of instance types similar to the one specified via `--aws-instance-type` (default: false). This can increase the likelihood of getting the required instances, especially when requesting spot instances. See [our reference]({{< relref "/reference/similar-ec2-instance-types" >}}) for details.
+- `--on-demand-percentage-above-base-capacity` - To use only on-demand instances, set this to 100. For any other value, the remainder to 100 will be filled with spot instances. For example, 50 will create a node pool that is half spot and half on-demand instances. 0 (zero) will use only spot instances. See [our AWS spot instances docs]({{< relref "/advanced/spot-instances/aws" >}}) for more information.
+- `--on-demand-base-capacity` - Can be used to set a fixed number of on-demand instances, regardless of the percentage (see above) of spot vs. on-demand to be used otherwise.
+- `--machine-deployment-subnet`: Size of the IPv4 subnet to reserve for the node pool. Must be a number between 20 and 28. For example, 24 stands for a /24 subnet with 256 addresses. Check the [`alpha.aws.giantswarm.io/aws-subnet-size`]({{< relref "/ui-api/management-api/crd/awsmachinedeployments.infrastructure.giantswarm.io.md#v1alpha2-alpha.aws.giantswarm.io/aws-subnet-size" >}}) annotation for details.
 
 ### Azure specific
 


### PR DESCRIPTION
Docs for `kubectl gs template nodepool` where missing some flags. This PR adds them.