### PR TITLE
Hide CAPV CRDs to shorten the list of CRDs

### DIFF
--- a/scripts/update-crd-reference/config.yaml
+++ b/scripts/update-crd-reference/config.yaml
@@ -17,3 +17,7 @@ skip_crds:
   - azureclusterconfigs.core.giantswarm.io
   - azureconfigs.provider.giantswarm.io
   - azuretools.tooling.giantswarm.io
+  - vsphereclusters.infrastructure.cluster.x-k8s.io
+  - vspheremachines.infrastructure.cluster.x-k8s.io
+  - vspheremachinetemplates.infrastructure.cluster.x-k8s.io
+  - vspherevms.infrastructure.cluster.x-k8s.io


### PR DESCRIPTION
CAPI/VMWare related CRDs are not yet relevant, so we are hiding them from the CRD docs.
