### PR TITLE
remove 30 day upgrade goal

### DIFF
--- a/src/content/general/releases/index.md
+++ b/src/content/general/releases/index.md
@@ -79,8 +79,6 @@ We use patch releases to publish bug fixes, security fixes, or to make changes t
 
 For every provider, we maintain **two different major versions** of workload cluster releases at the same time, which means that you have two different Kubernetes minor versions to chose from.
 
-Whenever a new Kubernetes minor version is released by the Kubernetes project, we aim to make that version available in a new major workload cluster release within 30 days.
-
 With our development of **new functionality** we focus on our latest major version. The older major version is mostly maintained to fix security issues and stability problems.
 
 Old workload cluster release get [deprecated](#deprecation) when replaced by newer ones. After deprecation, and once no longer in use by any customer, a workload cluster release gets archived, which means that it is no longer accessible to you.


### PR DESCRIPTION
This is by now far less important than it used to be and customers have not been very keen on it either. Also re https://github.com/giantswarm/giantswarm/issues/18078 we do not have this as a goal these days and have not adhered to it either.