### PR TITLE
Add topic label to catalogs.application.giantswarm.io CRD

### DIFF
--- a/src/data/crd_metadata.yaml
+++ b/src/data/crd_metadata.yaml
@@ -67,6 +67,9 @@ azuremachines.infrastructure.cluster.x-k8s.io:
 azuretools.tooling.giantswarm.io:
   provider:
     - azure
+catalogs.application.giantswarm.io:
+  topics:
+    - apps
 certconfigs.core.giantswarm.io:
   topics:
     - managementcluster


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/18019

This PR adds the `apps` label, to make it easier to understand what the CRD is used for, and to allow for selection by topic in the future.

Before

![image](https://user-images.githubusercontent.com/273727/125926387-e281fffc-edc5-49f4-b8af-26c3f5292f87.png)

After

![image](https://user-images.githubusercontent.com/273727/125926590-6a41c47d-7201-4569-8c5d-07b504cd3044.png)
