### PR TITLE
Hide AWSConfig and AWSClusterConfig CRDs

### DIFF
--- a/scripts/update-crd-reference/config.yaml
+++ b/scripts/update-crd-reference/config.yaml
@@ -4,6 +4,8 @@ source_repository:
   organization: giantswarm
   short_name: apiextensions
 skip_crds:
+  - awsclusterconfigs.core.giantswarm.io
+  - awsconfigs.provider.giantswarm.io
   - chartconfigs.core.giantswarm.io
   - clusters.core.giantswarm.io
   - draughtsmanconfigs.core.giantswarm.io

--- a/src/data/crd_metadata.yaml
+++ b/src/data/crd_metadata.yaml
@@ -14,17 +14,7 @@ appcatalogentries.application.giantswarm.io:
 apps.application.giantswarm.io:
   topics:
     - apps
-awsclusterconfigs.core.giantswarm.io:
-  provider:
-    - aws
-  topics:
-    - workloadcluster
 awsclusters.infrastructure.giantswarm.io:
-  provider:
-    - aws
-  topics:
-    - workloadcluster
-awsconfigs.provider.giantswarm.io:
   provider:
     - aws
   topics:


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/18019

Since these CRDs are only used in clusters before AWS release v10, they can be removed from docs now.