### PR TITLE
Fix link to replacement CRD in dprecated CRD details page

### DIFF
--- a/scripts/update-crd-reference/crd.template
+++ b/scripts/update-crd-reference/crd.template
@@ -65,7 +65,7 @@ source_repository_ref: {{ .SourceRepositoryRef }}
 {{ . }}
 {{- end }}
 {{- with .ReplacedBy }}
-This CRD is being replaced by <a href="/ui-api/management-api/crd/{{ .FullName }}.md">{{ .ShortName }}</a>.
+This CRD is being replaced by <a href="../{{ .FullName }}/">{{ .ShortName }}</a>.
 {{- end }}
 </p>
 {{- end }}

--- a/src/content/ui-api/management-api/crd/appcatalogs.application.giantswarm.io.md
+++ b/src/content/ui-api/management-api/crd/appcatalogs.application.giantswarm.io.md
@@ -34,7 +34,7 @@ source_repository_ref: v3.27.3
 # AppCatalog
 <p class="well disclaimer">
 <i class="fa fa-warning"></i> <b>Deprecation:</b>
-This CRD is being replaced by <a href="/ui-api/management-api/crd/catalogs.application.giantswarm.io.md">Catalog</a>.
+This CRD is being replaced by <a href="../catalogs.application.giantswarm.io/">Catalog</a>.
 </p>
 
 


### PR DESCRIPTION
If a deprecated CRD points to a replacement CRD, the link was broken. This is fixed in this PR.