### PR TITLE
Document namespaceConfig flags for gs template app command

### DIFF
--- a/src/content/ui-api/kubectl-gs/template-app.md
+++ b/src/content/ui-api/kubectl-gs/template-app.md
@@ -13,6 +13,7 @@ owner:
   - https://github.com/orgs/giantswarm/teams/team-batman
 user_questions:
   - How can I create an app manifest for the Management API?
+  - How can I add labels and annotations to the target namespace of an app?
 ---
 
 # `kubectl gs template app`
@@ -67,6 +68,8 @@ It also supports the following optional flags:
 - `--defaulting-enabled`: Only include fields that differ from the default value (default true). When false, a much longer template is created.
 - `--user-configmap`: Path to the user values configmap YAML file.
 - `--user-secret`: Path to the user secrets YAML file.
+- `--namespace-annotations`: Additional annotations to be appended to the target namespace's metadata in form `key=value`. To specify multiple annotations, either separate annotation pairs with commata (,) or specify the flag multiple times.
+- `--namespace-labels`: Additional labels to be appended to the target namespace's metadata in form `key=value`. To specify multiple labels, either separate label pairs with commata (,) or specify the flag multiple times.
 
 Only required fields are templated. Other fields are are set by the
 [defaulting webhook]({{< relref "/app-platform/defaulting-validation" >}}).

--- a/src/content/ui-api/kubectl-gs/template-app.md
+++ b/src/content/ui-api/kubectl-gs/template-app.md
@@ -68,8 +68,8 @@ It also supports the following optional flags:
 - `--defaulting-enabled`: Only include fields that differ from the default value (default true). When false, a much longer template is created.
 - `--user-configmap`: Path to the user values configmap YAML file.
 - `--user-secret`: Path to the user secrets YAML file.
-- `--namespace-annotations`: Additional annotations to be appended to the target namespace's metadata in form `key=value`. To specify multiple annotations, either separate annotation pairs with commata (,) or specify the flag multiple times.
-- `--namespace-labels`: Additional labels to be appended to the target namespace's metadata in form `key=value`. To specify multiple labels, either separate label pairs with commata (,) or specify the flag multiple times.
+- `--namespace-annotations`: Additional annotations to be appended to the target namespace's metadata ([`spec.namespaceConfig.annotations`]({{< relref "/app-platform/namespace-configuration/index.md" >}})) in form `key=value`. To specify multiple annotations, either separate annotation pairs with commata (,) or specify the flag multiple times.
+- `--namespace-labels`: Additional labels to be appended to the target namespace's metadata ([`spec.namespaceConfig.labels`]({{< relref "/app-platform/namespace-configuration/index.md" >}})) in form `key=value` through . To specify multiple labels, either separate label pairs with commata (,) or specify the flag multiple times.
 
 Only required fields are templated. Other fields are are set by the
 [defaulting webhook]({{< relref "/app-platform/defaulting-validation" >}}).

--- a/src/content/ui-api/kubectl-gs/template-app.md
+++ b/src/content/ui-api/kubectl-gs/template-app.md
@@ -68,8 +68,8 @@ It also supports the following optional flags:
 - `--defaulting-enabled`: Only include fields that differ from the default value (default true). When false, a much longer template is created.
 - `--user-configmap`: Path to the user values configmap YAML file.
 - `--user-secret`: Path to the user secrets YAML file.
-- `--namespace-annotations`: Additional annotations to be appended to the target namespace's metadata ([`spec.namespaceConfig.annotations`]({{< relref "/app-platform/namespace-configuration/index.md" >}})) in form `key=value`. To specify multiple annotations, either separate annotation pairs with commata (,) or specify the flag multiple times.
-- `--namespace-labels`: Additional labels to be appended to the target namespace's metadata ([`spec.namespaceConfig.labels`]({{< relref "/app-platform/namespace-configuration/index.md" >}})) in form `key=value` through . To specify multiple labels, either separate label pairs with commata (,) or specify the flag multiple times.
+- `--namespace-annotations`: Additional annotations to be appended to the metadata of the target namespace (through [`spec.namespaceConfig.annotations`]({{< relref "/app-platform/namespace-configuration/index.md" >}}) of [App]({{< relref "/ui-api/management-api/crd/apps.application.giantswarm.io.md" >}}) CR) in form `key=value`. To specify multiple annotations, either separate annotation pairs with commata (,) or specify the flag multiple times.
+- `--namespace-labels`: Additional labels to be appended to the metadata of the target namespace (through [`spec.namespaceConfig.labels`]({{< relref "/app-platform/namespace-configuration/index.md" >}}) of [App]({{< relref "/ui-api/management-api/crd/apps.application.giantswarm.io.md" >}}) CR) in form `key=value`. To specify multiple labels, either separate label pairs with commata (,) or specify the flag multiple times.
 
 Only required fields are templated. Other fields are are set by the
 [defaulting webhook]({{< relref "/app-platform/defaulting-validation" >}}).


### PR DESCRIPTION
This PR adds documentation to upcoming changes to `gs template app` flags.

We want to allow users to specify an `App` CRs `namespaceConfig` through flags. The `kubectl-gs` code changes will be merged before merging this PR.