### PR TITLE
Fixes limitation reason on dashboards page

### DIFF
--- a/src/content/ui-api/monitoring/index.md
+++ b/src/content/ui-api/monitoring/index.md
@@ -68,4 +68,4 @@ You can easily track changes in that repository directly from the Home dashboard
 
 ## Limitations
 
-Grafana access is currently not available in shared installations, where several customer's metrics are collected using the same Prometheus instance.
+Grafana access is currently not available in shared installations, where several customer's metrics would be available from the same Grafana instance.


### PR DESCRIPTION
We don't limit grafana access on shared installations because the same Prometheus instance would collect several customer's metrics - as we have one Prometheus server per cluster, one Prometheus instance can't collect metrics for several customers.

The limitation is more that multiple customers metrics would be available from the Grafana instance, which we want to avoid.

### Please remember to

- [x] Give the PR a meaningful title -- it will be shown in the release notes
- [x] Add (or remove) [user questions](https://github.com/giantswarm/docs/blob/master/CONTRIBUTING.md#front-matter) associated with any updated docs
