### PR TITLE
Update config.yaml to change Linkerd to Managed Apps (from Playground Apps)

### DIFF
--- a/scripts/aggregate-changelogs/config.yaml
+++ b/scripts/aggregate-changelogs/config.yaml
@@ -83,9 +83,9 @@ repositories:
   giantswarm/kubernetes-gpu:
     category: Playground Apps
   giantswarm/linkerd2-app:
-    category: Playground Apps
+    category: Managed Apps
   giantswarm/linkerd2-cni-app:
-    category: Playground Apps  
+    category: Managed Apps 
   giantswarm/loki-stack-app:
     category: Playground Apps
   giantswarm/opencensus-collector-app:


### PR DESCRIPTION
Linkerd is currently categorized as Playground Apps in Docs Changes and Releases: https://docs.giantswarm.io/changes/playground-apps/

This PR changes it to Managed Apps: https://docs.giantswarm.io/changes/managed-apps/

Copying @piontec and @ubergesundheit for visibility.