### PR TITLE
Turn off funky syntax highlighting

### DIFF
--- a/src/content/advanced/labelling-workload-clusters/index.md
+++ b/src/content/advanced/labelling-workload-clusters/index.md
@@ -103,7 +103,7 @@ The newly created cluster will be managed by your team in your upstate office an
 
 You've decided on using label keys `my-org/team` and `my-org/environment` to specify the clusters designation.
 
-```json
+```nohighlight
 PUT /v5/clusters/7g4di/labels/
 {
   "labels": {
@@ -115,7 +115,7 @@ PUT /v5/clusters/7g4di/labels/
 
 Another cluster from earlier is also managed by your team in the upstate office but is being used for production.
 
-```json
+```nohighlight
 PUT /v5/clusters/g8s2o/labels/
 {
   "labels": {
@@ -127,7 +127,7 @@ PUT /v5/clusters/g8s2o/labels/
 
 From this point on it is possible to select the clusters by label values or label key existence.
 
-```json
+```nohighlight
 POST /v5/clusters/by_label/
 {
   "labels": "my-org/team=upstate"


### PR DESCRIPTION
Here, the JSON syntax highlighting created a funky effect:

![image](https://user-images.githubusercontent.com/273727/128709724-f6b0eb2c-5be5-4490-9951-6cea6c0fb75f.png)

I'm applying `nohighlight` here to turn that off.