### PR TITLE
Fix namespace flag position in kubectl gs get apps

### DIFF
--- a/src/content/app-platform/getting-started/index.md
+++ b/src/content/app-platform/getting-started/index.md
@@ -148,7 +148,7 @@ allows installing multiple instances of an app.
 Now lets check the app using the `kubectl gs get app` command.
 
 ```nohighlight
-kubectl -n ${CLUSTER} gs get app nginx-ingress-controller-app -o yaml
+kubectl gs -n ${CLUSTER} get app nginx-ingress-controller-app -o yaml
 ```
 
 The labels, cluster config and kubeconfig have been all defaulted to the correct


### PR DESCRIPTION
### Please remember to

- [x] Give the PR a meaningful title -- it will be shown in the release notes
- [ ] Add (or remove) [user questions](https://github.com/giantswarm/docs/blob/master/CONTRIBUTING.md#front-matter) associated with any updated docs
