### PR TITLE
Add 'make validate-last-reviewed'

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install dependencies
-        run: pip3 install colored
+        run: pip3 install click colored
 
       - name: Validate front matter for changed files
         run: |

--- a/Makefile
+++ b/Makefile
@@ -54,12 +54,22 @@ lint:
 		--ignore ./src/content/ui-api/management-api/crd \
 		./src
 
+# Validate front matter in all pages.
 validate-front-matter:
 	docker run --rm \
 	  --volume=${PWD}:/workdir:ro \
 	  -w /workdir \
 	  quay.io/giantswarm/docs-scriptrunner:latest \
 	  /workdir/scripts/validate-front-matter/script.py
+
+# Print a report of pages with a last_review_date that's
+# too long ago.
+validate-last-reviewed:
+	docker run --rm \
+	  --volume=${PWD}:/workdir:ro \
+	  -w /workdir \
+	  quay.io/giantswarm/docs-scriptrunner:latest \
+	  /workdir/scripts/validate-front-matter/script.py --validation last-reviewed
 
 docker-build: update-latest-versions
 	docker build -t $(REGISTRY)/$(COMPANY)/$(PROJECT):latest .


### PR DESCRIPTION
Towards establishing a process for periodic content updates (https://github.com/giantswarm/giantswarm/issues/18329)

This PR adds a target `make validate-last-reviewed` which can be executed manually to create a report of pages which have a `last_review_date` that's longer than one year ago.

Technically, this uses the front matter validation script, but skipping all validations except for the last_review_date check.

Preview:

![image](https://user-images.githubusercontent.com/273727/129028762-e086303d-c339-47d2-b9d6-92990736e916.png)
