### PR TITLE
Update `gsctl scale cluster` docs article to be KVM only

### DIFF
--- a/src/content/ui-api/gsctl/_index.md
+++ b/src/content/ui-api/gsctl/_index.md
@@ -52,7 +52,7 @@ Follow the links below for a detailed documentation, where available. You can al
 | `login`                               | [Sign in as a user](login/)
 | `logout`                              | Sign out
 | `ping`                                | Check API connection
-| `scale cluster`                       | [Add or remove worker nodes of a cluster](scale-cluster/)
+| `scale cluster`                       | [Add or remove worker nodes of a KVM cluster](scale-cluster/)
 | `select endpoint`                     | [Select an endpoint](select-endpoint/)
 | `show cluster`                        | [Show cluster details](show-cluster/)
 | `show nodepool`                       | [Show node pool details](show-nodepool/)

--- a/src/content/ui-api/gsctl/scale-cluster.md
+++ b/src/content/ui-api/gsctl/scale-cluster.md
@@ -1,7 +1,7 @@
 ---
 linkTitle: scale cluster
 title: "'gsctl scale cluster' command reference"
-description: "The 'gsctl scale cluster' command allows to add or remove worker nodes to reach a desired number."
+description: "The 'gsctl scale cluster' command allows to add or remove worker nodes to an on-premises cluster (KVM)."
 weight: 180
 menu:
   main:
@@ -11,25 +11,19 @@ aliases:
 owner:
   - https://github.com/orgs/giantswarm/teams/sig-ux
 user_questions:
-  - How can I scale a cluster using gsctl?
-last_review_date: 2021-01-01
+  - How can I scale an on-premises (KVM) cluster using gsctl?
+last_review_date: 2021-08-13
 ---
 
 # `gsctl scale cluster`
 
-The `gsctl scale cluster` command allows you to influence the cluster size, i. e. the number of worker nodes.
-For an [autoscaling cluster]({{< relref "/kubernetes/cluster-size-autoscaling" >}}), the command allows to modify the scaling limits for the autoscaler.
+The `gsctl scale cluster` command allows to specify the number of worker nodes for an on-premises (KVM) cluster.
 
-As of now, all worker nodes in a cluster share the same configuraition.
-So any nodes added to the cluster will be of the same kind as the existing ones.
+For clusters on AWS and Azure, instead of scaling an entire cluster, please see [`gsctl update nodepool`]({{< relref "/ui-api/gsctl/update-nodepool" >}}) regarding how to scale a node pool.
 
 ## Notes on worker node removal {#node-removal}
 
-When reducing the worker node count, either manually or via the autoscaler, you have no influence in which exact order worker nodes are removed. Your workloads have to be configured in a way that single pods can be removed any time. See our [Recommendations and Best Practices]({{< relref "/kubernetes/best-practices" >}}) article for details on how to achieve that.
-
-For AWS, the Auto Scaling Group's logic determines which workers are removed. We use the [default termination policy](https://docs.aws.amazon.com/autoscaling/ec2/userguide/as-instance-termination.html#default-termination-policy). In brief, this policy will remove the oldest workers first. If all workers have the same age, the workers to be removed will be selected at random.
-
-On Azure, the virtual machine scale set (VMSS) behaviour is responsible for the termination order. Here, VMs with the highest IDs are removed first.
+When reducing the worker node count, you have no influence in which exact order worker nodes are removed. Your workloads have to be configured in a way that single pods can be removed any time. See our article on [recommendations and best practices]({{< relref "/kubernetes/best-practices" >}}) for details on how to achieve that.
 
 ## Command usage {#usage}
 
@@ -45,41 +39,25 @@ You can also use the cluster's name for identifying the cluster:
 gsctl scale cluster "Cluster name" --num-workers 5
 ```
 
-Where **autoscaling** is available, you can specify a range within which the autoscaler can scale the number of worker nodes.
-
-Note that autoscaling is currently available on AWS in workload cluster release v{{% first_aws_autoscaling_version %}} or newer.
-
-Example:
-
-```nohighlight
-gsctl scale cluster f01r4 --workers-min 5 --workers-max 20
-```
-
-To adjust only one side of the autoscaling range, e. g. the upper one, and leave the minimum worker node count untouched, do this:
-
-```nohighlight
-gsctl scale cluster f01r4 --workers-max 20
-```
-
-After the command has been executed, it can take a couple of minutes until the worker node count has adapted to the new settings.
+After the command has been executed, it can take a few minutes until the worker node count has adapted to the new settings.
 
 ## Confirmation
 
-If the command execution will result in the removal of worker nodes, you will have to confirm the scaling in an interactive prompt.
+When reducing the number of worker nodes, you will have to confirm the command execution in an interactive prompt.
 This prompt can be suppressed using the `--force` flag.
 
 When adding worker nodes, no such confirmation is required.
 
 ## Full argument reference {#arguments}
 
-- `-w`, `--num-workers`: Shorthand to set `--workers-min` and `--workers-max` to the same value. Note that where autoscaling is available, this effectively disables autoscaling.
-- `--workers-min`, `--workers-max`: Minimum and maximum number of worker nodes. For autoscaling clusters (available on AWS since workload cluster release v{{% first_aws_autoscaling_version %}}) this specifies the range within the autoscaler can scale the number of worker nodes. For workload cluster releases not supporting autoscaling, both values must be set to the same number.
+- `-w`, `--num-workers`: The intended number of worker nodes.
 - `--force`: If set, no confirmation is required when reducing the number of workers. You should only use this argument in automations when you are sure that reducing the number of workers is desired.
 
 Use `gsctl scale cluster --help` for a additional (global) arguments.
 
 ## Related
 
+- [`gsctl update nodepool`]({{< relref "/ui-api/gsctl/update-nodepool" >}}): Among others, allows to scale a node pool
 - [`gsctl delete cluster`]({{< relref "/ui-api/gsctl/delete-cluster" >}}): Delete a cluster
 - [Basics: Cluster Size and Autoscaling]({{< relref "/kubernetes/cluster-size-autoscaling" >}})
 - [API: Modify cluster](/api/#operation/modifyCluster)


### PR DESCRIPTION
The `gsctl scale cluster` command docs still contained a lot of explanation that's no longer relevant.

Now that there are almost only clusters with node pools on AWS and Azure, the command does not apply any more on these providers. The command is effectively only usable on KVM now.

I also added a pointer to the right command to use for AWS and Azure (`gsctl update nodepool`).