### PR TITLE
Set ownership of articles to team-rainbow

### DIFF
--- a/src/content/ui-api/gsctl/_index.md
+++ b/src/content/ui-api/gsctl/_index.md
@@ -21,7 +21,7 @@ user_questions:
 - Are there known bugs and limitations for gsctl?
 - What are the command line flags of gsctl?
 owner:
-  - https://github.com/orgs/giantswarm/teams/sig-ux
+  - https://github.com/orgs/giantswarm/teams/team-rainbow
 last_review_date: 2021-01-01
 ---
 

--- a/src/content/ui-api/gsctl/cluster-definition.md
+++ b/src/content/ui-api/gsctl/cluster-definition.md
@@ -18,7 +18,7 @@ user_questions:
   - Will my cluster definition change if I use node pools?
 last_review_date: 2021-01-01
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-biscuit
+  - https://github.com/orgs/giantswarm/teams/team-rainbow
 ---
 
 # Cluster definition reference

--- a/src/content/ui-api/gsctl/configuration-file.md
+++ b/src/content/ui-api/gsctl/configuration-file.md
@@ -9,7 +9,7 @@ menu:
 aliases:
   - /reference/gsctl/configuration-file/
 owner:
-  - https://github.com/orgs/giantswarm/teams/sig-ux
+  - https://github.com/orgs/giantswarm/teams/team-rainbow
 user_questions:
   - What settings does gsctl store in its config file?
   - Where can I find gsctl's configuration file?

--- a/src/content/ui-api/gsctl/create-cluster.md
+++ b/src/content/ui-api/gsctl/create-cluster.md
@@ -13,7 +13,7 @@ user_questions:
 aliases:
   - /reference/gsctl/create-cluster/
 owner:
-  - https://github.com/orgs/giantswarm/teams/sig-ux
+  - https://github.com/orgs/giantswarm/teams/team-rainbow
 last_review_date: 2021-01-01
 ---
 

--- a/src/content/ui-api/gsctl/create-keypair.md
+++ b/src/content/ui-api/gsctl/create-keypair.md
@@ -9,7 +9,7 @@ menu:
 aliases:
   - /reference/gsctl/create-keypair/
 owner:
-  - https://github.com/orgs/giantswarm/teams/sig-ux
+  - https://github.com/orgs/giantswarm/teams/team-rainbow
 user_questions:
   - How can I create a key pair for cluster access with gsctl?
 last_review_date: 2021-01-01

--- a/src/content/ui-api/gsctl/create-kubeconfig.md
+++ b/src/content/ui-api/gsctl/create-kubeconfig.md
@@ -13,7 +13,7 @@ user_questions:
   - How to gain access to a cluster using gsctl?
   - How can I configure kubie?
 owner:
-  - https://github.com/orgs/giantswarm/teams/sig-ux
+  - https://github.com/orgs/giantswarm/teams/team-rainbow
 last_review_date: 2021-01-01
 ---
 

--- a/src/content/ui-api/gsctl/create-nodepool.md
+++ b/src/content/ui-api/gsctl/create-nodepool.md
@@ -9,7 +9,7 @@ menu:
 aliases:
   - /reference/gsctl/create-nodepool/
 owner:
-  - https://github.com/orgs/giantswarm/teams/sig-ux
+  - https://github.com/orgs/giantswarm/teams/team-rainbow
 user_questions:
   - How can I create a node pool with gsctl?
 last_review_date: 2021-01-01

--- a/src/content/ui-api/gsctl/delete-cluster.md
+++ b/src/content/ui-api/gsctl/delete-cluster.md
@@ -9,7 +9,7 @@ menu:
 aliases:
   - /reference/gsctl/delete-cluster/
 owner:
-  - https://github.com/orgs/giantswarm/teams/sig-ux
+  - https://github.com/orgs/giantswarm/teams/team-rainbow
 user_questions:
   - How can I delete a cluster using gsctl?
 last_review_date: 2021-01-01

--- a/src/content/ui-api/gsctl/delete-endpoint.md
+++ b/src/content/ui-api/gsctl/delete-endpoint.md
@@ -9,7 +9,7 @@ menu:
 aliases:
   - /reference/gsctl/delete-endpoint/
 owner:
-  - https://github.com/orgs/giantswarm/teams/sig-ux
+  - https://github.com/orgs/giantswarm/teams/team-rainbow
 user_questions:
   - How can I delete an endpoint from gsctl?
   - How can I delete an installation from gsctl?

--- a/src/content/ui-api/gsctl/delete-nodepool.md
+++ b/src/content/ui-api/gsctl/delete-nodepool.md
@@ -9,7 +9,7 @@ menu:
 aliases:
   - /reference/gsctl/delete-nodepool/
 owner:
-  - https://github.com/orgs/giantswarm/teams/sig-ux
+  - https://github.com/orgs/giantswarm/teams/team-rainbow
 user_questions:
   - How can I delete a node pool using gsctl?
 last_review_date: 2021-01-01

--- a/src/content/ui-api/gsctl/global-options.md
+++ b/src/content/ui-api/gsctl/global-options.md
@@ -9,7 +9,7 @@ menu:
 aliases:
   - /reference/gsctl/global-options/
 owner:
-  - https://github.com/orgs/giantswarm/teams/sig-ux
+  - https://github.com/orgs/giantswarm/teams/team-rainbow
 user_questions:
   - What options/flags does gsctl offer for all commands?
   - How can I customize the gsctl configuration directory?

--- a/src/content/ui-api/gsctl/info.md
+++ b/src/content/ui-api/gsctl/info.md
@@ -9,7 +9,7 @@ menu:
 aliases:
   - /reference/gsctl/info/
 owner:
-  - https://github.com/orgs/giantswarm/teams/sig-ux
+  - https://github.com/orgs/giantswarm/teams/team-rainbow
 user_questions:
   - How can I find out my gsctl version?
   - How can I find out my current API endpoint used in gsctl?

--- a/src/content/ui-api/gsctl/list-clusters.md
+++ b/src/content/ui-api/gsctl/list-clusters.md
@@ -9,7 +9,7 @@ menu:
 aliases:
   - /reference/gsctl/list-clusters/
 owner:
-  - https://github.com/orgs/giantswarm/teams/sig-ux
+  - https://github.com/orgs/giantswarm/teams/team-rainbow
 user_questions:
   - How can I list all clusters I have access to using gsctl?
 last_review_date: 2021-01-01

--- a/src/content/ui-api/gsctl/list-endpoints.md
+++ b/src/content/ui-api/gsctl/list-endpoints.md
@@ -9,7 +9,7 @@ menu:
 aliases:
   - /reference/gsctl/list-endpoints/
 owner:
-  - https://github.com/orgs/giantswarm/teams/sig-ux
+  - https://github.com/orgs/giantswarm/teams/team-rainbow
 user_questions:
   - How can I list the API endpoints I have configured in gsctl?
 last_review_date: 2021-01-01

--- a/src/content/ui-api/gsctl/list-keypairs.md
+++ b/src/content/ui-api/gsctl/list-keypairs.md
@@ -9,7 +9,7 @@ menu:
 aliases:
   - /reference/gsctl/list-keypairs/
 owner:
-  - https://github.com/orgs/giantswarm/teams/sig-ux
+  - https://github.com/orgs/giantswarm/teams/team-rainbow
 user_questions:
   - How can I show the valid key pairs for a cluster using gsctl?
 last_review_date: 2021-01-01

--- a/src/content/ui-api/gsctl/list-nodepools.md
+++ b/src/content/ui-api/gsctl/list-nodepools.md
@@ -9,7 +9,7 @@ menu:
 aliases:
   - /reference/gsctl/list-nodepools/
 owner:
-  - https://github.com/orgs/giantswarm/teams/sig-ux
+  - https://github.com/orgs/giantswarm/teams/team-rainbow
 user_questions:
   - How can I see all node pools in a cluster using gsctl?
 last_review_date: 2021-01-01

--- a/src/content/ui-api/gsctl/list-releases.md
+++ b/src/content/ui-api/gsctl/list-releases.md
@@ -9,7 +9,7 @@ menu:
 aliases:
   - /reference/gsctl/list-releases/
 owner:
-  - https://github.com/orgs/giantswarm/teams/sig-ux
+  - https://github.com/orgs/giantswarm/teams/team-rainbow
 user_questions:
   - How can I see the workload cluster releases available using gsctl?
 last_review_date: 2021-01-01

--- a/src/content/ui-api/gsctl/login.md
+++ b/src/content/ui-api/gsctl/login.md
@@ -13,7 +13,7 @@ user_questions:
 aliases:
   - /reference/gsctl/login/
 owner:
-  - https://github.com/orgs/giantswarm/teams/sig-ux
+  - https://github.com/orgs/giantswarm/teams/team-rainbow
 last_review_date: 2021-01-01
 ---
 

--- a/src/content/ui-api/gsctl/scale-cluster.md
+++ b/src/content/ui-api/gsctl/scale-cluster.md
@@ -9,7 +9,7 @@ menu:
 aliases:
   - /reference/gsctl/scale-cluster/
 owner:
-  - https://github.com/orgs/giantswarm/teams/sig-ux
+  - https://github.com/orgs/giantswarm/teams/team-rainbow
 user_questions:
   - How can I scale an on-premises (KVM) cluster using gsctl?
 last_review_date: 2021-08-13

--- a/src/content/ui-api/gsctl/select-endpoint.md
+++ b/src/content/ui-api/gsctl/select-endpoint.md
@@ -9,7 +9,7 @@ menu:
 aliases:
   - /reference/gsctl/select-endpoint/
 owner:
-  - https://github.com/orgs/giantswarm/teams/sig-ux
+  - https://github.com/orgs/giantswarm/teams/team-rainbow
 user_questions:
   - How can I select an API endpoint for use with gsctl?
 last_review_date: 2021-01-01

--- a/src/content/ui-api/gsctl/show-cluster.md
+++ b/src/content/ui-api/gsctl/show-cluster.md
@@ -9,7 +9,7 @@ menu:
 aliases:
   - /reference/gsctl/show-cluster/
 owner:
-  - https://github.com/orgs/giantswarm/teams/sig-ux
+  - https://github.com/orgs/giantswarm/teams/team-rainbow
 user_questions:
   - How can I inspect cluster details using gsctl?
 last_review_date: 2021-01-01

--- a/src/content/ui-api/gsctl/show-nodepool.md
+++ b/src/content/ui-api/gsctl/show-nodepool.md
@@ -9,7 +9,7 @@ menu:
 aliases:
   - /reference/gsctl/show-nodepool/
 owner:
-  - https://github.com/orgs/giantswarm/teams/sig-ux
+  - https://github.com/orgs/giantswarm/teams/team-rainbow
 user_questions:
   - How can I inspect a node pool using gsctl?
 last_review_date: 2021-01-01

--- a/src/content/ui-api/gsctl/show-release.md
+++ b/src/content/ui-api/gsctl/show-release.md
@@ -9,7 +9,7 @@ menu:
 aliases:
   - /reference/gsctl/show-release/
 owner:
-  - https://github.com/orgs/giantswarm/teams/sig-ux
+  - https://github.com/orgs/giantswarm/teams/team-rainbow
 user_questions:
   - How can I inspeact a workload cluster release using gsctl?
 last_review_date: 2021-01-01

--- a/src/content/ui-api/gsctl/update-cluster.md
+++ b/src/content/ui-api/gsctl/update-cluster.md
@@ -9,7 +9,7 @@ menu:
 aliases:
   - /reference/gsctl/update-cluster/
 owner:
-  - https://github.com/orgs/giantswarm/teams/sig-ux
+  - https://github.com/orgs/giantswarm/teams/team-rainbow
 user_questions:
   - How can I modify a cluster using gsctl?
 last_review_date: 2021-01-01

--- a/src/content/ui-api/gsctl/update-nodepool.md
+++ b/src/content/ui-api/gsctl/update-nodepool.md
@@ -9,7 +9,7 @@ menu:
 aliases:
   - /reference/gsctl/update-nodepool/
 owner:
-  - https://github.com/orgs/giantswarm/teams/sig-ux
+  - https://github.com/orgs/giantswarm/teams/team-rainbow
 user_questions:
   - How can I modify a node pool using gsctl?
 last_review_date: 2021-01-01

--- a/src/content/ui-api/gsctl/update-org-set-credentials.md
+++ b/src/content/ui-api/gsctl/update-org-set-credentials.md
@@ -9,7 +9,7 @@ menu:
 aliases:
    /reference/gsctl/update-org-set-credentials/
 owner:
-  - https://github.com/orgs/giantswarm/teams/sig-ux
+  - https://github.com/orgs/giantswarm/teams/team-rainbow
 user_questions:
   - How can I set cloud provider credentials for an organization using gsctl?
 last_review_date: 2021-01-01

--- a/src/content/ui-api/gsctl/upgrade-cluster.md
+++ b/src/content/ui-api/gsctl/upgrade-cluster.md
@@ -9,7 +9,7 @@ menu:
 aliases:
   - /reference/gsctl/upgrade-cluster/
 owner:
-  - https://github.com/orgs/giantswarm/teams/sig-ux
+  - https://github.com/orgs/giantswarm/teams/team-rainbow
 user_questions:
   - How can I upgrade a workload cluster using gsctl?
 last_review_date: 2021-01-01

--- a/src/content/ui-api/kubectl-gs/_index.md
+++ b/src/content/ui-api/kubectl-gs/_index.md
@@ -13,7 +13,7 @@ user_questions:
 aliases:
   - /reference/kubectl-gs/
 owner:
-  - https://github.com/orgs/giantswarm/teams/sig-ux
+  - https://github.com/orgs/giantswarm/teams/team-rainbow
 ---
 
 # `kubectl gs` plugin reference

--- a/src/content/ui-api/kubectl-gs/get-clusters.md
+++ b/src/content/ui-api/kubectl-gs/get-clusters.md
@@ -9,7 +9,7 @@ menu:
 aliases:
   - /reference/kubectl-gs/get-clusters/
 owner:
-  - https://github.com/orgs/giantswarm/teams/sig-ux
+  - https://github.com/orgs/giantswarm/teams/team-rainbow
 user_questions:
   - How can I list clusters using kubectl?
   - How can I inspect clusters using kubectl?

--- a/src/content/ui-api/kubectl-gs/get-nodepools.md
+++ b/src/content/ui-api/kubectl-gs/get-nodepools.md
@@ -9,7 +9,7 @@ menu:
 aliases:
   - /reference/kubectl-gs/get-nodepools/
 owner:
-  - https://github.com/orgs/giantswarm/teams/sig-ux
+  - https://github.com/orgs/giantswarm/teams/team-rainbow
 user_questions:
   - How can I list node pools in a cluster using kubectl?
   - How can I inspect node pools using kubectl?

--- a/src/content/ui-api/kubectl-gs/installation.md
+++ b/src/content/ui-api/kubectl-gs/installation.md
@@ -9,7 +9,7 @@ menu:
 aliases:
   - /reference/kubectl-gs/installation/
 owner:
-  - https://github.com/orgs/giantswarm/teams/sig-ux
+  - https://github.com/orgs/giantswarm/teams/team-rainbow
 last_review_date: 2021-07-02
 user_questions:
   - Where can I find the Giant Swarm plugin for kubectl?

--- a/src/content/ui-api/kubectl-gs/login.md
+++ b/src/content/ui-api/kubectl-gs/login.md
@@ -10,7 +10,7 @@ menu:
 aliases:
   - /reference/kubectl-gs/login/
 owner:
-  - https://github.com/orgs/giantswarm/teams/sig-ux
+  - https://github.com/orgs/giantswarm/teams/team-rainbow
 user_questions:
   - How can I log in with kubectl for the Management API?
 last_review_date: 2021-01-01

--- a/src/content/ui-api/kubectl-gs/template-cluster.md
+++ b/src/content/ui-api/kubectl-gs/template-cluster.md
@@ -9,7 +9,7 @@ menu:
 aliases:
   - /reference/kubectl-gs/template-cluster/
 owner:
-  - https://github.com/orgs/giantswarm/teams/sig-ux
+  - https://github.com/orgs/giantswarm/teams/team-rainbow
 user_questions:
   - How can I create a cluster manifest for the Management API?
 last_review_date: 2021-01-01

--- a/src/content/ui-api/kubectl-gs/template-nodepool.md
+++ b/src/content/ui-api/kubectl-gs/template-nodepool.md
@@ -10,7 +10,7 @@ aliases:
   - /reference/kubectl-gs/template-nodepool/
 last_review_date: 2021-07-08
 owner:
-  - https://github.com/orgs/giantswarm/teams/sig-ux
+  - https://github.com/orgs/giantswarm/teams/team-rainbow
 user_questions:
   - How can I create a node pool manifest for the Management API?
 ---

--- a/src/content/ui-api/kubectl-gs/template-organization.md
+++ b/src/content/ui-api/kubectl-gs/template-organization.md
@@ -10,7 +10,7 @@ aliases:
   - /reference/kubectl-gs/template-organization/
 last_review_date: 2021-09-09
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-biscuit
+  - https://github.com/orgs/giantswarm/teams/team-rainbow
 user_questions:
   - How can I create an organization manifest for the Management API?
 ---

--- a/src/content/ui-api/management-api/authentication/index.md
+++ b/src/content/ui-api/management-api/authentication/index.md
@@ -14,7 +14,7 @@ user_questions:
   - What requirements are there to use single sign-on with the Management API?
   - How can I refresh my groups memberships for Management API authorization?
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-biscuit
+  - https://github.com/orgs/giantswarm/teams/team-rainbow
 ---
 
 # Authentication for the Management API

--- a/src/content/ui-api/management-api/overview/index.md
+++ b/src/content/ui-api/management-api/overview/index.md
@@ -12,7 +12,7 @@ user_questions:
   - In what development stage is the Management API?
 last_review_date: 2021-08-04
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-biscuit
+  - https://github.com/orgs/giantswarm/teams/team-rainbow
 ---
 
 # The Management API

--- a/src/content/ui-api/management-api/wc-key-pairs/index.md
+++ b/src/content/ui-api/management-api/wc-key-pairs/index.md
@@ -11,7 +11,7 @@ user_questions:
   - How to create workload cluster key pairs via the Management API?
 last_review_date: 2021-08-23
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-biscuit
+  - https://github.com/orgs/giantswarm/teams/team-rainbow
 ---
 
 # Creating workload cluster key pairs via the Management API

--- a/src/content/ui-api/rest-api/index.md
+++ b/src/content/ui-api/rest-api/index.md
@@ -12,7 +12,7 @@ user_questions:
   - How can I manage Giant Swarm resources programmatically?
   - How can I manage clusters via an API?
 owner:
-  - https://github.com/orgs/giantswarm/teams/sig-ux
+  - https://github.com/orgs/giantswarm/teams/team-rainbow
 last_review_date: 2021-01-01
 ---
 

--- a/src/content/ui-api/web/_index.md
+++ b/src/content/ui-api/web/_index.md
@@ -8,6 +8,6 @@ menu:
     identifier: uiapi-web
     parent: ui-api
 owner:
-  - https://github.com/orgs/giantswarm/teams/sig-ux
+  - https://github.com/orgs/giantswarm/teams/team-rainbow
 last_review_date: 2021-01-01
 ---

--- a/src/content/ui-api/web/overview.md
+++ b/src/content/ui-api/web/overview.md
@@ -15,7 +15,7 @@ user_questions:
   - How can I give feedback on the web UI?
 last_review_date: 2021-01-01
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-biscuit
+  - https://github.com/orgs/giantswarm/teams/team-rainbow
 ---
 
 # The web user interface

--- a/src/content/ui-api/web/usage-data.md
+++ b/src/content/ui-api/web/usage-data.md
@@ -9,7 +9,7 @@ menu:
 aliases:
    - /reference/web-interface/usage-data/
 owner:
-  - https://github.com/orgs/giantswarm/teams/sig-ux
+  - https://github.com/orgs/giantswarm/teams/team-rainbow
 user_questions:
   - What usage data is Giant Swarm recording in the web UI?
   - How is Giant Swarm treating usage data recorded in the web UI?

--- a/src/content/ui-api/web/workload-cluster-labelling/index.md
+++ b/src/content/ui-api/web/workload-cluster-labelling/index.md
@@ -14,7 +14,7 @@ aliases:
 user_questions:
   - How can I manage cluster labels via the web interface?
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-biscuit
+  - https://github.com/orgs/giantswarm/teams/team-rainbow
 ---
 
 # Labelling workload clusters using the web interface


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/19028

This transfers the ownership to team Rainbow for

- some articles owned by team-biscuit
- all articles owned by sig-ux