### PR TITLE
Prepare default branch change from 'master' to 'main'

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,10 +35,10 @@ jobs:
             echo $CURL_OUTPUT | grep --quiet "Giant Swarm"
 
       - deploy:
-          name: Deploy (only if branch is "master")
+          name: Deploy (only if in default branch)
           command: |
-            echo "Deploy only if '${CIRCLE_BRANCH}' == 'master'"
-            if [ "${CIRCLE_BRANCH}" == "master" ]; then
+            echo "Deploy only if '${CIRCLE_BRANCH}' == 'main'"
+            if [ "${CIRCLE_BRANCH}" == "main" ]; then
               ./architect deploy
             fi
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
 ### Please remember to
 
 - [ ] Give the PR a meaningful title -- it will be shown in the release notes
-- [ ] Add (or remove) [user questions](https://github.com/giantswarm/docs/blob/master/CONTRIBUTING.md#front-matter) associated with any updated docs
+- [ ] Add (or remove) [user questions](https://github.com/giantswarm/docs/blob/main/CONTRIBUTING.md#front-matter) associated with any updated docs

--- a/.github/workflows/on-merge-to-master-create-release.yml
+++ b/.github/workflows/on-merge-to-master-create-release.yml
@@ -3,7 +3,7 @@ name: Create Release
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   build:

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -2,7 +2,7 @@ name: Validate
 on:
   pull_request:
     branches:
-      - master
+      - main
     paths:
       - 'src/**.md'
 

--- a/src/layouts/partials/feedback_reference.html
+++ b/src/layouts/partials/feedback_reference.html
@@ -1,6 +1,6 @@
 {{ with .File }}
 <div class="feedback well">
   <h5><i class="fa fa-help-outline"></i> Anything missing here?</h5>
-  <p>We welcome your <a title="open this page in GitHub" href="https://github.com/giantswarm/docs/blob/master/src/content/{{ .Path }}" target="_blank" rel="noopener noreferrer">pull requests</a>, feedback and all sorts of questions. You can also send us an email to <a href="mailto:support@giantswarm.io">support@giantswarm.io</a>.</p>
+  <p>We welcome your <a title="open this page in GitHub" href="https://github.com/giantswarm/docs/blob/main/src/content/{{ .Path }}" target="_blank" rel="noopener noreferrer">pull requests</a>, feedback and all sorts of questions. You can also send us an email to <a href="mailto:support@giantswarm.io">support@giantswarm.io</a>.</p>
 </div>
 {{ end }}

--- a/src/layouts/partials/help_feedback.html
+++ b/src/layouts/partials/help_feedback.html
@@ -1,7 +1,7 @@
 {{ with .File }}
 <div class="feedback well">
   <h5><i class="fa fa-help-outline"></i> Need help, got feedback?</h5>
-  <p>We listen to your Slack support channel. You can also reach us at <a href="mailto:support@giantswarm.io">support@giantswarm.io</a>. And of course, we welcome your <a title="open this page in GitHub" href="https://github.com/giantswarm/docs/blob/master/src/content/{{ .Path }}" target="_blank" rel="noopener noreferrer">pull requests</a>!</p>
+  <p>We listen to your Slack support channel. You can also reach us at <a href="mailto:support@giantswarm.io">support@giantswarm.io</a>. And of course, we welcome your <a title="open this page in GitHub" href="https://github.com/giantswarm/docs/blob/main/src/content/{{ .Path }}" target="_blank" rel="noopener noreferrer">pull requests</a>!</p>
 </div>
 {{ end }}
 


### PR DESCRIPTION
I'd like us to change the default branch name to `main`.

### Please remember to

- [x] Give the PR a meaningful title -- it will be shown in the release notes
- [ ] Add (or remove) [user questions](https://github.com/giantswarm/docs/blob/master/CONTRIBUTING.md#front-matter) associated with any updated docs
