### PR TITLE
Fix repo cloning

### DIFF
--- a/scripts/aggregate-changelogs/script.py
+++ b/scripts/aggregate-changelogs/script.py
@@ -136,7 +136,7 @@ def get_cluster_releases(repo_shortname):
     """
     with tempfile.TemporaryDirectory() as tmpdir:
         print(f'Cloning to temporary directory {tmpdir}')
-        git.Git(tmpdir).clone(f"git://github.com/{repo_shortname}.git", depth=1)
+        git.Git(tmpdir).clone(f"https://github.com/{repo_shortname}.git", depth=1)
 
         (org, repo) = repo_shortname.split("/", maxsplit=1)
 


### PR DESCRIPTION
This fixes the problem

```
The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.'
```

in Changes & Releases aggregation.