### PR TITLE
add github.io to domain allowlist (required for chart tarballs)

### DIFF
--- a/src/content/reference/domain-allowlist/index.md
+++ b/src/content/reference/domain-allowlist/index.md
@@ -23,6 +23,8 @@ Below is a list of the external domains we require access to for our clusters to
     - `*.quay.io`
 - github.com
     - `*.github.com`
+- github.io
+    - `*.github.io`
 - amazonaws.com
     - `*.amazonaws.com`
 - docker.io


### PR DESCRIPTION
Chart tarballs are pulled from github pages, so we need customers to allow access to github.io domains.

### Please remember to

- [x] Give the PR a meaningful title -- it will be shown in the release notes
