### PR TITLE
Make provider differences stand out clearly

### DIFF
--- a/src/content/ui-api/management-api/credentials/index.md
+++ b/src/content/ui-api/management-api/credentials/index.md
@@ -30,7 +30,16 @@ As we are dealing with two cloud providers here which use different vocabulary i
 
 ## Credential secrets explained
 
-Credentials are stored in the management cluster in the form of a `Secret` resource. Here is an example for AWS:
+Credentials are stored in the management cluster in the form of a `Secret` resource.
+
+In the `metadata`, credential secrets _must_ provide the `giantswarm.io/managed-by: credentiald` and `app: credentiald` labels. We also _recommend_ to choose a resource name starting with `credential-`.
+
+The `data` part contains the cloud provider credentials that should be used. The format here differs slightly between cloud providers.
+
+{{< tabs >}}
+{{< tab title="AWS" >}}
+
+Here is an example for AWS:
 
 ```yaml
 apiVersion: v1
@@ -47,9 +56,7 @@ data:
   aws.awsoperator.arn: YXJuOmF3czppYW06OjEyMzQ1Njc4OTA6cm9sZS9HaWFudFN3YXJtQVdTT3BlcmF0b3I=
 ```
 
-In the `metadata`, credential secrets _must_ provide the `giantswarm.io/managed-by: credentiald` and `app: credentiald` labels. We also _recommend_ to choose a resource name starting with `credential-`.
-
-The `data` part contains the cloudprovider credentials that should be used. In above AWS example, these are two fields which both indicate AWS IAM role identifiers (ARNs). As typical with opaque secrets, the value is encoded in base64. Here is how the two example strings would look like when decoded:
+In above AWS example, these are two fields which both indicate AWS IAM role identifiers (ARNs). As typical with opaque secrets, the value is encoded in base64. Here is how the two example strings would look like when decoded:
 
 | Key                   | Example value (decoded)                              |
 |-----------------------|------------------------------------------------------|
@@ -60,10 +67,22 @@ The first of the two identifies the IAM role to be assumed by Giant Swarm staff 
 
 We provide [detailed documentation]({{< relref "/getting-started/cloud-provider-accounts/aws" >}}) regarding how to configure these roles in your AWS account.
 
-The `data` part of a credential secret in Azure looks slightly different:
+{{< /tab >}}
+{{< tab title="Azure" >}}
+
+Here is an example for a credential secret on Azure:
 
 ```yaml
-...
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: credential-example
+  namespace: my-namespace
+  labels:
+    app: credentiald
+    giantswarm.io/managed-by: credentiald
+data:
 data:
   azure.azureoperator.clientid: MTIzNGFiY2QtYWIxMi0xMmFiLWNkMzQtYWJjZDEyMzRhYmNkCg==
   azure.azureoperator.subscriptionid: NTY3OGFiY2QtYWI1Ni01NmFiLWNkNTYtYWJjZDU2NzhhYmNkCg==
@@ -71,8 +90,9 @@ data:
   azure.azureoperator.clientsecret: YWJjZC1lZmdoaWprbG1uTE9QUTEyMzQ1Njd+ODlSU3R1dnd4Cg==
 ```
 
- It contains four fields which specify the IDs of `Client`, `Subscription` and `Tenant` as well as the `Client Secret`.
- Decoded example:
+Here the `data` part contains four fields which specify the IDs of `Client`, `Subscription` and `Tenant` as well as the `Client Secret`.
+
+Decoded example:
 
 | Key                                  | Example value (decoded)                |
 |--------------------------------------|----------------------------------------|
@@ -82,19 +102,23 @@ data:
 | `azure.azureoperator.clientsecret`   | `abcd-efghijklmnLOPQ1234567~89RStuvwx` |
 
 In order for `azure-operator` to manage workload clusters using these credentials, it will need access to your `Subscription` using a `Service Principal`.
-We provide a detailed guide on how to do this in our [getting-started-guide]({{< relref "/getting-started/cloud-provider-accounts/azure" >}})
+
+We provide a [detailed guide](({{< relref "/getting-started/cloud-provider-accounts/azure" >}})) prepare and obtain this data.
+
+{{< /tab >}}
+{{< /tabs >}}
 
 ## Referencing credentials in the cluster resource {#explicit}
 
-When creating a workload cluster, there will be an [`AWSCluster`]({{< relref "/ui-api/management-api/crd/awsclusters.infrastructure.giantswarm.io.md" >}}) or [`AzureCluster`]({{< relref "/ui-api/management-api/crd/azureclusters.infrastructure.cluster.x-k8s.io.md" >}})resource created, containing the provider-specific configuration of your workload cluster.
+When creating a workload cluster, depending on the cloud provider, there will be an [`AWSCluster`]({{< relref "/ui-api/management-api/crd/awsclusters.infrastructure.giantswarm.io.md" >}}) or [`AzureCluster`]({{< relref "/ui-api/management-api/crd/azureclusters.infrastructure.cluster.x-k8s.io.md" >}}) resource created, containing the provider-specific configuration of your workload cluster.
 
 If you create your cluster manifest manually or via the [`kubectl gs template cluster`]({{< relref "/ui-api/kubectl-gs/template-cluster" >}}) command, you are free to adapt the provider cluster resource to match your exact requirements before submitting the manifest to the API (e. g. via `kubectl apply`).
 
-In AWS, it is possible to reference your credential secret directly. The custom resource definition (CRD) provides an attribute [`.spec.provider.credentialSecret`]({{< relref "/ui-api/management-api/crd/awsclusters.infrastructure.giantswarm.io.md#v1alpha3-.spec.provider.credentialSecret" >}}). The two sub-attributes `name` has to match the credential secret's resource name. The `namespace` sub-attribute accordingly must match the secret's namespace.
+In **AWS**, it is possible to reference your credential secret directly. The custom resource definition (CRD) provides an attribute [`.spec.provider.credentialSecret`]({{< relref "/ui-api/management-api/crd/awsclusters.infrastructure.giantswarm.io.md#v1alpha3-.spec.provider.credentialSecret" >}}). The two sub-attributes `name` has to match the credential secret's resource name. The `namespace` sub-attribute accordingly must match the secret's namespace.
 
 Note that this attribute has to be set _before_ submitting the manifest to the Management API. Otherwise, if the `AWSCluster` resource gets submitted without any `.spec.provider.credentialSecret` in place, our admission controllers will fill in default values. Read on to understand the defaulting logic.
 
-The `AzureCluster` field  [`.spec.identityRef`]({{< relref "/ui-api/management-api/crd/azureclusters.infrastructure.cluster.x-k8s.io.md#v1alpha4-.spec.identityRef" >}}) is set by the `azure-operator`. It references credential secrets indirectly by creating an `org-credential` based on the organization your workload cluster is created in.
+On **Azure**, the `AzureCluster` field  [`.spec.identityRef`]({{< relref "/ui-api/management-api/crd/azureclusters.infrastructure.cluster.x-k8s.io.md#v1alpha4-.spec.identityRef" >}}) is set by the `azure-operator`. It references credential secrets indirectly by creating an `org-credential` based on the organization your workload cluster is created in.
 
 ## Defaulting
 

--- a/src/content/ui-api/management-api/credentials/index.md
+++ b/src/content/ui-api/management-api/credentials/index.md
@@ -11,7 +11,7 @@ owner:
 last_review_date: 2021-11-02
 user_questions:
   - How can I provide AWS identity details to use with my workload clusters?
-  - How can I provide azure identity details to use with my workload clusters?
+  - How can I provide Azure identity details to use with my workload clusters?
   - How can I set cloud provider credentials via the Management API?
 ---
 
@@ -60,7 +60,7 @@ The first of the two identifies the IAM role to be assumed by Giant Swarm staff 
 
 We provide [detailed documentation]({{< relref "/getting-started/cloud-provider-accounts/aws" >}}) regarding how to configure these roles in your AWS account.
 
-The `data` part of a credential secret in azure looks slightly different:
+The `data` part of a credential secret in Azure looks slightly different:
 
 ```yaml
 ...
@@ -98,7 +98,7 @@ The `AzureCluster` field  [`.spec.identityRef`]({{< relref "/ui-api/management-a
 
 ## Defaulting
 
-If the cluster resource does not reference a provider credential secret to use (as explained above and as always the case on azure), our admission controller fills in some defaults, in this logical order
+If the cluster resource does not reference a provider credential secret to use (as explained above and as always the case on Azure), our admission controller fills in some defaults, in this logical order
 
 1. An organization's credential secret is used, if it exists
 2. Otherwise the installation's default secret is used
@@ -152,4 +152,4 @@ The defaulting options as well as the option to reference credentials explicitly
 ## Further reading
 
 - [aws-admission-controller](https://github.com/giantswarm/aws-admission-controller/): Explore the source code of the component that does the defaulting of AWS credentials on cluster creation.
-- [azure-operator](https://github.com/giantswarm/azure-admission-controller/): Explore the source code of the component that takes care of the indirect refence of azure credentials on cluster creation.
+- [azure-operator](https://github.com/giantswarm/azure-admission-controller/): Explore the source code of the component that takes care of the indirect reference of Azure credentials on cluster creation.


### PR DESCRIPTION
This is an addition to https://github.com/giantswarm/docs/pull/1188 where the differences between AWS and Azure should be easier to understand.

In the "Credential secrets explained" section it uses a tabs container to separate the provider-specific explanations.

@anvddriesch If this makes sense to you, feel free to merge it into your `azurecred` branch. If you want to talk about it first instead, that's also fine.