### PR TITLE
Add apps to Changes & Releases

### DIFF
--- a/scripts/aggregate-changelogs/config.yaml
+++ b/scripts/aggregate-changelogs/config.yaml
@@ -26,12 +26,16 @@ repositories:
     category: Documentation
   giantswarm/efk-stack-app:
     category: Managed Apps
+  giantswarm/falco-app:
+    category: Managed Apps
   giantswarm/goldilocks-app:
     category: Managed Apps
   giantswarm/gsctl:
     category: gsctl
   giantswarm/happa:
     category: Web UI
+  giantswarm/hello-world-app:
+    category: Managed Apps
   giantswarm/kong-app:
     category: Managed Apps
   giantswarm/kubectl-gs:
@@ -50,11 +54,21 @@ repositories:
     category: Managed Apps
   giantswarm/loki-app:
     category: Managed Apps
+  giantswarm/oauth2-proxy-app:
+    category: Managed Apps
   giantswarm/promtail-app:
+    category: Managed Apps
+  giantswarm/rook-operator-app:
+    category: Managed Apps
+  giantswarm/starboard-app:
+    category: Managed Apps
+  giantswarm/trivy-app:
     category: Managed Apps
   giantswarm/external-dns-app:
     category: Managed Apps
   giantswarm/fluent-logshipping-app:
+    category: Managed Apps
+  giantswarm/flux-app:
     category: Managed Apps
   giantswarm/cloudflared-app:
     category: Managed Apps

--- a/scripts/aggregate-changelogs/config.yaml
+++ b/scripts/aggregate-changelogs/config.yaml
@@ -41,7 +41,7 @@ repositories:
   giantswarm/kubectl-gs:
     category: kubectl gs
   giantswarm/kyverno-app:
-    category: Management API
+    category: Managed Apps
   giantswarm/kyverno-policies:
     category: Management API
   giantswarm/management-cluster-admission:


### PR DESCRIPTION
This PR adds apps that are currently in the Giant Swarm catalog, but don't have their changelogs aggregated in [Changes and Releases](https://docs.giantswarm.io/changes/).

Also moving kyverno-app into the `Managed Apps` category from `Management API`.