### PR TITLE
Fix changelog aggregation to not fail when release is incomplete

### DIFF
--- a/scripts/aggregate-changelogs/script.py
+++ b/scripts/aggregate-changelogs/script.py
@@ -227,7 +227,7 @@ def generate_release_file(repo_shortname, repo_config, release):
 
     version = normalize_version(release['version_tag'])
 
-    org, repo_id = repo_shortname.split("/", maxsplit=1)
+    _, repo_id = repo_shortname.split("/", maxsplit=1)
     aliases = None
 
     if repo_shortname == RELEASES_REPO:

--- a/scripts/aggregate-changelogs/script.py
+++ b/scripts/aggregate-changelogs/script.py
@@ -220,6 +220,11 @@ def generate_release_file(repo_shortname, repo_config, release):
     """
     Write a release file with YAML front matter and Markdown body
     """
+
+    if 'version_tag' not in release:
+        print(f'ERROR: {repo_shortname} release has no version tag. Skipping. Details: {release}')
+        return
+
     version = normalize_version(release['version_tag'])
 
     org, repo_id = repo_shortname.split("/", maxsplit=1)


### PR DESCRIPTION
Fixes this error:

```nohighlight
Traceback (most recent call last):
  File "/workdir/script.py", line 339, in <module>
Cloning to temporary directory /tmp/tmpdp3jzbnr
WARNING: Unexpected provider.
WARNING: Unexpected provider.
    generate_release_file(repo_short, repo_conf, release)
  File "/workdir/script.py", line 223, in generate_release_file
    version = normalize_version(release['version_tag'])
KeyError: 'version_tag'
make: *** [Makefile:19: changes] Error 1
Error: Process completed with exit code 2.
```