### PR TITLE
remove gitlab from domain allowlist

### DIFF
--- a/src/content/reference/domain-allowlist/index.md
+++ b/src/content/reference/domain-allowlist/index.md
@@ -71,10 +71,8 @@ Below is a list of the external domains we require access to for our clusters to
     - Monitoring and crash reporting for `happa`.
 - `api.opsgenie.com`
     - Opsgenie's API is used to send alerts.
-- `gitlab.com`
-    - Grafana may download plugins from repositories hosted by Gitlab.
 - `grafana.com`
-    - Grafana downloads a plugin directly from its API.
+    - Grafana may download plugins from the Grafana plugin registry.
 - `prometheus-us-central1.grafana.net`
     - Some metrics are pushed to our hosted Grafana tenant.
 - `vault.operations.giantswarm.io`


### PR DESCRIPTION
We no longer need access to gitlab.com - plugins are now pulled directly from grafana.com

### Please remember to

- [x] Give the PR a meaningful title -- it will be shown in the release notes
