### PR TITLE
Update `STATUS` column in example output for kubectl-gs `get releases` command

### DIFF
--- a/src/content/ui-api/kubectl-gs/get-releases.md
+++ b/src/content/ui-api/kubectl-gs/get-releases.md
@@ -61,10 +61,10 @@ The standard tabular output format features these columns:
 
 - `VERSION`: Unique identifier of the release.
 - `STATUS`: The state of the release. Possible states are:
-  - `ACTIVE`: A stable release, fully supported.
-  - `PREVIEW`: A preview for testing purposes only, not yet considered stable.
-  - `WIP`: Work in progress, a release in development.
-  - `DEPRECATED`: Has been replaced by a successor release. No longer recommended.
+    - `ACTIVE`: A stable release, fully supported.
+    - `PREVIEW`: A preview for testing purposes only, not yet considered stable.
+    - `WIP`: Work in progress, a release in development.
+    - `DEPRECATED`: Has been replaced by a successor release. No longer recommended.
 - `AGE`: How long ago was the release created.
 - `KUBERNETES`: The version of Kubernetes provided by this release
 - `CONTAINER LINUX`: The version of container linux provided by this release

--- a/src/content/ui-api/kubectl-gs/get-releases.md
+++ b/src/content/ui-api/kubectl-gs/get-releases.md
@@ -60,7 +60,11 @@ Note: As an alternative to `get releases`, `get release` will also work.
 The standard tabular output format features these columns:
 
 - `VERSION`: Unique identifier of the release.
-- `STATUS`: The state of the release (active, deprecated, preview, or WIP).
+- `STATUS`: The state of the release. Possible states are:
+  - `ACTIVE`: A stable release, fully supported.
+  - `PREVIEW`: A preview for testing purposes only, not yet considered stable.
+  - `WIP`: Work in progress, a release in development.
+  - `DEPRECATED`: Has been replaced by a successor release. No longer recommended.
 - `AGE`: How long ago was the release created.
 - `KUBERNETES`: The version of Kubernetes provided by this release
 - `CONTAINER LINUX`: The version of container linux provided by this release

--- a/src/content/ui-api/kubectl-gs/get-releases.md
+++ b/src/content/ui-api/kubectl-gs/get-releases.md
@@ -35,14 +35,14 @@ to list some information on all releases available to you in the current install
 Here is some example output:
 
 ```nohighlight
-VERSION          STATUS     AGE   KUBERNETES  CONTAINER LINUX   COREDNS   CALICO
-v14.2.1          active     2d    1.19.9      2765.2.3          1.6.5     3.15.3
-v14.2.2          active     2d    1.19.9      2605.12.0         1.6.5     3.15.3
-v15.0.0          inactive   3d    1.20.8      2765.2.6          1.6.5     3.15.3
-v15.1.0          inactive   4d    1.20.9      2765.2.6          1.8.3     3.15.5
-v15.1.1          inactive   4d    1.20.9      2765.2.6          1.8.3     3.15.5
-v15.2.0          active     20d   1.20.9      2765.2.6          1.8.3     3.15.5
-v15.2.1          active     21d   1.20.9      2765.2.6          1.8.3     3.15.5
+VERSION          STATUS       AGE   KUBERNETES  CONTAINER LINUX   COREDNS   CALICO
+v14.2.1          ACTIVE       2d    1.19.9      2765.2.3          1.6.5     3.15.3
+v14.2.2          ACTIVE       2d    1.19.9      2605.12.0         1.6.5     3.15.3
+v15.0.0          DEPRECATED   3d    1.20.8      2765.2.6          1.6.5     3.15.3
+v15.1.0          DEPRECATED   4d    1.20.9      2765.2.6          1.8.3     3.15.5
+v15.1.1          DEPRECATED   4d    1.20.9      2765.2.6          1.8.3     3.15.5
+v15.2.0          ACTIVE       20d   1.20.9      2765.2.6          1.8.3     3.15.5
+v15.2.1          ACTIVE       21d   1.20.9      2765.2.6          1.8.3     3.15.5
 ```
 
 ### Get specific release
@@ -60,7 +60,7 @@ Note: As an alternative to `get releases`, `get release` will also work.
 The standard tabular output format features these columns:
 
 - `VERSION`: Unique identifier of the release.
-- `STATUS`: Indication of if the release is currently active.
+- `STATUS`: The state of the release (active, deprecated, preview, or WIP).
 - `AGE`: How long ago was the release created.
 - `KUBERNETES`: The version of Kubernetes provided by this release
 - `CONTAINER LINUX`: The version of container linux provided by this release


### PR DESCRIPTION
Documentation update depending on [changes to the command in kubectl-gs](https://github.com/giantswarm/kubectl-gs/pull/608).

This PR updates the example output shown for the kubectl-gs `get releases` command, and updates the explanation for the `STATUS` column.