### PR TITLE
Dex article: add `teamNameField: slug` to example github connector

### DIFF
--- a/src/content/advanced/configure-dex-in-your-cluster/index.md
+++ b/src/content/advanced/configure-dex-in-your-cluster/index.md
@@ -46,7 +46,7 @@ kind: Cluster
 metadata:
   annotations:  
     oidc.giantswarm.io/client-id: dex-k8s-authenticator
-    oidc.giantswarm.io/issuer-url: https://dex.<CLUSTERID>.<BASEDOMAIN>
+    oidc.giantswarm.io/issuer-url: https://dex.<CLUSTER>.<BASEDOMAIN>
     oidc.giantswarm.io/group-claim: groups
     oidc.giantswarm.io/username-claim: email
   ...
@@ -66,13 +66,13 @@ spec:
         groups: groups
         username: email
       clientID: dex-k8s-authenticator
-      issuerURL: https://dex.<CLUSTERID>.<BASEDOMAIN>
+      issuerURL: https://dex.<CLUSTER>.<BASEDOMAIN>
 ```
 
 {{< /tab >}}
 {{< /tabs >}}
 
-__Note__: In the above snippets you need to change the `<CLUSTERID>` and `<BASEDOMAIN>` variables to the correct values - the cluster ID of the workload cluster you are configuring, and the base domain that you use for your installation, respectively.
+__Note__: In the above snippets you need to replace the `<CLUSTER>` and `<BASEDOMAIN>` placeholder with the correct values, which is the name of the workload cluster you are configuring, and the base domain that you use for your installation.
 
 ## Deploy the app to your cluster
 
@@ -88,7 +88,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: dex-app-user-values
-  namespace: <CLUSTERID>
+  namespace: <CLUSTER>
 data:
   values: |
     isWorkloadCluster: true
@@ -111,18 +111,18 @@ data:
             - groups
             - profile
             issuer: https://<IDP_ENDPOINT>/auth/realms/master
-            redirectURI: https://dex.<CLUSTERID>.<BASEDOMAIN>/callback
+            redirectURI: https://dex.<CLUSTER>.<BASEDOMAIN>/callback
 ```
 
 {{< /tab >}}
-{{< tab title="Github">}}
+{{< tab title="GitHub">}}
 
 ```yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: dex-app-user-values
-  namespace: <CLUSTERID>
+  namespace: <CLUSTER>
 data:
   values: |
     isWorkloadCluster: true
@@ -141,12 +141,14 @@ data:
             clientSecret: <CLIENT-SECRET-SET-IN--YOUR-IdP>
             loadAllGroups: false
             teamNameField: slug
-            redirectURI: https://dex.<CLUSTERID>.<BASEDOMAIN>/callback
+            redirectURI: https://dex.<CLUSTER>.<BASEDOMAIN>/callback
             orgs:
             - name: main-customer-org
               teams:
               - team-infra
 ```
+
+Note how you configure access for certain GitHub teams only. Make sure to list the team's _slug_ as it appears in the handle and team URL. In the example above, the team _name_ might be `Team Infra`, but the handle is `@main-customer-org/team-infra` and the slug used in this configuration is `team-infra`.
 
 {{< /tab >}}
 {{< tab title="Active Directory">}}
@@ -156,7 +158,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: dex-app-user-values
-  namespace: <CLUSTERID>
+  namespace: <CLUSTER>
 data:
   values: |
     isWorkloadCluster: true
@@ -174,7 +176,7 @@ data:
             clientID: <CLIENT-ID-SET-IN-YOUR-IdP>
             clientSecret: <CLIENT-SECRET-SET-IN--YOUR-IdP>
             tenant: <TENANT-SET-SET-IN--YOUR-IdP>
-            redirectURI: https://dex.<CLUSTERID>.<BASEDOMAIN>/callback
+            redirectURI: https://dex.<CLUSTER>.<BASEDOMAIN>/callback
 ```
 
 {{< /tab >}}
@@ -185,7 +187,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: dex-app-user-values
-  namespace: <CLUSTERID>
+  namespace: <CLUSTER>
 data:
   values: |
     isWorkloadCluster: true
@@ -209,7 +211,7 @@ data:
             - groups
             - profile
             issuer: https://<OKTA_OIDC_ENDPOINT>
-            redirectURI: https://dex.<CLUSTERID>.<BASEDOMAIN>/callback
+            redirectURI: https://dex.<CLUSTER>.<BASEDOMAIN>/callback
 ```
 
 {{< /tab >}}
@@ -217,7 +219,7 @@ data:
 
 __Warning__: With `oidc` connector you might need to add `getUserInfo` in the connector configuration to force a second call to the identity provider in order to get groups. This is required for example by Okta. More info on this can be found in [dexipd/dex#1065](https://github.com/dexidp/dex/issues/1065).
 
-__Note__: In the above snippet you have to replace the `<CLUSTERID>` variable and select a connector. Here we show examples for Keycloak, Active Directory, and GitHub.
+__Note__: In the above snippet you have to replace the `<CLUSTER>` variable and select a connector. Here we show examples for Keycloak, Active Directory, and GitHub.
 You can use more than one connector, but they need to have a different `id` value. We advice to use `- id: customer` for your primary connector.
 
 After you have applied the `ConfigMap` manifest to the Management API you have to submit the App custom resource that defines the intent to install the Dex app in the given cluster.
@@ -229,7 +231,7 @@ metadata:
   labels:
     app.kubernetes.io/name: dex-app
   name: dex-app
-  namespace: <CLUSTERID>
+  namespace: <CLUSTER>
 spec:
   catalog: giantswarm-playground
   name: dex-app
@@ -237,12 +239,12 @@ spec:
   userConfig:
     configMap:
       name: dex-app-user-values
-      namespace: <CLUSTERID>
+      namespace: <CLUSTER>
 ```
 
-__Note__: When applying the example in the snippet above, please change the `<CLUSTERID>` variable to the cluster ID of the workload cluster you are configuring,
+__Note__: When applying the example in the snippet above, please replace the `<CLUSTER>` placeholder with the name of the workload cluster you are configuring.
 
-Then submit the resource to the management API and the App operator will manage it to make the actual installation and configuration. You can log in now into the cluster API with your identity provider using the login endpoint that Dex creates for you. By default, it will be `https://login.<CLUSTERID>.<BASEDOMAIN>`.
+Then submit the resource to the management API and the App operator will manage it to make the actual installation and configuration. You can log in now into the cluster API with your identity provider using the login endpoint that Dex creates for you. By default, it will be `https://login.<CLUSTER>.<BASEDOMAIN>`.
 
 ## Monitoring Dex
 

--- a/src/content/advanced/configure-dex-in-your-cluster/index.md
+++ b/src/content/advanced/configure-dex-in-your-cluster/index.md
@@ -140,6 +140,7 @@ data:
             clientID: <CLIENT-ID-SET-IN-YOUR-IdP>
             clientSecret: <CLIENT-SECRET-SET-IN--YOUR-IdP>
             loadAllGroups: false
+            teamNameField: slug
             redirectURI: https://dex.<CLUSTERID>.<BASEDOMAIN>/callback
             orgs:
             - name: main-customer-org


### PR DESCRIPTION
We found that the github connector for Dex defaults to the team name if there is no `teamNameField` setting in the connector config. As the team name can contain spaces and uppercase letters, this is brittle. Using the team slug (the part that appears in the team's URL) is more robust and hence `teamNameField: slug` is our recommended setting.
