### PR TITLE
Update 'template' intros

### DIFF
--- a/src/content/ui-api/kubectl-gs/template-app.md
+++ b/src/content/ui-api/kubectl-gs/template-app.md
@@ -18,9 +18,9 @@ user_questions:
 
 # `kubectl gs template app`
 
-In order to create an App using custom resources, `kubectl gs` will help you create manifests for the resource type:
+The `template app` command allows to create a manifest for an app to be installed in a workload cluster. The resulting manifest is meant to be applied to the management cluster, for example via `kubectl apply`.
 
-- [App]({{< relref "/ui-api/management-api/crd/apps.application.giantswarm.io.md" >}}) (API group/version `application.giantswarm.io/v1alpha1`) - holds the base App specification.
+The resulting manifest of the `template app` defines an [App]({{< relref "/ui-api/management-api/crd/apps.application.giantswarm.io.md" >}}) resource (API group/version `application.giantswarm.io/v1alpha1`).
 
 ## Usage
 

--- a/src/content/ui-api/kubectl-gs/template-catalog.md
+++ b/src/content/ui-api/kubectl-gs/template-catalog.md
@@ -18,14 +18,14 @@ user_questions:
 
 # `kubectl gs template catalog`
 
-In order to create a [Catalog]({{< relref "/app-platform" >}}) using custom resources, `kubectl-gs` will help you create manifests for the resource type:
+The `template catalog` command allows to create an [app catalog]({{< relref "/app-platform" >}}) manifest. The resulting manifest is meant to be applied to the management cluster, for example via `kubectl apply`.
 
-- [`Catalog`]({{< relref "/ui-api/management-api/crd/catalogs.application.giantswarm.io.md" >}}) (API group/version `application.giantswarm.io/v1alpha1`) - holds the base Catalog specification.
+The resulting manifest will define a [`Catalog`]({{< relref "/ui-api/management-api/crd/catalogs.application.giantswarm.io.md" >}}) resource (API group/version `application.giantswarm.io/v1alpha1`).
 
-The Catalog CRD is namespace scoped and replaces the [AppCatalog]({{< relref "/ui-api/management-api/crd/appcatalogs.application.giantswarm.io.md" >}})
+**Note:** The `Catalog` CRD is namespace scoped and replaces the [AppCatalog]({{< relref "/ui-api/management-api/crd/appcatalogs.application.giantswarm.io.md" >}})
 CRD which is cluster scoped. This is to improve multi-tenancy support when used with the [Management API]({{< relref "/ui-api/management-api/overview/index.md" >}}).
 
-The Catalog CRD supports having a related ConfigMap or Secret with values YAML. These values are merged with the rest of the [configuration]({{< relref "/app-platform/app-configuration/index.md" >}}) when Apps are deployed from this App Catalog.
+The Catalog CRD supports having a related `ConfigMap` and/or `Secret` resource with values YAML. These values are merged with the rest of the [configuration]({{< relref "/app-platform/app-configuration/index.md" >}}) when Apps are deployed from this App Catalog.
 
 ## Usage
 

--- a/src/content/ui-api/kubectl-gs/template-nodepool.md
+++ b/src/content/ui-api/kubectl-gs/template-nodepool.md
@@ -17,7 +17,7 @@ user_questions:
 
 # `kubectl gs template nodepool`
 
-[Node pools]({{< relref "/advanced/node-pools" >}}) are groups of worker nodes sharing common configuration. The `template nodepool` command helps with creating a manifest for the custom resources that define a node pool.
+The `template nodepool` command allows to create [node pools]({{< relref "/advanced/node-pools" >}}), which are groups of worker nodes in a cluster sharing common configuration. The command creates a manifest for the custom resources that define a node pool. These are then meant to be applied to the management cluster, e. g. via `kubectl apply`.
 
 The resulting resources depend on the provider, set via the `--provider` flag.
 

--- a/src/content/ui-api/kubectl-gs/template-organization.md
+++ b/src/content/ui-api/kubectl-gs/template-organization.md
@@ -17,9 +17,7 @@ user_questions:
 
 # `kubectl gs template organization`
 
-In order to create an [organization]({{< relref "/general/organizations/index.md" >}}) using a custom resource, `kubectl-gs` will help you create the manifest for the resource type:
-
-- [`Organization`]({{< relref "/ui-api/management-api/crd/organizations.security.giantswarm.io.md" >}}) (API group/version `security.giantswarm.io/v1alpha1`) - holds the base organization specification.
+The `template organization` command creates an [organization]({{< relref "/general/organizations/index.md" >}}) manifest which can applied to a management cluster, e. g. via `kubectl apply`. The manifest will define an [`Organization`]({{< relref "/ui-api/management-api/crd/organizations.security.giantswarm.io.md" >}}) resource (API group/version `security.giantswarm.io/v1alpha1`).
 
 ## Usage
 


### PR DESCRIPTION
Goal of this PR is to make it clear where the output of the kubectl-gs `template <noun>` commands is to be applied.