### PR TITLE
Add training catalog

### DIFF
--- a/src/content/general/support/index.md
+++ b/src/content/general/support/index.md
@@ -60,3 +60,4 @@ Our support process is subject to change. As we continuously improve it we disco
 
 - [Giant Swarm Operation Layers]({{< relref "/security/operational-layers" >}})
 - [Giant Swarm Cluster Upgrades]({{< relref "/general/cluster-upgrades" >}})
+- [Giant Swarm Training Catalog]({{< relref "/general/training-catalog" >}})

--- a/src/content/general/training-catalog/index.md
+++ b/src/content/general/training-catalog/index.md
@@ -1,0 +1,85 @@
+---
+linkTitle: Training Catalog
+title: Giant Swarm Training Catalog
+description: >
+  Overview of the training and workshops we offer to customers
+weight: 60
+menu:
+  main:
+    parent: general
+last_review_date: 2022-03-07
+user_questions:
+  - Which trainings does Giant Swarm offer?
+  - How can I learn about Cloud Native topics?
+  - How can I fully exploit my Giant Swarm setup?
+owner:
+  - https://github.com/orgs/giantswarm/teams/team-teddyfriends
+---
+
+_____________________________________
+
+### Getting Started with Giant Swarm 
+_Team Teddyfriends_
+
+- Who is Giant Swarm?
+- What is the Support model?
+- Onboarding into Happa and `kubectl gs`
+- How does GS help platform teams service application teams?
+- What are best practices that we should aim together for?
+- What is some useful "technical" knowledge? What differentiates Giant Swarm from other providers?
+
+_____________________________________
+
+### Kubernetes 101
+
+_Team Phoenix & Team Rocket_
+
+- High level overview of microservices
+- What is Kubernetes and what are the reasons to use it 
+- Basic Kubernetes concepts
+- Basic Kubernetes best practices
+
+_____________________________________
+
+### GitOps 101
+
+_Team Honeybadger_
+
+- What is GitOps?
+- What are the advantages and reasons to work towards this method?
+- Tooling - our recommendations
+- Internal tour of how GS automation and pipeline is setup
+- An example of GitOps in action
+
+_____________________________________
+
+### Management API and User Authentication (SSO) 101
+
+_Team Rainbow_
+
+- What is the Giant Swarm Management API and why is it important?
+- Examples of Management API best practices
+- Overview of connecting identity providers to Management API as well as Workload Clusters
+
+
+_____________________________________
+
+### Cloud Native Security 101
+
+_Team Zachurity_ 
+
+- What does security mean in a cloud-native world?
+- What are PSPs, NetworkPolicies, RBAC, etc.?
+- What needs to be considered in securing infrastructure outside of Kubernetes clusters?
+- Tooling options for "Day 2" operations
+
+_____________________________________
+
+### Monitoring and Observability 101
+
+_Team Atlas_
+
+- What is the advantage of observability on Kubernetes?
+- Which tools do we provide and recommend? Why?
+- What does the Giant Swarm monitoring stack look like?
+- Monitoring infrastructure and applications

--- a/src/content/general/training-catalog/index.md
+++ b/src/content/general/training-catalog/index.md
@@ -2,7 +2,7 @@
 linkTitle: Training Catalog
 title: Giant Swarm Training Catalog
 description: >
-  Overview of the training and workshops we offer to customers
+  Overview of the trainings and workshops we offer to customers in order to share our knowledge and best practices with them and answer possible follow-up questions.
 weight: 60
 menu:
   main:


### PR DESCRIPTION
This PR intends to make the Giant Swarm training catalog public.

### Please remember to

- [x] Give the PR a meaningful title -- it will be shown in the release notes
- [x] Add (or remove) [user questions](https://github.com/giantswarm/docs/blob/main/CONTRIBUTING.md#front-matter) associated with any updated docs
