### PR TITLE
Set HUGO_DOCS_VERSION environment variable on build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,9 @@ WORKDIR /docs
 
 COPY . /docs
 
+# Expose the release version in content
+ENV HUGO_DOCS_VERSION $CIRCLE_TAG
+
 RUN hugo \
       --verbose \
       --gc \

--- a/helm/docs-app/templates/deployment.yaml
+++ b/helm/docs-app/templates/deployment.yaml
@@ -24,9 +24,6 @@ spec:
           # Public image required
           image: quay.io/giantswarm/{{ .Values.image.name }}:{{ .Values.image.tag }}
           imagePullPolicy: Always
-          env:
-            - name: HUGO_DOCS_VERSION
-              value: {{ .Values.image.tag }}
           ports:
             - containerPort: 8080
               name: http


### PR DESCRIPTION
Towards publishing the docs release version in a content meta tag.

When setting the variable as an env variable in the pod, I missed that it has to be set on build time instead.