### PR TITLE
Update architect-orb to 4.15.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@4.13.0
+  architect: giantswarm/architect@4.15.0
 
 
 jobs:


### PR DESCRIPTION
This PR updates architect-orb to 4.15.0