### PR TITLE
Improve Windows installation instructions for kubectl-gs by using a variable for the target path

### DIFF
--- a/src/content/ui-api/kubectl-gs/installation.md
+++ b/src/content/ui-api/kubectl-gs/installation.md
@@ -149,7 +149,7 @@ Please note that we only provide a 64bit release.
 2. Copy `kubectl-gs.exe` to a location that is included in your `%PATH%`. For example:
 
     ```nohighlight
-    C:\Users\USERNAME\AppData\Local\Microsoft\WindowsApps
+    %USERPROFILE%\AppData\Local\Microsoft\WindowsApps
     ```
 
 {{< /tab >}}


### PR DESCRIPTION
I learned that the `%USERPROFILE%` variable usually points to the user's profile base folder. So this way out path can be copied and used without modification.