### PR TITLE
Adjust OIDC provider endpoint for Service Accounts (IRSA)

### DIFF
--- a/src/content/advanced/iam-roles-for-service-accounts/index.md
+++ b/src/content/advanced/iam-roles-for-service-accounts/index.md
@@ -64,12 +64,12 @@ In oder to use the IAM role with a service account you need to create new AWS ro
         {
             "Effect": "Allow",
             "Principal": {
-                "Federated": "arn:aws:iam::AWS_ACCOUNT:oidc-provider/s3-REGION.amazonaws.com/AWS_ACCOUNT-g8s-CLUSTER_ID-oidc-pod-identity"
+                "Federated": "arn:aws:iam::AWS_ACCOUNT:oidc-provider/s3.REGION.amazonaws.com/AWS_ACCOUNT-g8s-CLUSTER_ID-oidc-pod-identity"
             },
             "Action": "sts:AssumeRoleWithWebIdentity",
             "Condition": {
                 "StringEquals": {
-                    "s3-REGION.amazonaws.com/AWS_ACCOUNT-g8s-CLUSTER_ID-oidc-pod-identity:sub": "system:serviceaccount:NAMESPACE:SA_NAME"
+                    "s3.REGION.amazonaws.com/AWS_ACCOUNT-g8s-CLUSTER_ID-oidc-pod-identity:sub": "system:serviceaccount:NAMESPACE:SA_NAME"
                 }
             }
         }


### PR DESCRIPTION
Slightly adjusting the OIDC provider for service accounts.

The alias `s3-region.amazonaws.com` doesn't work for all regions. Changing it to `s3.region.amazonaws.com` will work


### Please remember to

- [ ] Give the PR a meaningful title -- it will be shown in the release notes
- [ ] Add (or remove) [user questions](https://github.com/giantswarm/docs/blob/main/CONTRIBUTING.md#front-matter) associated with any updated docs
