### PR TITLE
Fix and improve the authentication script for programmatic access

### DIFF
--- a/src/content/ui-api/management-api/authentication/automation/index.md
+++ b/src/content/ui-api/management-api/authentication/automation/index.md
@@ -84,13 +84,18 @@ kubectl --kubeconfig FILE config set-credentials default \
   --token TOKEN
 ```
 
-Last, execute this command with `INSTALLATION` being your installation's name, as in all the previous steps.
+Then execute this command with `INSTALLATION` being your installation's name, as in all the previous steps.
 
 ```nohighlight
 kubectl --kubeconfig FILE config set-context gs-INSTALLATION \
   --cluster default \
-  --user default \
-  --current
+  --user default
+```
+
+Last, select the only context in the kubeconfig as the current one.
+
+```nohighlight
+kubectl --kubeconfig FILE config use-context gs-INSTALLATION
 ```
 
 As a result, in the path `FILE` you have a self-contained kubeconfig file for the Management API. This file includes the service account's authentication token.

--- a/src/content/ui-api/management-api/authentication/automation/index.md
+++ b/src/content/ui-api/management-api/authentication/automation/index.md
@@ -134,26 +134,21 @@ CA_CERT=$(kubectl --context gs-$INSTALLATION --namespace default get secret $SEC
 # Fetch the Management API endpoint
 API_URL=$(kubectl --context gs-$INSTALLATION config view --minify -o jsonpath='{.clusters[0].cluster.server}')
 
-# Generate kubectl configuration
-cat <<EOF > kubeconfig_$INSTALLATION.yaml
-apiVersion: v1
-kind: Config
-clusters:
-- name: default
-   cluster:
-      certificate-authority-data: $CA_CERT
-      server: $API_URL
-users:
-- name: default
-   user:
-      token: $TOKEN
-current-context: gs-$INSTALLATION
-contexts:
-- context:
-   cluster: default
-   user: default
-name: gs-$INSTALLATION
-EOF
+# Create the kubeconfig file
+
+kubectl --kubeconfig kubeconfig_$INSTALLATION.yaml config set-cluster default \
+  --server $API_URL \
+  --embed-certs \
+  --certificate-authority $INSTALLATION-ca.pem
+
+kubectl --kubeconfig kubeconfig_$INSTALLATION.yaml config set-credentials default \
+  --token $TOKEN
+
+kubectl --kubeconfig kubeconfig_$INSTALLATION.yaml config set-context gs-$INSTALLATION \
+  --cluster default \
+  --user default
+
+kubectl --kubeconfig kubeconfig_$INSTALLATION.yaml config use-context gs-$INSTALLATION
 ```
 
 ## Further reading


### PR DESCRIPTION
- We fix the problem that in the `kubectl config set-context` command, the flag `--current` cannot be used with a context name. So we add a `kubectl config use-context` command to fill in the `current-context` in the created file.
- We remove our own YAML which had bad whitespace/indentation and instead make the script use the same commands as the explanation.