### PR TITLE
Display Hubspot GDPR consent banner

### DIFF
--- a/scripts/update-website-content/overrides.css
+++ b/scripts/update-website-content/overrides.css
@@ -4,6 +4,11 @@ html {
 
 a {
   font-weight: unset;
+  color: #1c91d5;
+}
+
+*, ::before, ::after {
+  box-sizing: border-box;
 }
 
 .fa {

--- a/scripts/update-website-content/script.ts
+++ b/scripts/update-website-content/script.ts
@@ -7,6 +7,7 @@ const websiteURL = "https://www.giantswarm.io/why-giant-swarm";
 
 const headerElementSelector = ".header-container-wrapper";
 const footerElementSelector = ".footer-container-wrapper";
+const cookiesBannerElementSelector = "#hs-eu-cookie-confirmation-inner";
 
 const sectionTemplatesPath = path.join(
   __dirname,
@@ -19,6 +20,7 @@ const sectionTemplatesPath = path.join(
 const headerPath = path.join(sectionTemplatesPath, "gs_header.html");
 const footerPath = path.join(sectionTemplatesPath, "gs_footer.html");
 const stylesPath = path.join(sectionTemplatesPath, "gs_styles.html");
+const cookiesBannerStylesPath = path.join(sectionTemplatesPath, "gs_cookies_banner_styles.html");
 
 const cssOverridesPath = path.join(__dirname, "overrides.css");
 
@@ -71,6 +73,19 @@ const generatedFileDisclaimer =
   log("Writing common CSS file.");
   await writeGeneratedFile(
     stylesPath,
+    `<style>\n${commonCSS.join("\n")}\n</style>`
+  );
+
+  // Cookie Consent Banner.
+  log("Extracting cookies consent banner HTML.");
+  const cookiesBanner = await extractElementContents(page, cookiesBannerElementSelector);
+
+  log("Applying custom CSS.");
+  commonCSS = await applyCSSOverrides(Array.from(new Set(cookiesBanner.css)));
+
+  log("Writing cookies consent banner CSS file.");
+  await writeGeneratedFile(
+    cookiesBannerStylesPath,
     `<style>\n${commonCSS.join("\n")}\n</style>`
   );
 

--- a/src/layouts/partials/footer.html
+++ b/src/layouts/partials/footer.html
@@ -6,5 +6,7 @@
 
     {{ partial "scripts" . }}
 
+    {{ partial "gs_cookies_banner_styles"}}
+
 </body>
 </html>

--- a/src/layouts/partials/gs_cookies_banner_styles.html
+++ b/src/layouts/partials/gs_cookies_banner_styles.html
@@ -1,0 +1,137 @@
+<!-- !!! DO NOT EDIT !!! File generated with 'make update-website-content' -->
+
+<style>
+a { background-color: transparent; }
+*, ::before, ::after { box-sizing: inherit; }
+a { color: rgb(0, 159, 255); text-decoration: none; transition: color 0.4s ease 0s, text-shadow 0.4s ease 0s, background-color 0.4s ease 0s, border-color 0.4s ease 0s, box-shadow 0.4s ease 0s, opacity 0.4s ease 0s; font-weight: 500; }
+p { max-width: 100%; margin-top: 0px; }
+p, .p { margin-bottom: 1.8em; }
+div#hs-eu-cookie-confirmation * { box-sizing: border-box !important; }
+div#hs-eu-cookie-confirmation div#hs-eu-cookie-confirmation-inner { background: rgb(255, 255, 255); margin: 0px auto; max-width: 1000px; padding: 20px; }
+div#hs-eu-cookie-confirmation div#hs-eu-cookie-confirmation-inner a { text-decoration: none !important; }
+div#hs-eu-cookie-confirmation div#hs-eu-cookie-confirmation-inner a, div#hs-eu-cookie-confirmation div#hs-eu-cookie-confirmation-inner a:hover { color: rgb(0, 145, 174); font-family: inherit; font-size: inherit; line-height: inherit; text-align: left; background: none !important; border: none !important; box-shadow: none !important; font-weight: 400 !important; text-shadow: none !important; }
+div#hs-eu-cookie-confirmation div#hs-eu-cookie-confirmation-inner a:hover { text-decoration: underline !important; }
+div#hs-eu-cookie-confirmation div#hs-eu-cookie-confirmation-inner div#hs-eu-policy-wording { margin-bottom: 12px; }
+div#hs-eu-cookie-confirmation div#hs-eu-cookie-confirmation-inner div#hs-en-cookie-confirmation-buttons-area, div#hs-eu-cookie-confirmation div#hs-eu-cookie-confirmation-inner div#hs-eu-cookie-confirmation-button-group { display: flex; flex-flow: row wrap; align-items: center; }
+div#hs-eu-cookie-confirmation div#hs-eu-cookie-confirmation-inner div#hs-en-cookie-confirmation-buttons-area { justify-content: flex-end; align-items: center; margin: 10px 0px 0px !important; }
+div#hs-eu-cookie-confirmation div#hs-eu-cookie-confirmation-inner div#hs-eu-cookie-confirmation-button-group { justify-content: center; }
+div#hs-eu-cookie-confirmation div#hs-eu-cookie-confirmation-inner a#hs-eu-confirmation-button, div#hs-eu-cookie-confirmation div#hs-eu-cookie-confirmation-inner a#hs-eu-cookie-settings-button, div#hs-eu-cookie-confirmation div#hs-eu-cookie-confirmation-inner a#hs-eu-decline-button { margin: 6px !important; }
+div#hs-eu-cookie-confirmation div#hs-eu-cookie-confirmation-inner a#hs-eu-confirmation-button, div#hs-eu-cookie-confirmation div#hs-eu-cookie-confirmation-inner a#hs-eu-decline-button { border-radius: 3px; display: inline-block; padding: 10px 16px !important; text-decoration: none !important; }
+div#hs-eu-cookie-confirmation div#hs-eu-cookie-confirmation-inner a#hs-eu-confirmation-button { color: rgb(255, 255, 255); font-family: inherit; font-size: inherit; line-height: inherit; text-align: left; background-color: rgb(66, 91, 118) !important; border: 1px solid rgb(66, 91, 118) !important; font-weight: 400 !important; text-shadow: none !important; }
+div#hs-eu-cookie-confirmation div#hs-eu-cookie-confirmation-inner a#hs-eu-decline-button { color: rgb(66, 91, 118); font-family: inherit; font-size: inherit; line-height: inherit; text-align: left; border: 1px solid rgb(66, 91, 118) !important; font-weight: 400 !important; text-shadow: none !important; }
+div#hs-eu-cookie-confirmation div#hs-eu-cookie-confirmation-inner a#hs-eu-cookie-settings-button { color: rgb(66, 91, 118) !important; }
+div#hs-eu-cookie-confirmation div#hs-eu-cookie-confirmation-inner p { margin: 0px 0px 12px; color: rgb(51, 71, 91); font-family: inherit; font-size: inherit; line-height: inherit; text-align: left; font-weight: 400 !important; text-shadow: none !important; }
+@media (max-width: 800px) {
+div#hs-eu-cookie-confirmation div#hs-eu-cookie-confirmation-inner div#hs-en-cookie-confirmation-buttons-area { justify-content: center; }
+}
+@media screen and (max-width: 480px) {
+div#hs-eu-cookie-confirmation div#hs-eu-cookie-confirmation-inner { padding: 8px 14px 14px !important; }
+div#hs-eu-cookie-confirmation div#hs-eu-cookie-confirmation-inner a, div#hs-eu-cookie-confirmation div#hs-eu-cookie-confirmation-inner a#hs-eu-confirmation-button { font-size: 12px !important; }
+div#hs-eu-cookie-confirmation div#hs-eu-cookie-confirmation-inner p { font-size: 12px !important; margin-bottom: 12px !important; line-height: 15px !important; }
+}
+div#hs-eu-cookie-confirmation-inner { display: table; max-width: 1260px !important; padding: 20px 30px 10px !important; }
+#hs-eu-policy-wording { display: table-cell; font-size: 14px; line-height: 24px; color: rgb(91, 108, 121); vertical-align: middle !important; }
+#hs-en-cookie-confirmation-buttons-area { display: table-cell !important; vertical-align: middle !important; }
+div#hs-eu-cookie-confirmation div#hs-eu-cookie-confirmation-inner a, div#hs-eu-cookie-confirmation div#hs-eu-cookie-confirmation-inner a:hover { color: rgb(0, 159, 255) !important; font-weight: 500 !important; }
+div#hs-eu-cookie-confirmation div#hs-eu-cookie-confirmation-inner a#hs-eu-confirmation-button { background: rgb(232, 109, 0) !important; color: rgb(255, 255, 255) !important; font-size: 14px !important; font-weight: 600 !important; padding: 11px 23px !important; border: none !important; border-radius: 60px !important; min-width: 160px !important; text-align: center !important; }
+div#hs-eu-cookie-confirmation div#hs-eu-cookie-confirmation-inner a#hs-eu-confirmation-button:hover { transform: scale(1.15) !important; transition: all 0.2s ease-in-out 0s !important; }
+div#hs-eu-cookie-confirmation div#hs-eu-cookie-confirmation-inner a#hs-eu-decline-button { font-size: 14px !important; color: rgb(111, 138, 159) !important; text-decoration: underline !important; border: none !important; padding: 0px !important; font-weight: 500 !important; }
+div#hs-eu-cookie-confirmation-button-group { margin: 0px auto !important; }
+@media (max-width: 767px) {
+div#hs-eu-cookie-confirmation-inner, #hs-eu-policy-wording, #hs-en-cookie-confirmation-buttons-area { display: block !important; }
+#hs-eu-policy-wording { font-size: 14px !important; line-height: 24px !important; }
+div#hs-eu-cookie-confirmation div#hs-eu-cookie-confirmation-inner a#hs-eu-confirmation-button { width: 100% !important; }
+div#hs-eu-cookie-confirmation div#hs-eu-cookie-confirmation-inner { padding: 30px !important; }
+@media (max-width: 480px) {
+#hs-eu-policy-wording, div#hs-eu-cookie-confirmation div#hs-eu-cookie-confirmation-inner p { font-size: 14px !important; line-height: 24px !important; color: rgb(91, 108, 121) !important; }
+div#hs-eu-cookie-confirmation div#hs-eu-cookie-confirmation-inner { padding: 30px !important; }
+}
+}
+html {
+  font-size: 100% !important;
+}
+
+a {
+  font-weight: unset;
+  color: #1c91d5;
+}
+
+*, ::before, ::after {
+  box-sizing: border-box;
+}
+
+.fa {
+  font-weight: inherit !important;
+  font-family: "GiantSwarmHappaAndDocs" !important;
+}
+
+.header-container-wrapper .fa,
+.footer-container-wrapper .fa {
+  font-weight: 900 !important;
+  font-family: "Font Awesome 5 Free" !important;
+}
+
+.header-container-wrapper,
+.footer-container-wrapper {
+  font-weight: 400;
+  font-family: inherit;
+  line-height: 1.7;
+}
+
+.header-container-wrapper .header-container.container-fluid,
+.footer-container-wrapper .footer-container.container-fluid {
+  padding-left: 0;
+  padding-right: 0;
+}
+
+.header-container-wrapper {
+  background: #fff;
+  z-index: 999999;
+  margin-bottom: 20px;
+}
+
+.header-container-wrapper .button {
+  display: inline-block;
+  position: relative;
+  max-width: 100%;
+  border: 2px solid transparent;
+  border-radius: 60px;
+  font-weight: 700;
+  text-align: center;
+  text-decoration: none !important;
+  text-shadow: none;
+  cursor: pointer;
+  transition: 0.2s ease-in-out;
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.header-container-wrapper .control-button.search {
+  display: none;
+}
+
+.header-container-wrapper .slide-menu-scroller .close,
+.header-container-wrapper .slide-menu-scroller .close:hover,
+.header-container-wrapper .slide-menu-scroller .close:focus {
+  color: #fff;
+  text-shadow: none;
+  float: none;
+  opacity: unset;
+}
+
+.footer-container-wrapper {
+  margin-top: 80px;
+}
+
+.footer-container-wrapper a:hover {
+  text-decoration: none;
+}
+
+@media (max-width: 1139px) {
+  .header-container-wrapper .control-button.menu.hidden.md-visible.sm-visible,
+  .header-container-wrapper .button.hidden.md-visible.sm-visible {
+    display: block !important;
+    visibility: visible !important;
+  }
+}
+</style>

--- a/src/layouts/partials/gs_styles.html
+++ b/src/layouts/partials/gs_styles.html
@@ -1093,6 +1093,11 @@ html {
 
 a {
   font-weight: unset;
+  color: #1c91d5;
+}
+
+*, ::before, ::after {
+  box-sizing: border-box;
 }
 
 .fa {

--- a/src/layouts/partials/scripts.html
+++ b/src/layouts/partials/scripts.html
@@ -8,3 +8,6 @@
 <script type="text/javascript" src="https://s.giantswarm.io/giantswarmio/0.10.18/1/bootstrap.min.js"></script>
 <script type="text/javascript" src="/js/polyfill/IntersectionObserver.js"></script>
 <script type="text/javascript" src="{{ $secureJS.RelPermalink }}" integrity="{{ htmlUnescape $secureJS.Data.Integrity }}"></script>
+<!-- Start of HubSpot Embed Code -->
+<script type="text/javascript" id="hs-script-loader" async defer src="//js.hs-scripts.com/430224.js"></script>
+<!-- End of HubSpot Embed Code -->


### PR DESCRIPTION
Closes https://github.com/giantswarm/giantswarm/issues/22127.

This PR enables the display of the GDPR consent banner from Hubspot by adding the Hubspot embed code. The `update-website-content` script has also been modified to extract and apply styles for the banner from the main website.

<img width="1326" alt="Screen Shot 2022-05-17 at 14 07 43" src="https://user-images.githubusercontent.com/62935115/168814746-29e036a6-70d8-4968-8c8c-8bfd5c00219f.png">
