### PR TITLE
Updating template app doc

### DIFF
--- a/src/content/ui-api/kubectl-gs/template-app.md
+++ b/src/content/ui-api/kubectl-gs/template-app.md
@@ -68,6 +68,7 @@ It also supports the following optional flags:
 - `--user-secret`: Path to the user secrets YAML file.
 - `--namespace-annotations`: Additional annotations to be appended to the metadata of the target namespace (through [`spec.namespaceConfig.annotations`]({{< relref "/app-platform/namespace-configuration/index.md" >}}) of [App]({{< relref "/ui-api/management-api/crd/apps.application.giantswarm.io.md" >}}) CR) in form `key=value`. To specify multiple annotations, either separate annotation pairs with commata (,) or specify the flag multiple times.
 - `--namespace-labels`: Additional labels to be appended to the metadata of the target namespace (through [`spec.namespaceConfig.labels`]({{< relref "/app-platform/namespace-configuration/index.md" >}}) of [App]({{< relref "/ui-api/management-api/crd/apps.application.giantswarm.io.md" >}}) CR) in form `key=value`. To specify multiple labels, either separate label pairs with commata (,) or specify the flag multiple times.
+- `--in-cluster`: Creates in-cluster App CR, necessary for insalling collection of apps, for example [Security Pack]({{< relref "/app-platform/apps/security/index.md" >}}).
 
 Only required fields are templated. Other fields are are set by the
 [defaulting webhook]({{< relref "/app-platform/defaulting-validation" >}}).


### PR DESCRIPTION
### Description

Adding information about `--in-cluster`. I don't think we need another mention about `--cluster` flag, as it is already defined as required at the top of the document. So let's not make it more conditional, I like the straightforwardness it provides now.

Towards: https://github.com/giantswarm/kubectl-gs/pull/816

### Please remember to

- [x] Give the PR a meaningful title -- it will be shown in the release notes
- [x] Add (or remove) [user questions](https://github.com/giantswarm/docs/blob/main/CONTRIBUTING.md#front-matter) associated with any updated docs
