### PR TITLE
Fixing managed-by label doc

### DIFF
--- a/src/content/app-platform/defaulting-validation/index.md
+++ b/src/content/app-platform/defaulting-validation/index.md
@@ -124,9 +124,11 @@ If you are managing your App CRs by the means of a third party tool (e.g. Flux) 
 validating webhook may block creation of the App CR if it is created before the
 referenced ConfigMap or Secret.
 
-To prevent this you can add the label `giantswarm.io/managed-by` and set the value
-to the tool you're using e.g. `flux` or `helm`, see example below (some fields have
-been removed for brevity).
+To prevent this you can add the label `giantswarm.io/managed-by` and set the value to the tool
+you're using e.g. `flux` or `helm`. If you are not using a particular tool to deploy your
+resources but find the validation blocking you, you may also set this to some other value,
+for example `external`, to allow your CRs to be created regardless. See example below, note,
+some fields have been removed for brevity.
 
 ```yaml
 apiVersion: application.giantswarm.io/v1alpha1

--- a/src/content/app-platform/defaulting-validation/index.md
+++ b/src/content/app-platform/defaulting-validation/index.md
@@ -12,7 +12,7 @@ owner:
 aliases:
   - /reference/app-defaulting-validation/
 user_questions:
-  - Is App CR defaulting and validation logic enabled for my cluster? 
+  - Is App CR defaulting and validation logic enabled for my cluster?
   - How can I use App CR defaulting logic when installing Managed Apps?
   - What fields are validated in App CRs when installing or updating Managed Apps?
   - How can I ensure Flux is not blocked by the validating webhook?
@@ -118,28 +118,34 @@ If app-operator finds a matching [AppCatalogEntry]({{< relref "/ui-api/managemen
 - Cloud provider compatibility (e.g. you can’t install the azure-ad-pod-identity app in AWS).
 - Namespace restriction (cluster singleton, namespace singleton, fixed namespace).
 
-## GitOps support
+## Skipping Configuration Validation
 
-If you are managing your App CRs with Flux or a similar GitOps tool then the
+If you are managing your App CRs by the means of a third party tool (e.g. Flux) then the
 validating webhook may block creation of the App CR if it is created before the
-referenced configmap or secret.
+referenced ConfigMap or Secret.
 
 To prevent this you can add the label `giantswarm.io/managed-by` and set the value
-to the tool you're using e.g. `flux`.
+to the tool you're using e.g. `flux` or `helm`, see example below (some fields have
+been removed for brevity).
 
 ```yaml
 apiVersion: application.giantswarm.io/v1alpha1
 kind: App
 metadata:
-  name: my-kong
-  namespace: x7jwz
+  name: my-app
+  namespace: w0xyz
   labels:
     giantswarm.io/managed-by: flux
+spec:
+  userConfig:
+    configMap:
+      name: my-app-userconfig
+      namespace: w0xyz
 ```
 
-app-admission-controller will now allow the App CR to be created. app-operator
-will still perform the validation checks and once the referenced configmap or
-secret exists the app will be installed.
+The `app-admission-controller` will now allow the App CR to be created despite the referenced
+`my-app-userconfig` does not exist. The `app-operator` will still perform the validation checks
+and once the referenced ConfigMap or Secret exists the app will be installed.
 
 ## Retry Logic
 


### PR DESCRIPTION
### Description

Some time ago we introduced possibility to skip ConfigMaps and Secrets existence validation in the `app-admission-controller` and at the beginning it was enabled for App CRs with the `giantswarm.io/managed-by: flux` label set. Later on, we made it more general, so that this label can have any value, though we haven't properly emphasized it in the docs.

Related discussions:
* https://gigantic.slack.com/archives/C02GDJJ68Q1/p1656519031560279
* https://gigantic.slack.com/archives/C01G30NGUS3/p1653379121548609

### Please remember to

- [x] Give the PR a meaningful title -- it will be shown in the release notes
- [x] Add (or remove) [user questions](https://github.com/giantswarm/docs/blob/main/CONTRIBUTING.md#front-matter) associated with any updated docs
