### PR TITLE
replace installation names with example

### DIFF
--- a/src/content/getting-started/rbac-and-psp/index.md
+++ b/src/content/getting-started/rbac-and-psp/index.md
@@ -302,7 +302,7 @@ Setting a Common Name Prefix results in a username like the following:
 <cn-prefix>.user.api.<cluster-domain>
 ```
 
-where `<cn-prefix>` is a username of your choice and `<cluster-domain>` is your cluster's domain, e.g. `w6wn8.k8s.ginger.eu-central-1.aws.gigantic.io`.
+where `<cn-prefix>` is a username of your choice and `<cluster-domain>` is your cluster's domain, e.g. `w6wn8.k8s.example.eu-central-1.aws.gigantic.io`.
 
 When binding roles to a user you need to use the full username mentioned above.
 
@@ -352,7 +352,7 @@ metadata:
   namespace: development
 subjects:
   - kind: User
-    name: jane.w6wn8.k8s.ginger.eu-central-1.aws.gigantic.io
+    name: jane.w6wn8.k8s.example.eu-central-1.aws.gigantic.io
     apiGroup: rbac.authorization.k8s.io
   - kind: Group
     name: dev-admin
@@ -390,7 +390,7 @@ metadata:
   name: cluster-viewer
 subjects:
   - kind: User
-    name: jane.w6wn8.k8s.ginger.eu-central-1.aws.gigantic.io
+    name: jane.w6wn8.k8s.example.eu-central-1.aws.gigantic.io
     apiGroup: rbac.authorization.k8s.io
   - kind: Group
     name: cluster-view

--- a/src/content/ui-api/gsctl/info.md
+++ b/src/content/ui-api/gsctl/info.md
@@ -45,8 +45,8 @@ gsctl version:        0.11.2
 gsctl build:          2018-04-26T07:33:33Z
 Config path:          /Users/marian/.config/gsctl/config.yaml
 kubectl config path:  /Users/marian/.kube/config
-API endpoint:         https://api.g8s.gollum.westeurope.azure.gigantic.io
-API endpoint alias:   gollum
+API endpoint:         https://api.g8s.example.westeurope.azure.gigantic.io
+API endpoint alias:   example
 Email:                somebody@example.com
 Logged in:            no
 Provider:             n/a

--- a/src/content/ui-api/kubectl-gs/login.md
+++ b/src/content/ui-api/kubectl-gs/login.md
@@ -158,7 +158,7 @@ Example:
 
 ```nohighlight
 O=73ce775d904da53e,
-CN=73ce775d904da53e.i94nf.k8s.garlic.westeurope.azure.gigantic.io
+CN=73ce775d904da53e.i94nf.k8s.example.westeurope.azure.gigantic.io
 ```
 
 When presenting such client certificate to the Kubernetes API server, the `CN` field is interpreted as the user identifier, while the `O` field is interpreted as a list of groups the user is a member of.
@@ -182,7 +182,7 @@ The resulting client certificate would have a subject like this:
 O=group1,
 O=group2,
 O=5ab261600796bef7,
-CN=5ab261600796bef7.i94nf.k8s.garlic.westeurope.azure.gigantic.io
+CN=5ab261600796bef7.i94nf.k8s.example.westeurope.azure.gigantic.io
 ```
 
 #### Creating a client certificate in automation {#wc-client-cert-automation}

--- a/src/content/ui-api/management-api/crd/azureclusters.infrastructure.cluster.x-k8s.io.md
+++ b/src/content/ui-api/management-api/crd/azureclusters.infrastructure.cluster.x-k8s.io.md
@@ -73,7 +73,7 @@ metadata:
   namespace: org-giantswarm
 spec:
   controlPlaneEndpoint:
-    host: api.mmh5x.k8s.ghost.westeurope.azure.gigantic.io
+    host: api.mmh5x.k8s.example.westeurope.azure.gigantic.io
     port: 443
   location: westeurope
   networkSpec:

--- a/src/content/ui-api/management-api/crd/certconfigs.core.giantswarm.io.md
+++ b/src/content/ui-api/management-api/crd/certconfigs.core.giantswarm.io.md
@@ -67,10 +67,10 @@ spec:
   cert:
     allowBareDomains: false
     altNames:
-    - api.c68pn.gollum.westeurope.azure.gigantic.io
+    - api.c68pn.example.westeurope.azure.gigantic.io
     clusterComponent: prometheus
     clusterID: c68pn
-    commonName: api.c68pn.k8s.gollum.westeurope.azure.gigantic.io
+    commonName: api.c68pn.k8s.example.westeurope.azure.gigantic.io
     disableRegeneration: false
     organizations:
     - giantswarm

--- a/src/content/ui-api/management-api/creating-workload-clusters/aws/index.md
+++ b/src/content/ui-api/management-api/creating-workload-clusters/aws/index.md
@@ -78,7 +78,7 @@ spec:
   cluster:
     description: Demo cluster
     dns:
-      domain: gorilla.eu-central-1.aws.gigantic.io
+      domain: example.eu-central-1.aws.gigantic.io
     oidc:
       claims: {}
   provider:

--- a/src/content/ui-api/management-api/creating-workload-clusters/azure/index.md
+++ b/src/content/ui-api/management-api/creating-workload-clusters/azure/index.md
@@ -56,7 +56,7 @@ spec:
     namespace: default
     name: nzr5z
   controlPlaneEndpoint:
-    host: api.nzr5z.k8s.ghost.westeurope.azure.gigantic.io
+    host: api.nzr5z.k8s.example.westeurope.azure.gigantic.io
     port: 443
 ```
 
@@ -86,7 +86,7 @@ spec:
   location: westeurope
   resourceGroup: nzr5z
   controlPlaneEndpoint:
-    host: api.nzr5z.k8s.ghost.westeurope.azure.gigantic.io
+    host: api.nzr5z.k8s.example.westeurope.azure.gigantic.io
     port: 443
 ```
 

--- a/src/content/ui-api/monitoring/index.md
+++ b/src/content/ui-api/monitoring/index.md
@@ -36,11 +36,11 @@ In case you want to construct the URL to the Grafana web application in your ins
 
 For example, if your web interface URL is
 
-    https://happa.g8s.gollum.westeurope.azure.gigantic.io/
+    https://happa.g8s.example.westeurope.azure.gigantic.io/
 
 then simply replace `happa` with `grafana` to get to your Grafana URL:
 
-    https://grafana.g8s.gollum.westeurope.azure.gigantic.io/
+    https://grafana.g8s.example.westeurope.azure.gigantic.io/
 
 ## Authentication and authorization
 


### PR DESCRIPTION
Searched and replaced all installations names with `example`.

Maybe `installation` would have a been a better keyword ?