### PR TITLE
Node pools: change KVM support to 'not planned'

### DIFF
--- a/src/content/advanced/node-pools/index.md
+++ b/src/content/advanced/node-pools/index.md
@@ -18,7 +18,7 @@ owner:
 last_review_date: 2021-01-01
 ---
 
-{{< platform_support_table aws="beta=v10.0.0,ga=v11.0.0" azure="ga=v13.0.0" kvm="Not planned" >}}
+{{< platform_support_table aws="beta=v10.0.0,ga=v11.0.0" azure="ga=v13.0.0" >}}
 
 ## Definition
 

--- a/src/content/advanced/node-pools/index.md
+++ b/src/content/advanced/node-pools/index.md
@@ -18,7 +18,7 @@ owner:
 last_review_date: 2021-01-01
 ---
 
-{{< platform_support_table aws="beta=v10.0.0,ga=v11.0.0" azure="ga=v13.0.0" kvm="roadmap=https://github.com/giantswarm/roadmap/issues/209" >}}
+{{< platform_support_table aws="beta=v10.0.0,ga=v11.0.0" azure="ga=v13.0.0" kvm="Not planned" >}}
 
 ## Definition
 


### PR DESCRIPTION
Removes platform support info for KVM.

### Currently

<img width="668" alt="image" src="https://user-images.githubusercontent.com/273727/188647408-71e8a444-d135-4e54-a461-9612c2cd4bb5.png">


### Please remember to

- [x] Give the PR a meaningful title -- it will be shown in the release notes
- [x] Add (or remove) [user questions](https://github.com/giantswarm/docs/blob/main/CONTRIBUTING.md#front-matter) associated with any updated docs
