### PR TITLE
Add info to `kubectl gs get organizations` docs page

### DIFF
--- a/src/content/ui-api/kubectl-gs/get-organizations.md
+++ b/src/content/ui-api/kubectl-gs/get-organizations.md
@@ -18,6 +18,8 @@ last_review_date: 2022-09-07
 
 Like with all `get` commands in `kubectl`, this command can be used to get details on one item, an organization in this case, or list several of them.
 
+The command is an improvement over `kubectl get organizations`, for several reasons. First, it is usable by all users who have access to the management API, not only admins, as it does not require permission to list Organization resources on the cluster scope. Second, it provides slightly more details in the list output.
+
 ## Usage
 
 ### Get a list of organizations {#list}


### PR DESCRIPTION
Found it worthwhile to explain why we have this command.

### Please remember to

- [x] Give the PR a meaningful title -- it will be shown in the release notes
- [ ] Add (or remove) [user questions](https://github.com/giantswarm/docs/blob/main/CONTRIBUTING.md#front-matter) associated with any updated docs
