### PR TITLE
Update linkchecker docker image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ linkcheck:
 	docker run --rm -ti --name linkchecker \
 		-v ${PWD}/volumes/linkchecker:/workdir:rw \
 		-w /workdir \
-		linkchecker \
+		ghcr.io/linkchecker/linkchecker \
 		https://docs.giantswarm.io \
 		-t 1 \
 		--file-output csv/linkcheck.csv \


### PR DESCRIPTION
### What does this PR do?

Modifies the docker image name for "linkchecker" in the Makefile.

The image we used from Dockerhub is no longer maintained.