### PR TITLE
Show the right repo name instead of "apiextensions" in CRD docs

### DIFF
--- a/src/layouts/_default/crd.html
+++ b/src/layouts/_default/crd.html
@@ -19,7 +19,11 @@
 
       <hr />
 
-      <p>This documentation page shows information based on <a href="{{ $.Params.crd.source_repository }}/tree/{{ $.Params.crd.source_repository_ref }}" target="_blank" rel="noopener noreferrer">apiextensions {{ $.Params.crd.source_repository_ref }}</a>.
+      {{ $nameparts := split $.Params.crd.source_repository "/" }}
+      {{ $nameparts := last 1 $nameparts }}
+      {{ $shortname := index $nameparts 0 }}
+
+      <p>This documentation page shows information based on <a href="{{ $.Params.crd.source_repository }}/tree/{{ $.Params.crd.source_repository_ref }}" target="_blank" rel="noopener noreferrer">{{ $shortname }} {{ $.Params.crd.source_repository_ref }}</a>.
 
       <div class="feedback well">
         <h5><i class="fa fa-help-outline"></i> Need help with the Management API?</h5>


### PR DESCRIPTION
### What does this PR do?

In the CRD details page template, replaces a hard coded repository name with the name of the Github repo containing the source of truth of the current CRD.

### What does it look like?

Before

<img width="609" alt="image" src="https://user-images.githubusercontent.com/273727/189897095-e1213f3b-3dd8-477e-b675-1fd96451748f.png">

After

<img width="642" alt="image" src="https://user-images.githubusercontent.com/273727/189897035-368ba6a8-994f-4144-bc2f-20424295d5fc.png">

