### PR TITLE
Kubectl gs deprecated flags update

### DIFF
--- a/src/content/ui-api/kubectl-gs/_index.md
+++ b/src/content/ui-api/kubectl-gs/_index.md
@@ -11,7 +11,7 @@ menu:
   main:
     identifier: uiapi-kubectlgs
     parent: ui-api
-last_review_date: 2022-09-08
+last_review_date: 2022-09-14
 user_questions:
   - Which commands does kubectl-gs offer?
 aliases:
@@ -49,6 +49,37 @@ Deprecated commands:
 
 - [`get appcatalogs`][100] -- replaced by [`get catalogs`][3]
 - [`template appcatalog`][101] -- replaced by [`template catalog`][7]
+
+## Flags {#flags}
+
+| Name               | Description             |
+|--------------------|-------------------------|
+| `--v`, `--version` | Version for kubectl gs. |
+
+## Global flags {#global-flags}
+
+| Name                         | Description                                                                                                                                                                                                     |
+|------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `--as`                       | Username to impersonate for the operation. User could be a regular user or a service account in a namespace.                                                                                                    |
+| `--as-group`                 | Group to impersonate for the operation, this flag can be repeated to specify multiple groups.                                                                                                                   |
+| `--as-uid`                   | UID to impersonate for the operation.                                                                                                                                                                           |
+| `--cache-dir`                | Default cache directory.                                                                                                                                                                                        |
+| `--certificate-authority`    | Path to a cert file for the certificate authority.                                                                                                                                                              |
+| `--client-certificate`       | Path to a client certificate file for TLS.                                                                                                                                                                      |
+| `--client-key`               | Path to a client key file for TLS.                                                                                                                                                                              |
+| `--cluster`                  | The name of the kubeconfig cluster to use.                                                                                                                                                                      |
+| `--context`                  | The name of the kubeconfig context to use.                                                                                                                                                                      |
+| `--debug`                    | Toggle debug mode, for seeing full error output.                                                                                                                                                                |
+| `--disable-version-check`    | Disable self-update version check.                                                                                                                                                                              |
+| `-h`, `--help`               | Help for kubectl gs.                                                                                                                                                                                            |
+| `--insecure-skip-tls-verify` | If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure.                                                                                             |
+| `--kubeconfig`               | Path to the kubeconfig file to use for CLI requests.                                                                                                                                                            |
+| `-n`, `--namespace`          | If present, the namespace scope for this CLI request.                                                                                                                                                           |
+| `--request-timeout`          | The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0") |
+| `-s`, `--server`             | The address and port of the Kubernetes API server                                                                                                                                                               |
+| `--tls-server-name`          | Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used                                                                                    |
+| `--token`                    | Bearer token for authentication to the API server                                                                                                                                                               |
+| `--user`                     | The name of the kubeconfig user to use                                                                                                                                                                          |
 
 ## Installing and updating {#install}
 

--- a/src/content/ui-api/kubectl-gs/gitops/add-app.md
+++ b/src/content/ui-api/kubectl-gs/gitops/add-app.md
@@ -8,7 +8,7 @@ menu:
     parent: kubectlgs-gitops
 aliases:
   - /reference/kubectl-gs/gitops/add-app/
-last_review_date: 2022-08-31
+last_review_date: 2022-09-14
 owner:
   - https://github.com/orgs/giantswarm/teams/team-honeybadger
 user_questions:
@@ -45,20 +45,28 @@ working base to reference with the `--base` flag. In any case, user may provide 
 
 ## Flags
 
-| Name              | Description                                                                | Required |
-| ----------------- | -------------------------------------------------------------------------- | -------- |
+| Name                 | Description                                                             | Required |
+|----------------------| ----------------------------------------------------------------------- | -------- |
 | `app`                | App name in the catalog.                                                | false    |
 | `base`               | Path to the base directory. It must be relative to the repository root. | false    |
 | `catalog`            | Catalog to install the app from.                                        | false    |
 | `management-cluster` | Codename of the Management Cluster the Workload Cluster belongs to.     | true     |
 | `name`               | Name of the app to use for creating the repository directory structure. | false    |
-| `namespace`          | Namespace to install app into.                                          | false    |
+| `target-namespace`   | Namespace to install app into.                                          | false    |
 | `organization`       | Name of the Organization the Workload Cluster belongs to.               | true     |
 | `skip-mapi`          | Skip mapi directory when adding the app.                                | false    |
 | `user-configmap`     | Values YAML to customize the app with. Will get turn into a ConfigMap.  | false    |
 | `user-secret`        | Values YAML to customize the app with. Will get turn into a Secret.     | false    |
 | `version`            | App version to install.                                                 | false    |
 | `workload-cluster`   | Name of the Workload Cluster to configure the app for.                  | true     |
+
+### Deprecated flags
+
+To maintain backward compatibility the command also supports an older flag variation:
+
+- `--namespace` - replaced by `--target-namespace`
+
+This older flag variation is marked as deprecated and will be removed in the next major version of `kubectl gs`.
 
 ## Usage
 
@@ -78,7 +86,7 @@ kubectl gs gitops add app \
 --app hello-world \
 --catalog giantswarm \
 --version 0.3.0 \
---namespace default \
+--target-namespace default \
 --name hello-world \
 --dry-run
 
@@ -138,7 +146,7 @@ kubectl gs gitops add app \
 --app hello-world \
 --catalog giantswarm \
 --version 0.3.0 \
---namespace default \
+--target-namespace default \
 --name hello-world \
 --user-configmap /tmp/values.yaml \
 --dry-run

--- a/src/content/ui-api/kubectl-gs/template-app.md
+++ b/src/content/ui-api/kubectl-gs/template-app.md
@@ -8,7 +8,7 @@ menu:
     parent: uiapi-kubectlgs
 aliases:
   - /reference/kubectl-gs/template-app/
-last_review_date: 2021-06-29
+last_review_date: 2022-09-14
 owner:
   - https://github.com/orgs/giantswarm/teams/team-honeybadger
 user_questions:
@@ -27,10 +27,17 @@ The command to execute is `kubectl gs template app`.
 It supports the following required flags:
 
 - `--name`: Name of the app in the catalog. This is also the name of the App CR unless `--app-name` is set.
-- `--namespace`: Namespace where the app will be deployed.
+- `--target-namespace`: Namespace where the app will be deployed.
 - `--catalog`: Catalog name where the app package is stored. `Catalog` CR for this catalog must exist in the cluster.
-- `--cluster`: Name of the cluster the app will be deployed to.
+- `--cluster-name`: Name of the cluster the app will be deployed to.
 - `--version`: Version of the app to be installed. The version package must exist in the `Catalog` storage.
+
+It also supports older flag variations to maintain backward compatibility:
+
+- `--namespace` - replaced by `--target-namespace`.
+- `--cluster` - replaced by `--cluster-name`.
+
+These older flag variations are marked as deprecated and will be removed in the next major version of `kubectl gs`.
 
 The example command
 
@@ -38,8 +45,8 @@ The example command
 kubectl gs template app \
   --catalog giantswarm-playground \
   --name keda \
-  --namespace default \
-  --cluster 2hr7z  \
+  --target-namespace default \
+  --cluster-name 2hr7z  \
   --version 0.1.0
 ```
 

--- a/src/content/ui-api/kubectl-gs/template-catalog.md
+++ b/src/content/ui-api/kubectl-gs/template-catalog.md
@@ -8,7 +8,7 @@ menu:
     parent: uiapi-kubectlgs
 aliases:
   - /reference/kubectl-gs/template-catalog/
-last_review_date: 2021-07-20
+last_review_date: 2022-09-14
 owner:
   - https://github.com/orgs/giantswarm/teams/team-honeybadger
 user_questions:
@@ -32,19 +32,25 @@ The command to execute is `kubectl gs template catalog`.
 It supports the following required flags:
 
 - `--name` - Catalog name.
-- `--namespace` - Namespace where the catalog will be created.
+- `--target-namespace` - Namespace where the catalog will be created.
 - `--description` - Description of the purpose of the catalog.
 - `--url` - URL where the helm repository lives. Can be defined multiple times if you want to utilize repository mirroring.
 - `--type` - Label containing a type of the helm repository. Defaults to `helm`. Can be defined multiple times.
 - `--logo` - URL of the catalog logo image.
 - `--visibility` - Defaults to `public` in which case the catalog appears in the web UI. Any other value will hide the catalog.
 
+It also supports an older flag variation to maintain backward compatibility:
+
+- `--namespace` - replaced by `--target-namespace`.
+
+This older flag variation is marked as deprecated and will be removed in the next major version of `kubectl gs`.
+
 Example command:
 
 ```nohighlight
 kubectl gs template catalog \
   --name example-catalog \
-  --namespace example-org \
+  --target-namespace example-org \
   --description "An example Catalog" \
   --url https://example.github.io/my-app-catalog/ \
   --logo https://example.com/logos/example-logo.png
@@ -55,7 +61,7 @@ Example command with multiple repositories defined:
 ```nohighlight
 kubectl gs template catalog \
   --name example-catalog \
-  --namespace example-org \
+  --target-namespace example-org \
   --description "An example Catalog" \
   --type helm \
   --url https://example.github.io/my-app-catalog/ \


### PR DESCRIPTION
### What does this PR do?

- Updated docs of kubectl-gs commands with deprecated flags - added notes about deprecation replacement flags. The affected commands are:
  - `kubectl gs template app`
  - `kubectl gs template catalog`
  - `kubectl gs gitops add app`
- Documented global and root-level flags available in kubectl-gs

### Any background context you can provide?

Kubectl-gs recently introduced global flags taken over from kubectl. Some of these global flags shadowed command-specific flags with the same names. The shadowed local flags were renamed with the old names still kept around and for backward compatibility and marked as deprecated.

This PR updates the docs to reflect all the changes in kubectl-gs described above.