### PR TITLE
Add margin to bottom of tab content

### DIFF
--- a/src/assets/styles/base.sass
+++ b/src/assets/styles/base.sass
@@ -510,6 +510,7 @@ h2:hover .header-link, h3:hover .header-link, h4:hover .header-link, h5:hover .h
 
 .tab-pane
   padding-top: 20px
+  margin-bottom: 20px
 
 .well.disclaimer
   background-color: #1e1f5036


### PR DESCRIPTION
### What does this PR do?

Adds margin to the bottom of tabbed content, to prevent tab content directly "touching" the following content.

### What does it look like?

Before

![image](https://user-images.githubusercontent.com/273727/190991900-3f84d758-9def-41f2-b695-23a3d3ab2b85.png)

After there are 20 additional pixels of white space.
