### PR TITLE
Updating docs with App Platform timeouts support

### DIFF
--- a/scripts/update-crd-reference/config.yaml
+++ b/scripts/update-crd-reference/config.yaml
@@ -8,7 +8,7 @@ source_repositories:
   - url: https://github.com/giantswarm/apiextensions-application
     organization: giantswarm
     short_name: apiextensions-application
-    commit_reference: v0.5.1
+    commit_reference: v0.6.0
     crd_paths:
       - config/crd
     cr_paths:
@@ -309,7 +309,7 @@ source_repositories:
       flannelconfigs.core.giantswarm.io:
         hidden: true
       g8scontrolplanes.infrastructure.giantswarm.io:
-        owner: 
+        owner:
           - https://github.com/orgs/giantswarm/teams/team-phoenix
         provider:
           - aws

--- a/src/content/app-platform/installation-configuration/index.md
+++ b/src/content/app-platform/installation-configuration/index.md
@@ -1,0 +1,162 @@
+---
+linkTitle: Configuring installation process
+title: Configuring Helm execution
+description: Which options for the Helm execution are currently supported by the App Platform.
+weight: 60
+menu:
+  main:
+    parent: app-platform
+owner:
+  - https://github.com/orgs/giantswarm/teams/team-honeybadger
+last_review_date: 2021-07-07
+user_questions:
+  - How can I configure custom timeouts for installations and upgrades?
+---
+
+## Overview
+
+As stated in the [App Platform overview]({{< relref "/app-platform/overview/index.md" >}}) all managed apps are
+Helm Charts underneath. This of course means that at the very bottom the platform must trigger the Helm-related
+actions, like installation or upgrade, against the requested application. This process, mostly, cannot be
+influenced by a user as we try to well-tune it universally to all the apps. Yet, we anticipate that apps not
+matching these universal rules may exist, hence we offer a way to tweak some of the Helm's options.
+
+Next paragraphs introduce the options currently supported for each of the major Helm action, along the version of
+App Operator and Chart Operator they have started to be supported with. Each paragraph comes with a short
+explanation and [App CR]({{< relref "/ui-api/management-api/crd/apps.application.giantswarm.io.md" >}}) code snippet with most of the fields removed for brevity.
+
+## Install
+
+The installation options are exposed via the corresponding `.spec.install` field of the App CR.
+
+### SkipCRDs
+
+#### Description
+
+If set, no CRDs will be installed by the Helm. By default, CRDs are installed if not already present. Find the
+example below.
+
+```yaml
+apiVersion: application.giantswarm.io/v1alpha1
+kind: App
+metadata:
+  name: demo
+spec:
+  install:
+    skipCRDs: true
+```
+
+#### Support
+
+| Operator         | Version  |
+| ---------------- | -------- |
+| `app-operator`   | `v4.4.0` |
+| `chart-operator` | `v2.8.0` |
+
+### Timeout
+
+#### Description
+
+Time to wait for any individual Kubernetes operation (like Jobs for hooks). If not set, the default timeout of
+5 minutes is used.
+
+```yaml
+apiVersion: application.giantswarm.io/v1alpha1
+kind: App
+metadata:
+  name: demo
+spec:
+  install:
+    timeout: 10m
+```
+
+#### Support
+
+| Operator         | Version   |
+| ---------------- | --------- |
+| `app-operator`   | `v6.4.0`  |
+| `chart-operator` | `v2.30.0` |
+
+## Upgrade
+
+The installation options are exposed via the corresponding `.spec.upgrade` field of the App CR.
+
+### Timeout
+
+#### Description
+
+Time to wait for any individual Kubernetes operation (like Jobs for hooks). If not set, the default timeout of
+5 minutes is used.
+
+```yaml
+apiVersion: application.giantswarm.io/v1alpha1
+kind: App
+metadata:
+  name: demo
+spec:
+  upgrade:
+    timeout: 10m
+```
+
+#### Support
+
+| Operator         | Version   |
+| ---------------- | --------- |
+| `app-operator`   | `v6.4.0`  |
+| `chart-operator` | `v2.30.0` |
+
+## Rollback
+
+The installation options are exposed via the corresponding `.spec.rollback` field of the App CR.
+
+### Timeout
+
+#### Description
+
+Time to wait for any individual Kubernetes operation (like Jobs for hooks). If not set, the default timeout of
+5 minutes is used.
+
+```yaml
+apiVersion: application.giantswarm.io/v1alpha1
+kind: App
+metadata:
+  name: demo
+spec:
+  rollback:
+    timeout: 10m
+```
+
+#### Support
+
+| Operator         | Version   |
+| ---------------- | --------- |
+| `app-operator`   | `v6.4.0`  |
+| `chart-operator` | `v2.30.0` |
+
+## Uninstall
+
+The installation options are exposed via the corresponding `.spec.uninstall` field of the App CR.
+
+### Timeout
+
+#### Description
+
+Time to wait for any individual Kubernetes operation (like Jobs for hooks). If not set, the default timeout of
+5 minutes is used.
+
+```yaml
+apiVersion: application.giantswarm.io/v1alpha1
+kind: App
+metadata:
+  name: demo
+spec:
+  uninstall:
+    timeout: 10m
+```
+
+#### Support
+
+| Operator         | Version   |
+| ---------------- | --------- |
+| `app-operator`   | `v6.4.0`  |
+| `chart-operator` | `v2.30.0` |

--- a/src/content/app-platform/overview/index.md
+++ b/src/content/app-platform/overview/index.md
@@ -33,6 +33,9 @@ from a single place; the management cluster.
 
 We fully support [Helm](https://helm.sh/) as a general tool to deploy your applications as well as for our general App Catalog. Apps are packaged as Helm charts and can be configured with _values_. We provide a recommended
 [app configuration]({{< relref "/app-platform/app-configuration" >}}) which you can override to meet your needs.
+The App Platform then, underneath, installs these Helm Charts whenever an app installation is requested by you.
+The Helm execution is mostly not configurable for you, with the exception to the options presented in 
+[installation configuration]({{< relref "/app-platform/installation-configuration" >}}).
 
 Using this platform, we are providing a collection of curated _Apps_. These _Apps_ are grouped into _App Catalogs_, which are browsable through our web interface.
 We also use app platform to install the apps that are pre-installed in your cluster (such as CoreDNS).
@@ -81,6 +84,8 @@ together to enable the features of the Giant Swarm App Platform:
 
 ![A diagram showing an overview of various components and concepts that make up the Giant Swarm App Platform](app-platform-overview.png)
 <!-- Original version: https://docs.google.com/drawings/d/1V3KcUImxRdrrb2v_nIQnkapHiRkRM6t8PoYGCqWebYY/edit -->
+
+
 
 ### What kind of App Catalogs are there
 

--- a/src/content/ui-api/management-api/crd/appcatalogentries.application.giantswarm.io.md
+++ b/src/content/ui-api/management-api/crd/appcatalogentries.application.giantswarm.io.md
@@ -12,7 +12,7 @@ crd:
   technical_name: appcatalogentries.application.giantswarm.io
   scope: Namespaced
   source_repository: https://github.com/giantswarm/apiextensions-application
-  source_repository_ref: v0.5.1
+  source_repository_ref: v0.6.0
   versions:
     - v1alpha1
   topics:
@@ -24,7 +24,7 @@ aliases:
   - /reference/cp-k8s-api/appcatalogentries.application.giantswarm.io/
 technical_name: appcatalogentries.application.giantswarm.io
 source_repository: https://github.com/giantswarm/apiextensions-application
-source_repository_ref: v0.5.1
+source_repository_ref: v0.6.0
 ---
 
 # AppCatalogEntry

--- a/src/content/ui-api/management-api/crd/appcatalogs.application.giantswarm.io.md
+++ b/src/content/ui-api/management-api/crd/appcatalogs.application.giantswarm.io.md
@@ -12,7 +12,7 @@ crd:
   technical_name: appcatalogs.application.giantswarm.io
   scope: Cluster
   source_repository: https://github.com/giantswarm/apiextensions-application
-  source_repository_ref: v0.5.1
+  source_repository_ref: v0.6.0
   versions:
     - v1alpha1
   topics:
@@ -28,7 +28,7 @@ aliases:
   - /reference/cp-k8s-api/appcatalogs.application.giantswarm.io/
 technical_name: appcatalogs.application.giantswarm.io
 source_repository: https://github.com/giantswarm/apiextensions-application
-source_repository_ref: v0.5.1
+source_repository_ref: v0.6.0
 ---
 
 # AppCatalog

--- a/src/content/ui-api/management-api/crd/apps.application.giantswarm.io.md
+++ b/src/content/ui-api/management-api/crd/apps.application.giantswarm.io.md
@@ -12,7 +12,7 @@ crd:
   technical_name: apps.application.giantswarm.io
   scope: Namespaced
   source_repository: https://github.com/giantswarm/apiextensions-application
-  source_repository_ref: v0.5.1
+  source_repository_ref: v0.6.0
   versions:
     - v1alpha1
   topics:
@@ -24,7 +24,7 @@ aliases:
   - /reference/cp-k8s-api/apps.application.giantswarm.io/
 technical_name: apps.application.giantswarm.io
 source_repository: https://github.com/giantswarm/apiextensions-application
-source_repository_ref: v0.5.1
+source_repository_ref: v0.6.0
 ---
 
 # App
@@ -73,6 +73,7 @@ spec:
       namespace: f2def
   install:
     skipCRDs: true
+    timeout: 6m0s
   kubeConfig:
     context:
       name: f2def
@@ -85,6 +86,12 @@ spec:
   namespaceConfig:
     annotations:
       linkerd.io/inject: enabled
+  rollback:
+    timeout: 7m0s
+  uninstall:
+    timeout: 8m0s
+  upgrade:
+    timeout: 9m0s
   userConfig:
     configMap:
       name: prometheus-user-values
@@ -462,6 +469,24 @@ spec:
 </div>
 </div>
 
+<div class="property depth-2">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.install.timeout">.spec.install.timeout</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">string</span>
+
+</div>
+
+<div class="property-description">
+<p>Timeout for the Helm install. When not set the default timeout of 5 minutes is being enforced.</p>
+
+</div>
+
+</div>
+</div>
+
 <div class="property depth-1">
 <div class="property-header">
 <h3 class="property-path" id="v1alpha1-.spec.kubeConfig">.spec.kubeConfig</h3>
@@ -672,6 +697,114 @@ spec:
 
 <div class="property-description">
 <p>Labels is a string map of labels to apply to the target namespace.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-1">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.rollback">.spec.rollback</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">object</span>
+
+</div>
+
+<div class="property-description">
+<p>Rollback is the config used when rolling back the app.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-2">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.rollback.timeout">.spec.rollback.timeout</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">string</span>
+
+</div>
+
+<div class="property-description">
+<p>Timeout for the Helm rollback. When not set the default timeout of 5 minutes is being enforced.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-1">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.uninstall">.spec.uninstall</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">object</span>
+
+</div>
+
+<div class="property-description">
+<p>Uninstall is the config used when uninstalling the app.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-2">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.uninstall.timeout">.spec.uninstall.timeout</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">string</span>
+
+</div>
+
+<div class="property-description">
+<p>Timeout for the Helm uninstall. When not set the default timeout of 5 minutes is being enforced.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-1">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.upgrade">.spec.upgrade</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">object</span>
+
+</div>
+
+<div class="property-description">
+<p>Upgrade is the config used when upgrading the app.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-2">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.upgrade.timeout">.spec.upgrade.timeout</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">string</span>
+
+</div>
+
+<div class="property-description">
+<p>Timeout for the Helm upgrade. When not set the default timeout of 5 minutes is being enforced.</p>
 
 </div>
 

--- a/src/content/ui-api/management-api/crd/catalogs.application.giantswarm.io.md
+++ b/src/content/ui-api/management-api/crd/catalogs.application.giantswarm.io.md
@@ -12,7 +12,7 @@ crd:
   technical_name: catalogs.application.giantswarm.io
   scope: Namespaced
   source_repository: https://github.com/giantswarm/apiextensions-application
-  source_repository_ref: v0.5.1
+  source_repository_ref: v0.6.0
   versions:
     - v1alpha1
   topics:
@@ -24,7 +24,7 @@ aliases:
   - /reference/cp-k8s-api/catalogs.application.giantswarm.io/
 technical_name: catalogs.application.giantswarm.io
 source_repository: https://github.com/giantswarm/apiextensions-application
-source_repository_ref: v0.5.1
+source_repository_ref: v0.6.0
 ---
 
 # Catalog
@@ -71,6 +71,7 @@ spec:
       namespace: my-namespace
   description: A catalog to store all new application packages.
   logoURL: https://my-org.github.com/logo.png
+  repositories: null
   storage:
     URL: https://my-org.github.com/my-playground-catalog/
     type: helm

--- a/src/content/ui-api/management-api/crd/charts.application.giantswarm.io.md
+++ b/src/content/ui-api/management-api/crd/charts.application.giantswarm.io.md
@@ -12,7 +12,7 @@ crd:
   technical_name: charts.application.giantswarm.io
   scope: Namespaced
   source_repository: https://github.com/giantswarm/apiextensions-application
-  source_repository_ref: v0.5.1
+  source_repository_ref: v0.6.0
   versions:
     - v1alpha1
   topics:
@@ -24,7 +24,7 @@ aliases:
   - /reference/cp-k8s-api/charts.application.giantswarm.io/
 technical_name: charts.application.giantswarm.io
 source_repository: https://github.com/giantswarm/apiextensions-application
-source_repository_ref: v0.5.1
+source_repository_ref: v0.6.0
 ---
 
 # Chart
@@ -75,12 +75,19 @@ spec:
       resourceVersion: ""
   install:
     skipCRDs: true
+    timeout: 6m0s
   name: prometheus
   namespace: monitoring
   namespaceConfig:
     annotations:
       linkerd.io/inject: enabled
+  rollback:
+    timeout: 7m0s
   tarballURL: prometheus-1.0.1.tgz
+  uninstall:
+    timeout: 8m0s
+  upgrade:
+    timeout: 9m0s
   version: 1.0.1
 ```
 
@@ -348,6 +355,24 @@ spec:
 </div>
 </div>
 
+<div class="property depth-2">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.install.timeout">.spec.install.timeout</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">string</span>
+
+</div>
+
+<div class="property-description">
+<p>Timeout for the Helm install. When not set the default timeout of 5 minutes is being enforced.</p>
+
+</div>
+
+</div>
+</div>
+
 <div class="property depth-1">
 <div class="property-header">
 <h3 class="property-path" id="v1alpha1-.spec.name">.spec.name</h3>
@@ -440,6 +465,42 @@ spec:
 
 <div class="property depth-1">
 <div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.rollback">.spec.rollback</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">object</span>
+
+</div>
+
+<div class="property-description">
+<p>Rollback is the config used to rollback the app and is passed to Helm.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-2">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.rollback.timeout">.spec.rollback.timeout</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">string</span>
+
+</div>
+
+<div class="property-description">
+<p>Timeout for the Helm rollback. When not set the default timeout of 5 minutes is being enforced.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-1">
+<div class="property-header">
 <h3 class="property-path" id="v1alpha1-.spec.tarballURL">.spec.tarballURL</h3>
 </div>
 <div class="property-body">
@@ -450,6 +511,78 @@ spec:
 
 <div class="property-description">
 <p>TarballURL is the URL for the Helm chart tarball to be deployed. e.g. <a href="https://example.com/path/to/prom-1-0-0.tgz">https://example.com/path/to/prom-1-0-0.tgz</a></p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-1">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.uninstall">.spec.uninstall</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">object</span>
+
+</div>
+
+<div class="property-description">
+<p>Uninstall is the config used to uninstall the app and is passed to Helm.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-2">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.uninstall.timeout">.spec.uninstall.timeout</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">string</span>
+
+</div>
+
+<div class="property-description">
+<p>Timeout for the Helm uninstall. When not set the default timeout of 5 minutes is being enforced.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-1">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.upgrade">.spec.upgrade</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">object</span>
+
+</div>
+
+<div class="property-description">
+<p>Upgrade is the config used to upgrade the app and is passed to Helm.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-2">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.upgrade.timeout">.spec.upgrade.timeout</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">string</span>
+
+</div>
+
+<div class="property-description">
+<p>Timeout for the Helm upgrade. When not set the default timeout of 5 minutes is being enforced.</p>
 
 </div>
 


### PR DESCRIPTION
### What does this PR do?

It extends the App Platform part of the docs with information of supported Helm flags.

### What does it look like?

It is a textual description with code snippets.

### Any background context you can provide?

Some applications require more time to install, see the full context here https://github.com/giantswarm/giantswarm/issues/23699.

### What is needed from the reviewers?

Check if the update explains clearly the concept.

### Have you maintained the front matter?

User question: how can I extend the Helm's default installation timeout?
