### PR TITLE
Simplify and clarify gitops command family page

### DIFF
--- a/src/content/ui-api/kubectl-gs/gitops/_index.md
+++ b/src/content/ui-api/kubectl-gs/gitops/_index.md
@@ -53,12 +53,12 @@ Refer to the subcommand documentation for details.
 | Command                       | Description                                                        |
 | ----------------------------- | ------------------------------------------------------------------ |
 | [`init`][1]                   | [Set up a GitOps repository with its basic structure][1]           |
-| [`add mc`][2]                 | [Add a new management cluster to the GitOps repository][2]         |
-| [`add org`][3]                | [Add a new organization to the GitOps repository][3]               |
-| [`add wc`][4]                 | [Add a new workload cluster to the GitOps repository][4]           |
+| [`add management-cluster`][2] | [Add a new management cluster to the GitOps repository][2]         |
+| [`add organization`][3]       | [Add a new organization to the GitOps repository][3]               |
+| [`add workload-cluster`][4]   | [Add a new workload cluster to the GitOps repository][4]           |
 | [`add app`][5]                | [Add a new app to the GitOps repository][5]                        |
-| [`add update`][6]             | [Enable automatic updates for an app][6]                           |
-| [`add enc`][7]                | [Add a new GPG key pair to the SOPS repository configuration][7]   |
+| [`add automatic-update`][6]   | [Enable automatic updates for an app][6]                           |
+| [`add encryption`][7]         | [Add a new GPG key pair to the SOPS repository configuration][7]   |
 
 [1]: {{< relref "/ui-api/kubectl-gs/gitops/init" >}}
 [2]: {{< relref "/ui-api/kubectl-gs/gitops/add-mc" >}}

--- a/src/content/ui-api/kubectl-gs/gitops/_index.md
+++ b/src/content/ui-api/kubectl-gs/gitops/_index.md
@@ -8,7 +8,7 @@ menu:
   main:
     identifier: kubectlgs-gitops
     parent: uiapi-kubectlgs
-last_review_date: 2022-08-31
+last_review_date: 2022-09-29
 user_questions:
   - Which GitOps commands does the kubectl-gs offer?
 aliases:
@@ -17,49 +17,48 @@ owner:
   - https://github.com/orgs/giantswarm/teams/team-honeybadger
 ---
 
-The `gitops` command groups all the GitOps-targeted operations supported by the `kubectl-gs` plugin.
+The `gitops` command family provides operations to set up a GitOps repository as required to manage Giant Swarm infrastructure, as well as add and modify resources in this repository.
 
 It implements the same basic operations the [gitops-template repository](https://github.com/giantswarm/gitops-template#using-this-repository) supports and respects [the recommended GitOps structure](https://github.com/giantswarm/gitops-template/blob/main/docs/repo_structure.md).
 
-## Caveats
+## Important remarks
 
-The command is expected to run against a local clone of the GitOps repository and does not go beyond creating
+The subcommands are expected to run against a local clone of the GitOps repository and does not go beyond creating
 requested files and directories. Hence, **all git-related operations**, like cloning or pushing, must be perform by
-the user prior to or after the plugin execution. By default command targets the current working directory, this
-behaviour can be controlled with the `--local-path <path_to_repository_dir>` flag.
+the user prior to or after the plugin execution.
 
-The command supports the dry-run mode of operation that offers a preview of the changes that are going to be applied to the
-repository. The behaviour can be controlled with the `--dry-run` flag. In this mode the command solely prints the list of
-directories, files in these directories, and content of the files, that are to be created and modified, as indicated by
-the `## CREATE ##` and `## MODIFY ##` sections of the output respectively.
+The commands provide a **dry-run mode**, to preview the changes that will be applied to the
+repository. Add the `--dry-run` flag to activate this mode.
 
-The commands will not re-create already existing files to prevent overriding users, or other commands, changes.
+The commands **will not overwrite already existing files** to prevent overriding users, or other commands, changes.
 It is often that one command creates a file with an initial content, and some other command updates it with content important
 to its context. Without preventing re-creation, running the first command again would result in restoring the original content
-and possibly damaging the user environment, by for example accidental removal of resources. **This also implies that doing
-updates with the `kubectl-gs` is currently not possible**, meaning, if user first runs a command with limited set of flags,
-to re-run it later with a new set of flags, outcome of the first command will not be replaced. User will have to manually put
-the needed changes, or to remove the directory and then re-run the command. This may get changed in the future.
+and possibly damaging the user environment, by for example accidental removal of resources.
+
+This also implies that **these commands cannot be used for modifications of resources**. This means that if you first run a command with limited set of flags,
+and later re-run it with a new set of flags, the outcome of the first command will not be replaced. You will either have to make
+the required changes manually, or remove the directory and then re-run the command. **Note:** this behavior may change in a future release of kubectl-gs.
 
 ## Usage {#usage}
 
-The command to execute is the `kubectl gs gitops`.
+The normal assumption is that commands are **executed from the root folder of the GitOps repository**.
+This behavior can be modified using the `--local-path PATH_TO_ROOT` flag.
 
-The command itself does not perform any actions on the filesystem, it instead gives a handy shorthand of this
-document.
+The general syntax is `kubectl gs gitops SUBCOMMAND [FLAGS]`.
 
-## Subcommands {#subcommands}
+Refer to the subcommand documentation for details.
+
+### Subcommands {#subcommands}
 
 | Command                       | Description                                                        |
 | ----------------------------- | ------------------------------------------------------------------ |
-| [`init`][1]                   | [Pre-configure GitOps repository with basic structure][1]          |
-| [`add mc`][2]                 | [Adds a new Management Cluster to the repository structure][2]     |
-| [`add org`][3]                | [Adds a new Organization to the repository structure][3]           |
-| [`add wc`][4]                 | [Adds a new Workload Cluster to the repository structure][4]       |
-| [`add app`][5]                | [Adds a new Application to your GitOps directory structure][5]     |
-| [`add update`][6]             | [Enable automatic updates for an app.][6]                          |
-| [`add enc`][7]                | [Adds a new GPG key pair to the SOPS repository configuration.][7] |
-
+| [`init`][1]                   | [Set up a GitOps repository with its basic structure][1]           |
+| [`add mc`][2]                 | [Add a new management cluster to the GitOps repository][2]         |
+| [`add org`][3]                | [Add a new organization to the GitOps repository][3]               |
+| [`add wc`][4]                 | [Add a new workload cluster to the GitOps repository][4]           |
+| [`add app`][5]                | [Add a new app to the GitOps repository][5]                        |
+| [`add update`][6]             | [Enable automatic updates for an app][6]                           |
+| [`add enc`][7]                | [Add a new GPG key pair to the SOPS repository configuration][7]   |
 
 [1]: {{< relref "/ui-api/kubectl-gs/gitops/init" >}}
 [2]: {{< relref "/ui-api/kubectl-gs/gitops/add-mc" >}}

--- a/src/content/ui-api/kubectl-gs/gitops/_index.md
+++ b/src/content/ui-api/kubectl-gs/gitops/_index.md
@@ -10,7 +10,7 @@ menu:
     parent: uiapi-kubectlgs
 last_review_date: 2022-09-29
 user_questions:
-  - Which GitOps commands does the kubectl-gs offer?
+  - Which GitOps commands does the kubectl-gs plugin offer?
 aliases:
   - /reference/kubectl-gs/gitops/
 owner:


### PR DESCRIPTION
### What does this PR do?

- Improve readability and structure of the gitops command family overview.
- Use canonical subcommand names instead of short form aliases.

### What does it look like?

<details>
<summary>Screenshot</summary>

![localhost_1313_ui-api_kubectl-gs_gitops_](https://user-images.githubusercontent.com/273727/193033334-05b77df0-20f1-4c4b-ad7c-2d799349d033.png)

</details>

### Any background context you can provide?

Just a general enhancement of some details.

### What is needed from the reviewers?

Nothing special.

### Have you maintained the front matter?

Yes
