### PR TITLE
Improve gitops subcommand reference pages

### DIFF
--- a/src/content/ui-api/kubectl-gs/gitops/_index.md
+++ b/src/content/ui-api/kubectl-gs/gitops/_index.md
@@ -11,8 +11,6 @@ menu:
 last_review_date: 2022-09-29
 user_questions:
   - Which GitOps commands does the kubectl-gs plugin offer?
-aliases:
-  - /reference/kubectl-gs/gitops/
 owner:
   - https://github.com/orgs/giantswarm/teams/team-honeybadger
 ---

--- a/src/content/ui-api/kubectl-gs/gitops/add-app.md
+++ b/src/content/ui-api/kubectl-gs/gitops/add-app.md
@@ -1,7 +1,7 @@
 ---
-linkTitle: add application
+linkTitle: add app
 title: "'kubectl gs gitops add app' command reference"
-description: Reference documentation on how to add a new Application to the GitOps repository.
+description: Reference documentation on how to add a new App to the GitOps repository.
 weight: 30
 menu:
   main:
@@ -15,11 +15,12 @@ user_questions:
 
 This command adds a new App to the GitOps repository.
 
-Other command this commad depends on:
+Other commands this command depends on:
+
 - [gitops init]({{< relref "/ui-api/kubectl-gs/gitops/init" >}})
-- [gitops add mc]({{< relref "/ui-api/kubectl-gs/gitops/add-mc" >}})
-- [gitops add org]({{< relref "/ui-api/kubectl-gs/gitops/add-org" >}})
-- [gitops add wc]({{< relref "/ui-api/kubectl-gs/gitops/add-wc" >}})
+- [gitops add management-cluster]({{< relref "/ui-api/kubectl-gs/gitops/add-mc" >}})
+- [gitops add organization]({{< relref "/ui-api/kubectl-gs/gitops/add-org" >}})
+- [gitops add workload-cluster]({{< relref "/ui-api/kubectl-gs/gitops/add-wc" >}})
 
 ## Description
 
@@ -41,55 +42,49 @@ from a base, resulting in the `kustomization.yaml` creation, which then referenc
 working base to reference with the `--base` flag. In any case, user may provide configuration to the application with the
 `--user-configmap` and the `--user-secret` flags.
 
-## Flags
+## Usage
 
-| Name                 | Description                                                             | Required |
-|----------------------| ----------------------------------------------------------------------- | -------- |
-| `app`                | App name in the catalog.                                                | false    |
-| `base`               | Path to the base directory. It must be relative to the repository root. | false    |
-| `catalog`            | Catalog to install the app from.                                        | false    |
-| `management-cluster` | Codename of the Management Cluster the Workload Cluster belongs to.     | true     |
-| `name`               | Name of the app to use for creating the repository directory structure. | false    |
-| `target-namespace`   | Namespace to install app into.                                          | false    |
-| `organization`       | Name of the Organization the Workload Cluster belongs to.               | true     |
-| `skip-mapi`          | Skip mapi directory when adding the app.                                | false    |
-| `user-configmap`     | Values YAML to customize the app with. Will get turn into a ConfigMap.  | false    |
-| `user-secret`        | Values YAML to customize the app with. Will get turn into a Secret.     | false    |
-| `version`            | App version to install.                                                 | false    |
-| `workload-cluster`   | Name of the Workload Cluster to configure the app for.                  | true     |
+Basic command syntax: `kubectl gs gitops add app FLAGS`.
+
+### Flags
+
+- `--management-cluster` -- name of the management cluster the workload cluster belongs to (required)
+- `--organization` -- name of the organization the workload cluster belongs to (required)
+- `--workload-cluster` -- name of the workload cluster to configure the app for (required)
+- `--app` -- app name in the catalog
+- `--base` -- path to the base directory; must be relative to the repository root
+- `--catalog` -- catalog to install the app from
+- `--name` -- name of the app to use for creating the repository directory structure
+- `--target-namespace` -- namespace to install app into
+- `--skip-mapi` -- skip mapi directory when adding the app
+- `--user-configmap` -- values YAML to customize the app with; will get inserted into a ConfigMap.
+- `--user-secret` -- values YAML to customize the app with; will get inserted into a Secret.
+- `--version` -- app version to install.
 
 {{% kubectl_gs_gitops_common_flags %}}
 
-### Deprecated flags
-
-To maintain backward compatibility the command also supports an older flag variation:
-
-- `--namespace` - replaced by `--target-namespace`
-
-This older flag variation is marked as deprecated and will be removed in the next major version of `kubectl gs`.
-
-## Usage
-
-The command to execute is the `kubectl gs gitops add app`.
-
-To preview the objects to be created by the command, run it with the `--dry-run` flag. Find examples below.
+### Examples
 
 {{< tabs >}}
 {{< tab id="no-base" title="Direct" >}}
 
 ```nohighlight
 kubectl gs gitops add app \
---local-path /tmp/gitops-demo \
---management-cluster demomc \
---organization demoorg \
---workload-cluster demowc \
---app hello-world \
---catalog giantswarm \
---version 0.3.0 \
---target-namespace default \
---name hello-world \
---dry-run
+  --local-path /tmp/gitops-demo \
+  --management-cluster demomc \
+  --organization demoorg \
+  --workload-cluster demowc \
+  --app hello-world \
+  --catalog giantswarm \
+  --version 0.3.0 \
+  --target-namespace default \
+  --name hello-world \
+  --dry-run
+```
 
+Output:
+
+```nohighlight
 ## CREATE ##
 /tmp/gitops-demo/management-clusters/demomc/organizations/demoorg/workload-clusters/demowc/mapi/apps
 /tmp/gitops-demo/management-clusters/demomc/organizations/demoorg/workload-clusters/demowc/mapi/apps/hello-world
@@ -139,18 +134,22 @@ After saving this into `/tmp/values.yaml`, it can be referenced when adding an a
 
 ```nohighlight
 kubectl gs gitops add app \
---local-path /tmp/gitops-demo \
---management-cluster demomc \
---organization demoorg \
---workload-cluster demowc \
---app hello-world \
---catalog giantswarm \
---version 0.3.0 \
---target-namespace default \
---name hello-world \
---user-configmap /tmp/values.yaml \
---dry-run
+  --local-path /tmp/gitops-demo \
+  --management-cluster demomc \
+  --organization demoorg \
+  --workload-cluster demowc \
+  --app hello-world \
+  --catalog giantswarm \
+  --version 0.3.0 \
+  --target-namespace default \
+  --name hello-world \
+  --user-configmap /tmp/values.yaml \
+  --dry-run
+```
 
+Output:
+
+```nohighlight
 ## CREATE ##
 /tmp/gitops-demo/management-clusters/demomc/organizations/demoorg/workload-clusters/demowc/mapi/apps
 /tmp/gitops-demo/management-clusters/demomc/organizations/demoorg/workload-clusters/demowc/mapi/apps/hello-world
@@ -205,14 +204,18 @@ In order to add app from a base the `--base` flag should be used instead of spec
 
 ```nohighlight
 kubectl gs gitops add app \
---local-path /tmp/gitops-demo \
---management-cluster demomc \
---organization demoorg \
---workload-cluster demowc \
---base bases/apps/hello-world \
---name hello-world \
---dry-run
+  --local-path /tmp/gitops-demo \
+  --management-cluster demomc \
+  --organization demoorg \
+  --workload-cluster demowc \
+  --base bases/apps/hello-world \
+  --name hello-world \
+  --dry-run
+```
 
+Output:
+
+```nohighlight
 ## CREATE ##
 /tmp/gitops-demo/management-clusters/demomc/organizations/demoorg/workload-clusters/demowc/mapi/apps
 /tmp/gitops-demo/management-clusters/demomc/organizations/demoorg/workload-clusters/demowc/mapi/apps/hello-world
@@ -243,7 +246,7 @@ resources:
 {{< /tab >}}
 {{< tab id="base-config" title="Indirect & Config" >}}
 
-When adding app from a base, it can still be customised with user configuration. **Note, files referenced by these flags should
+When adding app from a base, it can still be customized with user configuration. **Note, files referenced by these flags should
 carry a valid values YAML configuration conforming the values schema of the given the app version.**
 
 Below is the example of `values.yaml` configuring number of replicas and overriding the app's name.
@@ -257,15 +260,19 @@ After saving this into `/tmp/values.yaml`, it can be referenced when adding an a
 
 ```nohighlight
 kubectl gs gitops add app \
---local-path /tmp/gitops-demo \
---management-cluster demomc \
---organization demoorg \
---workload-cluster demowc \
---base bases/apps/hello-world \
---name hello-world \
---user-configmap /tmp/values.yaml \
---dry-run
+  --local-path /tmp/gitops-demo \
+  --management-cluster demomc \
+  --organization demoorg \
+  --workload-cluster demowc \
+  --base bases/apps/hello-world \
+  --name hello-world \
+  --user-configmap /tmp/values.yaml \
+  --dry-run
+```
 
+Output:
+
+```nohighlight
 ## CREATE ##
 /tmp/gitops-demo/management-clusters/demomc/organizations/demoorg/workload-clusters/demowc/mapi/apps
 /tmp/gitops-demo/management-clusters/demomc/organizations/demoorg/workload-clusters/demowc/mapi/apps/hello-world

--- a/src/content/ui-api/kubectl-gs/gitops/add-app.md
+++ b/src/content/ui-api/kubectl-gs/gitops/add-app.md
@@ -6,8 +6,6 @@ weight: 30
 menu:
   main:
     parent: kubectlgs-gitops
-aliases:
-  - /reference/kubectl-gs/gitops/add-app/
 last_review_date: 2022-09-14
 owner:
   - https://github.com/orgs/giantswarm/teams/team-honeybadger

--- a/src/content/ui-api/kubectl-gs/gitops/add-app.md
+++ b/src/content/ui-api/kubectl-gs/gitops/add-app.md
@@ -6,7 +6,7 @@ weight: 30
 menu:
   main:
     parent: kubectlgs-gitops
-last_review_date: 2022-09-14
+last_review_date: 2022-09-29
 owner:
   - https://github.com/orgs/giantswarm/teams/team-honeybadger
 user_questions:
@@ -15,12 +15,14 @@ user_questions:
 
 This command adds a new App to the GitOps repository.
 
-Other commands this command depends on:
+## Prerequisites
 
-- [gitops init]({{< relref "/ui-api/kubectl-gs/gitops/init" >}})
-- [gitops add management-cluster]({{< relref "/ui-api/kubectl-gs/gitops/add-mc" >}})
-- [gitops add organization]({{< relref "/ui-api/kubectl-gs/gitops/add-org" >}})
-- [gitops add workload-cluster]({{< relref "/ui-api/kubectl-gs/gitops/add-wc" >}})
+Your GitOps repository should provide the following structural layers:
+
+- Basic structure (see [`init`]({{< relref "/ui-api/kubectl-gs/gitops/init" >}}))
+- Management cluster (see [`add management-cluster`]({{< relref "/ui-api/kubectl-gs/gitops/add-mc" >}}))
+- Organization (see [`add organization`]({{< relref "/ui-api/kubectl-gs/gitops/add-org" >}}))
+- Workload cluster (see [`add workload-cluster`]({{< relref "/ui-api/kubectl-gs/gitops/add-wc" >}}))
 
 ## Description
 

--- a/src/content/ui-api/kubectl-gs/gitops/add-app.md
+++ b/src/content/ui-api/kubectl-gs/gitops/add-app.md
@@ -58,6 +58,8 @@ working base to reference with the `--base` flag. In any case, user may provide 
 | `version`            | App version to install.                                                 | false    |
 | `workload-cluster`   | Name of the Workload Cluster to configure the app for.                  | true     |
 
+{{% kubectl_gs_gitops_common_flags %}}
+
 ### Deprecated flags
 
 To maintain backward compatibility the command also supports an older flag variation:

--- a/src/content/ui-api/kubectl-gs/gitops/add-enc.md
+++ b/src/content/ui-api/kubectl-gs/gitops/add-enc.md
@@ -1,6 +1,6 @@
 ---
 linkTitle: add encryption
-title: "'kubectl gs gitops add enc' command reference"
+title: "'kubectl gs gitops add encryption' command reference"
 description: Reference documentation on how to configure encryption for the GitOps repository.
 weight: 40
 menu:
@@ -15,11 +15,12 @@ user_questions:
 
 This command configures encryption for the GitOps repository.
 
-Other command this commad depends on:
+Other commands this command depends on:
+
 - [gitops init]({{< relref "/ui-api/kubectl-gs/gitops/init" >}})
-- [gitops add mc]({{< relref "/ui-api/kubectl-gs/gitops/add-mc" >}})
-- [gitops add org]({{< relref "/ui-api/kubectl-gs/gitops/add-org" >}})
-- [gitops add wc]({{< relref "/ui-api/kubectl-gs/gitops/add-wc" >}})
+- [gitops add management-cluster]({{< relref "/ui-api/kubectl-gs/gitops/add-mc" >}})
+- [gitops add organization]({{< relref "/ui-api/kubectl-gs/gitops/add-org" >}})
+- [gitops add workload-cluster]({{< relref "/ui-api/kubectl-gs/gitops/add-wc" >}})
 - [gitops add app]({{< relref "/ui-api/kubectl-gs/gitops/add-app" >}})
 
 ## Description
@@ -41,31 +42,29 @@ The structure created by this command is presented below. Resources enclosed in 
         └── ORG_NAME
             └── workload-clusters
                 └── [WC_NAME.yaml]
-
 ```
 
 Encryption can be configured for multiple layers of the repository depending on the set of the flags passed to the command.
-As stated in the [init command](#init.md), the `kubectl-gs` does not perform encryption on behalf of the user, hence user is
+As stated in the [init command]({{< relref "/ui-api/kubectl-gs/gitops/init" >}}), the `kubectl-gs` does not perform encryption on behalf of the user, hence user is
 obliged to run the `sops` binary on his own. The command will however instruct user of how to import the public key into his
 keychain.
 
-## Flags
+## Usage
 
-| Name                 | Description                                                              | Required |
-| -------------------- | ------------------------------------------------------------------------ | -------- |
-| `generate`           | Generate new key pair.                                                   | true     |
-| `management-cluster` | Management cluster to configure the encryption for.                      | true     |
-| `organization`       | Organization in the Management Cluster to configure the encryption for.  | false    |
-| `target`             | Relative directory to configure the encryption for. (default "secrets/") | false    |
-| `workload-cluster`   | Workload Cluster in the Organization to configure the encryption for.    | false    |
+Basic command syntax: `kubectl gs gitops add encryption FLAGS`
+
+### Flags
+
+- `--generate` -- generate new key pair (required)
+- `--management-cluster` -- management cluster to configure the encryption for (required)
+- `--organization` -- organization in the management cluster to configure the encryption for
+- `--target` -- relative directory to configure the encryption for (default "secrets/")
+- `--workload-cluster` -- workload cluster in the Organization to configure the encryption for
 
 {{% kubectl_gs_gitops_common_flags %}}
 
-## Usage
 
-The command to execute is the `kubectl gs gitops add enc`.
-
-To preview the objects to be created by the command, run it with the `--dry-run` flag. Find examples below.
+### Examples
 
 In each of the examples below it is assumed the `protected-dir` directory exists at the layer being configured.
 
@@ -73,13 +72,17 @@ In each of the examples below it is assumed the `protected-dir` directory exists
 {{< tab id="mc-enc" title="Management Cluster" >}}
 
 ```nohighlight
-kubectl gs gitops add enc \
---local-path /tmp/gitops-demo \
---generate \
---management-cluster demomc \
---target protected-dir \
---dry-run
+kubectl gs gitops add encryption \
+  --local-path /tmp/gitops-demo \
+  --generate \
+  --management-cluster demomc \
+  --target protected-dir \
+  --dry-run
+```
 
+Output:
+
+```nohighlight
 ## CREATE ##
 /tmp/gitops-demo/management-clusters/demomc/.sops.keys/demomc.25c90481570b4a46176dc453f7bf506e0ad50d47.asc
 -----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -146,14 +149,18 @@ to load the public key into the keychain for SOPS to work.
 {{< tab id="org-enc" title="Organization" >}}
 
 ```nohighlight
-kubectl gs gitops add enc \
---local-path /tmp/gitops-demo \
---generate \
---management-cluster demomc \
---organization demoorg \
---target protected-dir \
---dry-run
+kubectl gs gitops add encryption \
+  --local-path /tmp/gitops-demo \
+  --generate \
+  --management-cluster demomc \
+  --organization demoorg \
+  --target protected-dir \
+  --dry-run
+```
 
+Output:
+
+```nohighlight
 ## CREATE ##
 /tmp/gitops-demo/management-clusters/demomc/.sops.keys/demomc.5286137ee4a4890c0cae093a3df892dbc5f532ca.asc
 -----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -220,15 +227,19 @@ to load the public key into the keychain for SOPS to work.
 {{< tab id="wc-enc" title="Workload Cluster" >}}
 
 ```nohighlight
-kubectl gs gitops add enc \
---local-path /tmp/gitops-demo \
---generate \
---management-cluster demomc \
---organization demoorg \
---workload-cluster demowc \
---target protected-dir \
---dry-run
+kubectl gs gitops add encryption \
+  --local-path /tmp/gitops-demo \
+  --generate \
+  --management-cluster demomc \
+  --organization demoorg \
+  --workload-cluster demowc \
+  --target protected-dir \
+  --dry-run
+```
 
+Output:
+
+```nohighlight
 ## CREATE ##
 /tmp/gitops-demo/management-clusters/demomc/.sops.keys/demowc.5ee3687ce2ef2ee94dc671d11483c46dbf667bf2.asc
 -----BEGIN PGP PUBLIC KEY BLOCK-----

--- a/src/content/ui-api/kubectl-gs/gitops/add-enc.md
+++ b/src/content/ui-api/kubectl-gs/gitops/add-enc.md
@@ -59,6 +59,8 @@ keychain.
 | `target`             | Relative directory to configure the encryption for. (default "secrets/") | false    |
 | `workload-cluster`   | Workload Cluster in the Organization to configure the encryption for.    | false    |
 
+{{% kubectl_gs_gitops_common_flags %}}
+
 ## Usage
 
 The command to execute is the `kubectl gs gitops add enc`.

--- a/src/content/ui-api/kubectl-gs/gitops/add-enc.md
+++ b/src/content/ui-api/kubectl-gs/gitops/add-enc.md
@@ -6,7 +6,7 @@ weight: 40
 menu:
   main:
     parent: kubectlgs-gitops
-last_review_date: 2022-08-31
+last_review_date: 2022-09-29
 owner:
   - https://github.com/orgs/giantswarm/teams/team-honeybadger
 user_questions:
@@ -15,13 +15,15 @@ user_questions:
 
 This command configures encryption for the GitOps repository.
 
-Other commands this command depends on:
+## Prerequisites
 
-- [gitops init]({{< relref "/ui-api/kubectl-gs/gitops/init" >}})
-- [gitops add management-cluster]({{< relref "/ui-api/kubectl-gs/gitops/add-mc" >}})
-- [gitops add organization]({{< relref "/ui-api/kubectl-gs/gitops/add-org" >}})
-- [gitops add workload-cluster]({{< relref "/ui-api/kubectl-gs/gitops/add-wc" >}})
-- [gitops add app]({{< relref "/ui-api/kubectl-gs/gitops/add-app" >}})
+Your GitOps repository should provide the following structural layers:
+
+- Basic structure (see [`init`]({{< relref "/ui-api/kubectl-gs/gitops/init" >}}))
+- Management cluster (see [`add management-cluster`]({{< relref "/ui-api/kubectl-gs/gitops/add-mc" >}}))
+- Organization (see [`add organization`]({{< relref "/ui-api/kubectl-gs/gitops/add-org" >}}))
+- Workload cluster (see [`add workload-cluster`]({{< relref "/ui-api/kubectl-gs/gitops/add-wc" >}}))
+- Apps (see [`add app`]({{< relref "/ui-api/kubectl-gs/gitops/add-app" >}}))
 
 ## Description
 

--- a/src/content/ui-api/kubectl-gs/gitops/add-enc.md
+++ b/src/content/ui-api/kubectl-gs/gitops/add-enc.md
@@ -6,8 +6,6 @@ weight: 40
 menu:
   main:
     parent: kubectlgs-gitops
-aliases:
-  - /reference/kubectl-gs/gitops/add-enc/
 last_review_date: 2022-08-31
 owner:
   - https://github.com/orgs/giantswarm/teams/team-honeybadger

--- a/src/content/ui-api/kubectl-gs/gitops/add-mc.md
+++ b/src/content/ui-api/kubectl-gs/gitops/add-mc.md
@@ -6,7 +6,7 @@ weight: 15
 menu:
   main:
     parent: kubectlgs-gitops
-last_review_date: 2022-08-31
+last_review_date: 2022-09-29
 owner:
   - https://github.com/orgs/giantswarm/teams/team-honeybadger
 user_questions:
@@ -15,9 +15,11 @@ user_questions:
 
 This command adds a new Management Cluster to the GitOps repository.
 
-Other commands this command depends on:
+## Prerequisites
 
-- [gitops init]({{< relref "/ui-api/kubectl-gs/gitops/init" >}})
+Your GitOps repository should provide the following structural layers:
+
+- Basic structure (see [`init`]({{< relref "/ui-api/kubectl-gs/gitops/init" >}}))
 
 ## Description
 

--- a/src/content/ui-api/kubectl-gs/gitops/add-mc.md
+++ b/src/content/ui-api/kubectl-gs/gitops/add-mc.md
@@ -6,8 +6,6 @@ weight: 15
 menu:
   main:
     parent: kubectlgs-gitops
-aliases:
-  - /reference/kubectl-gs/gitops/add-mc/
 last_review_date: 2022-08-31
 owner:
   - https://github.com/orgs/giantswarm/teams/team-honeybadger

--- a/src/content/ui-api/kubectl-gs/gitops/add-mc.md
+++ b/src/content/ui-api/kubectl-gs/gitops/add-mc.md
@@ -1,6 +1,6 @@
 ---
 linkTitle: add management-cluster
-title: "'kubectl gs gitops add mc' command reference"
+title: "'kubectl gs gitops add management-cluster' command reference"
 description: Reference documentation on how to add a new Management Cluster to the GitOps repository.
 weight: 15
 menu:
@@ -15,7 +15,8 @@ user_questions:
 
 This command adds a new Management Cluster to the GitOps repository.
 
-Other command this commad depends on:
+Other command this command depends on:
+
 - [gitops init]({{< relref "/ui-api/kubectl-gs/gitops/init" >}})
 
 ## Description
@@ -36,24 +37,22 @@ management-clusters
 
 **Note**, in a default mode the creation of SOPS GPG key pair is skipped. It is because in its most basic form GitOps
 repository can be driven without encryption. To enable the keys creation pass the `--gen-master-key` flag
-when adding the cluster. When skipped at this point, encryption can still be added later by the [`add enc`](#add-enc.mc)
+when adding the cluster. When skipped at this point, encryption can still be added later by the [`add encryption`]({{< relref "/ui-api/kubectl-gs/gitops/add-enc" >}})
 command.
-
-## Flags
-
-| Name              | Description                                          | Required |
-| ----------------- | ---------------------------------------------------- | -------- |
-| `gen-master-key`  | Generate Management Cluster master GPG key for SOPS. | false    |
-| `name`            | Codename of the Management Cluster.                  | true     |
-| `repository-name` | Name of the GitOps repository.                       | true     |
-
-{{% kubectl_gs_gitops_common_flags %}}
 
 ## Usage
 
-The command to execute is the `kubectl gs gitops add mc`.
+Basic command syntax: `kubectl gs gitops add management-cluster FLAGS`.
 
-To preview the objects to be created by the command, run it with the `--dry-run` flag. Find examples below.
+### Flags
+
+- `--name` -- name of the management cluster (required)
+- `--repository-name` -- name of the GitOps repository (required)
+- `--gen-master-key` -- generate a master GPG key for SOPS for this management cluster
+
+{{% kubectl_gs_gitops_common_flags %}}
+
+### Examples
 
 {{< tabs >}}
 {{< tab id="no-encryption" title="No Encryption" >}}
@@ -61,12 +60,16 @@ To preview the objects to be created by the command, run it with the `--dry-run`
 By default command configures basic directory structure without any encryption.
 
 ```nohighlight
-kubectl gs gitops add mc \
---local-path /tmp/gitops-demo \
---name demomc \
---repository-name gitops-demo \
---dry-run
+kubectl gs gitops add management-cluster \
+  --local-path /tmp/gitops-demo \
+  --name demomc \
+  --repository-name gitops-demo \
+  --dry-run
+```
 
+Output:
+
+```nohighlight
 ## CREATE ##
 /tmp/gitops-demo/management-clusters/demomc
 /tmp/gitops-demo/management-clusters/demomc/demomc.yaml
@@ -102,13 +105,17 @@ metadata:
 Upon passing the `--gen-master-key` flag, the output will get enriched with the GPG key pair, see example:
 
 ```nohighlight
-kubectl gs gitops add mc \
---local-path /tmp/gitops-demo \
---name demomc \
---repository-name gitops-demo \
---gen-master-key \
---dry-run
+kubectl gs gitops add management-cluster \
+  --local-path /tmp/gitops-demo \
+  --name demomc \
+  --repository-name gitops-demo \
+  --gen-master-key \
+  --dry-run
+```
 
+Output:
+
+```nohighlight
 ## CREATE ##
 /tmp/gitops-demo/management-clusters/demomc
 /tmp/gitops-demo/management-clusters/demomc/demomc.yaml

--- a/src/content/ui-api/kubectl-gs/gitops/add-mc.md
+++ b/src/content/ui-api/kubectl-gs/gitops/add-mc.md
@@ -15,7 +15,7 @@ user_questions:
 
 This command adds a new Management Cluster to the GitOps repository.
 
-Other command this command depends on:
+Other commands this command depends on:
 
 - [gitops init]({{< relref "/ui-api/kubectl-gs/gitops/init" >}})
 

--- a/src/content/ui-api/kubectl-gs/gitops/add-mc.md
+++ b/src/content/ui-api/kubectl-gs/gitops/add-mc.md
@@ -47,6 +47,7 @@ command.
 | `name`            | Codename of the Management Cluster.                  | true     |
 | `repository-name` | Name of the GitOps repository.                       | true     |
 
+{{% kubectl_gs_gitops_common_flags %}}
 
 ## Usage
 

--- a/src/content/ui-api/kubectl-gs/gitops/add-org.md
+++ b/src/content/ui-api/kubectl-gs/gitops/add-org.md
@@ -1,7 +1,7 @@
 ---
 linkTitle: add organization
-title: "'kubectl gs gitops add org' command reference"
-description: Reference documentation on how to add a new Organization to the GitOps repository.
+title: "'kubectl gs gitops add organization' command reference"
+description: Reference documentation on how to add a new organization to a GitOps repository.
 weight: 20
 menu:
   main:
@@ -10,14 +10,15 @@ last_review_date: 2022-08-31
 owner:
   - https://github.com/orgs/giantswarm/teams/team-honeybadger
 user_questions:
-  - How do I configure Organization in the GitOps repository?
+  - How do I add an organization to a GitOps repository?
 ---
 
 This command adds a new Organization to the GitOps repository.
 
-Other command this commad depends on:
+Other commands this command depends on:
+
 - [gitops init]({{< relref "/ui-api/kubectl-gs/gitops/init" >}})
-- [gitops add mc]({{< relref "/ui-api/kubectl-gs/gitops/add-mc" >}})
+- [gitops add management-cluster]({{< relref "/ui-api/kubectl-gs/gitops/add-mc" >}})
 
 ## Description
 
@@ -31,28 +32,30 @@ management-clusters/MC_NAME/organizations
         └── kustomization.yaml
 ```
 
-## Flags
+## Usage
 
-| Name              | Description                                        | Required |
-| ----------------- | -------------------------------------------------- | -------- |
-| `management-cluster` | Management Cluster the Organization belongs to. | true     |
-| `name`            | Organization name.                                 | true     |
+Basic command syntax: `kubectl gs gitops add organization FLAGS`.
+
+### Flags
+
+- `--management-cluster` -- management cluster the organization belongs to (required)
+- `--name` -- organization name (required)
 
 {{% kubectl_gs_gitops_common_flags %}}
 
-## Usage
-
-The command to execute is the `kubectl gs gitops add org`.
-
-To preview the objects to be created by the command, run it with the `--dry-run` flag. Example:
+### Examples
 
 ```nohighlight
-kubectl gs gitops add org \
---local-path /tmp/gitops-demo \
---name demoorg \
---management-cluster demomc \
---dry-run
+kubectl gs gitops add organization \
+  --local-path /tmp/gitops-demo \
+  --name demoorg \
+  --management-cluster demomc \
+  --dry-run
+```
 
+Output:
+
+```nohighlight
 ## CREATE##
 /tmp/gitops-demo/management-clusters/demomc/organizations/demoorg
 /tmp/gitops-demo/management-clusters/demomc/organizations/demoorg/demoorg.yaml

--- a/src/content/ui-api/kubectl-gs/gitops/add-org.md
+++ b/src/content/ui-api/kubectl-gs/gitops/add-org.md
@@ -6,8 +6,6 @@ weight: 20
 menu:
   main:
     parent: kubectlgs-gitops
-aliases:
-  - /reference/kubectl-gs/gitops/add-org/
 last_review_date: 2022-08-31
 owner:
   - https://github.com/orgs/giantswarm/teams/team-honeybadger

--- a/src/content/ui-api/kubectl-gs/gitops/add-org.md
+++ b/src/content/ui-api/kubectl-gs/gitops/add-org.md
@@ -38,6 +38,8 @@ management-clusters/MC_NAME/organizations
 | `management-cluster` | Management Cluster the Organization belongs to. | true     |
 | `name`            | Organization name.                                 | true     |
 
+{{% kubectl_gs_gitops_common_flags %}}
+
 ## Usage
 
 The command to execute is the `kubectl gs gitops add org`.

--- a/src/content/ui-api/kubectl-gs/gitops/add-org.md
+++ b/src/content/ui-api/kubectl-gs/gitops/add-org.md
@@ -6,7 +6,7 @@ weight: 20
 menu:
   main:
     parent: kubectlgs-gitops
-last_review_date: 2022-08-31
+last_review_date: 2022-09-29
 owner:
   - https://github.com/orgs/giantswarm/teams/team-honeybadger
 user_questions:
@@ -15,10 +15,12 @@ user_questions:
 
 This command adds a new Organization to the GitOps repository.
 
-Other commands this command depends on:
+## Prerequisites
 
-- [gitops init]({{< relref "/ui-api/kubectl-gs/gitops/init" >}})
-- [gitops add management-cluster]({{< relref "/ui-api/kubectl-gs/gitops/add-mc" >}})
+Your GitOps repository should provide the following structural layers:
+
+- Basic structure (see [`init`]({{< relref "/ui-api/kubectl-gs/gitops/init" >}}))
+- Management cluster (see [`add management-cluster`]({{< relref "/ui-api/kubectl-gs/gitops/add-mc" >}}))
 
 ## Description
 

--- a/src/content/ui-api/kubectl-gs/gitops/add-update.md
+++ b/src/content/ui-api/kubectl-gs/gitops/add-update.md
@@ -51,7 +51,7 @@ Basic command syntax: `kubectl gs gitops add automatic-update FLAGS`.
 - `--app` -- name of the App in the repository to configure automatic update for (required)
 - `--management-cluster` -- name of the management cluster the workload cluster belongs to (required)
 - `--organization` -- name of the organization the workload cluster belongs to (required)
-- `--version-repository` -- the OCR repository to update the version from. (required)
+- `--version-repository` -- the container image repository to update the version from. (required)
 - `--workload-cluster` -- name of the workload cluster to configure the app for (required)
 - `--skip-mapi` -- skip mapi directory when adding the app
 

--- a/src/content/ui-api/kubectl-gs/gitops/add-update.md
+++ b/src/content/ui-api/kubectl-gs/gitops/add-update.md
@@ -6,7 +6,7 @@ weight: 35
 menu:
   main:
     parent: kubectlgs-gitops
-last_review_date: 2022-08-31
+last_review_date: 2022-09-29
 owner:
   - https://github.com/orgs/giantswarm/teams/team-honeybadger
 user_questions:
@@ -15,13 +15,15 @@ user_questions:
 
 This command adds configuration to automatically update an App into a GitOps repository.
 
-Other commands this command depends on:
+## Prerequisites
 
-- [gitops init]({{< relref "/ui-api/kubectl-gs/gitops/init" >}})
-- [gitops add management-cluster]({{< relref "/ui-api/kubectl-gs/gitops/add-mc" >}})
-- [gitops add organization]({{< relref "/ui-api/kubectl-gs/gitops/add-org" >}})
-- [gitops add workload-cluster]({{< relref "/ui-api/kubectl-gs/gitops/add-wc" >}})
-- [gitops add app]({{< relref "/ui-api/kubectl-gs/gitops/add-app" >}})
+Your GitOps repository should provide the following structural layers:
+
+- Basic structure (see [`init`]({{< relref "/ui-api/kubectl-gs/gitops/init" >}}))
+- Management cluster (see [`add management-cluster`]({{< relref "/ui-api/kubectl-gs/gitops/add-mc" >}}))
+- Organization (see [`add organization`]({{< relref "/ui-api/kubectl-gs/gitops/add-org" >}}))
+- Workload cluster (see [`add workload-cluster`]({{< relref "/ui-api/kubectl-gs/gitops/add-wc" >}}))
+- Apps (see [`add app`]({{< relref "/ui-api/kubectl-gs/gitops/add-app" >}}))
 
 ## Description
 

--- a/src/content/ui-api/kubectl-gs/gitops/add-update.md
+++ b/src/content/ui-api/kubectl-gs/gitops/add-update.md
@@ -6,8 +6,6 @@ weight: 35
 menu:
   main:
     parent: kubectlgs-gitops
-aliases:
-  - /reference/kubectl-gs/gitops/add-update/
 last_review_date: 2022-08-31
 owner:
   - https://github.com/orgs/giantswarm/teams/team-honeybadger

--- a/src/content/ui-api/kubectl-gs/gitops/add-update.md
+++ b/src/content/ui-api/kubectl-gs/gitops/add-update.md
@@ -53,6 +53,8 @@ coming from a base updates must be configured in the base instead, what is outsi
 | `version-repository` | The OCR repository to update the version from.                      | true     |
 | `workload-cluster`   | Name of the Workload Cluster to configure the app for.              | true     |
 
+{{% kubectl_gs_gitops_common_flags %}}
+
 ## Usage
 
 The command to execute is the `kubectl gs gitops add update`.

--- a/src/content/ui-api/kubectl-gs/gitops/add-update.md
+++ b/src/content/ui-api/kubectl-gs/gitops/add-update.md
@@ -1,6 +1,6 @@
 ---
 linkTitle: add automatic-update
-title: "'kubectl gs gitops add update' command reference"
+title: "'kubectl gs gitops add automatic-update' command reference"
 description: Reference documentation on how to configure automatic updates for an App to the GitOps repository.
 weight: 35
 menu:
@@ -13,13 +13,14 @@ user_questions:
   - How do I configure automatic updates for an App with the GitOps repository?
 ---
 
-This command adds a new App to the GitOps repository.
+This command adds configuration to automatically update an App into a GitOps repository.
 
-Other command this commad depends on:
+Other commands this command depends on:
+
 - [gitops init]({{< relref "/ui-api/kubectl-gs/gitops/init" >}})
-- [gitops add mc]({{< relref "/ui-api/kubectl-gs/gitops/add-mc" >}})
-- [gitops add org]({{< relref "/ui-api/kubectl-gs/gitops/add-org" >}})
-- [gitops add wc]({{< relref "/ui-api/kubectl-gs/gitops/add-wc" >}})
+- [gitops add management-cluster]({{< relref "/ui-api/kubectl-gs/gitops/add-mc" >}})
+- [gitops add organization]({{< relref "/ui-api/kubectl-gs/gitops/add-org" >}})
+- [gitops add workload-cluster]({{< relref "/ui-api/kubectl-gs/gitops/add-wc" >}})
 - [gitops add app]({{< relref "/ui-api/kubectl-gs/gitops/add-app" >}})
 
 ## Description
@@ -36,45 +37,46 @@ management-clusters/MC_NAME/organizations/ORG_NAME/workload-clusters/[mapi/]
         ├── appcr.yaml
         ├── imagepolicy.yaml
         └── imagerepository.yaml
-
 ```
 
 **Note, automatic update requires the `appcr.yaml` file and hence can only be configured for directly added apps**. For apps
 coming from a base updates must be configured in the base instead, what is outside of the command's scope.
 
-## Flags
+## Usage
 
-| Name                 | Description                                                         | Required |
-| -------------------- | ------------------------------------------------------------------- | -------- |
-| `app`                |  App in the repository to configure automatic update for.           | true     |
-| `management-cluster` | Codename of the Management Cluster the Workload Cluster belongs to. | true     |
-| `organization`       | Name of the Organization the Workload Cluster belongs to.           | true     |
-| `skip-mapi`          | Skip mapi directory when adding the app.                            | false    |
-| `version-repository` | The OCR repository to update the version from.                      | true     |
-| `workload-cluster`   | Name of the Workload Cluster to configure the app for.              | true     |
+Basic command syntax: `kubectl gs gitops add automatic-update FLAGS`.
+
+### Flags
+
+- `--app` -- name of the App in the repository to configure automatic update for (required)
+- `--management-cluster` -- name of the management cluster the workload cluster belongs to (required)
+- `--organization` -- name of the organization the workload cluster belongs to (required)
+- `--version-repository` -- the OCR repository to update the version from. (required)
+- `--workload-cluster` -- name of the workload cluster to configure the app for (required)
+- `--skip-mapi` -- skip mapi directory when adding the app
 
 {{% kubectl_gs_gitops_common_flags %}}
 
-## Usage
-
-The command to execute is the `kubectl gs gitops add update`.
-
-To preview the objects to be created by the command, run it with the `--dry-run` flag. Find examples below.
+### Examples
 
 {{< tabs >}}
 {{< tab id="direct" title="Direct App" >}}
 
 ```nohighlight
-kubectl gs gitops add update \
---local-path /tmp/gitops-demo \
---management-cluster demomc \
---organization demoorg \
---workload-cluster demowc \
---app hello-world \
---version-repository giantswarmpublic.azurecr.io/giantswarm-catalog/hello-world-app \
---repository gitops-demo \
---dry-run
+kubectl gs gitops add automatic-update \
+  --local-path /tmp/gitops-demo \
+  --management-cluster demomc \
+  --organization demoorg \
+  --workload-cluster demowc \
+  --app hello-world \
+  --version-repository giantswarmpublic.azurecr.io/giantswarm-catalog/hello-world-app \
+  --repository gitops-demo \
+  --dry-run
+```
 
+Output:
+
+```nohighlight
 ## CREATE ##
 /tmp/gitops-demo/management-clusters/demomc/organizations/demoorg/workload-clusters/demowc/mapi/automatic-updates
 /tmp/gitops-demo/management-clusters/demomc/organizations/demoorg/workload-clusters/demowc/mapi/automatic-updates/imageupdate.yaml
@@ -164,16 +166,20 @@ resources:
 Upon trying to configure automatic updates for app coming from a base, the command will return an error.
 
 ```nohighlight
-kubectl gs gitops add update \
---local-path /tmp/gitops-demo \
---management-cluster demomc \
---organization demoorg \
---workload-cluster demowc \
---app hello-world \
---version-repository giantswarmpublic.azurecr.io/giantswarm-catalog/hello-world-app \
---repository gitops-demo \
---dry-run
+kubectl gs gitops add automatic-update \
+  --local-path /tmp/gitops-demo \
+  --management-cluster demomc \
+  --organization demoorg \
+  --workload-cluster demowc \
+  --app hello-world \
+  --version-repository giantswarmpublic.azurecr.io/giantswarm-catalog/hello-world-app \
+  --repository gitops-demo \
+  --dry-run
+```
 
+Output:
+
+```nohighlight
 validation error: Operation cannot be fulfilled on directory missing the `appcr.yaml` file.
 ```
 

--- a/src/content/ui-api/kubectl-gs/gitops/add-wc.md
+++ b/src/content/ui-api/kubectl-gs/gitops/add-wc.md
@@ -6,8 +6,6 @@ weight: 25
 menu:
   main:
     parent: kubectlgs-gitops
-aliases:
-  - /reference/kubectl-gs/gitops/add-wc/
 last_review_date: 2022-08-31
 owner:
   - https://github.com/orgs/giantswarm/teams/team-honeybadger

--- a/src/content/ui-api/kubectl-gs/gitops/add-wc.md
+++ b/src/content/ui-api/kubectl-gs/gitops/add-wc.md
@@ -73,6 +73,7 @@ nevertheless mandatory, and hence this flag is planned to be removed from `kubec
 ## Usage
 
 The command to execute is the `kubectl gs gitops add wc`.
+{{% kubectl_gs_gitops_common_flags %}}
 
 To preview the objects to be created by the command, run it with the `--dry-run` flag. Fine example below.
 

--- a/src/content/ui-api/kubectl-gs/gitops/add-wc.md
+++ b/src/content/ui-api/kubectl-gs/gitops/add-wc.md
@@ -6,7 +6,7 @@ weight: 25
 menu:
   main:
     parent: kubectlgs-gitops
-last_review_date: 2022-08-31
+last_review_date: 2022-09-29
 owner:
   - https://github.com/orgs/giantswarm/teams/team-honeybadger
 user_questions:
@@ -15,11 +15,13 @@ user_questions:
 
 This command adds a new workload cluster to the GitOps repository.
 
-Other command this command depends on:
+## Prerequisites
 
-- [gitops init]({{< relref "/ui-api/kubectl-gs/gitops/init" >}})
-- [gitops add management-cluster]({{< relref "/ui-api/kubectl-gs/gitops/add-mc" >}})
-- [gitops add organization]({{< relref "/ui-api/kubectl-gs/gitops/add-org" >}})
+Your GitOps repository should provide the following structural layers:
+
+- Basic structure (see [`init`]({{< relref "/ui-api/kubectl-gs/gitops/init" >}}))
+- Management cluster (see [`add management-cluster`]({{< relref "/ui-api/kubectl-gs/gitops/add-mc" >}}))
+- Organization (see [`add organization`]({{< relref "/ui-api/kubectl-gs/gitops/add-org" >}}))
 
 ## Description
 

--- a/src/content/ui-api/kubectl-gs/gitops/add-wc.md
+++ b/src/content/ui-api/kubectl-gs/gitops/add-wc.md
@@ -1,7 +1,7 @@
 ---
 linkTitle: add workload-cluster
-title: "'kubectl gs gitops add wc' command reference"
-description: Reference documentation on how to add a new Workload Cluster to the GitOps repository.
+title: "'kubectl gs gitops add workload-cluster' command reference"
+description: Reference documentation on how to add a new workload cluster to a GitOps repository.
 weight: 25
 menu:
   main:
@@ -10,15 +10,16 @@ last_review_date: 2022-08-31
 owner:
   - https://github.com/orgs/giantswarm/teams/team-honeybadger
 user_questions:
-  - How do I configure Workload Cluster in the GitOps repository?
+  - How do I add a workload cluster to a GitOps repository?
 ---
 
-This command adds a new Workload Cluster to the GitOps repository.
+This command adds a new workload cluster to the GitOps repository.
 
-Other command this commad depends on:
+Other command this command depends on:
+
 - [gitops init]({{< relref "/ui-api/kubectl-gs/gitops/init" >}})
-- [gitops add mc]({{< relref "/ui-api/kubectl-gs/gitops/add-mc" >}})
-- [gitops add org]({{< relref "/ui-api/kubectl-gs/gitops/add-org" >}})
+- [gitops add management-cluster]({{< relref "/ui-api/kubectl-gs/gitops/add-mc" >}})
+- [gitops add organization]({{< relref "/ui-api/kubectl-gs/gitops/add-org" >}})
 
 ## Description
 
@@ -44,38 +45,36 @@ management-clusters/MC_NAME/organizations/ORG_NAME/workload-clusters
             └── [patch_default_apps_userconfig.yaml]
 ```
 
-Content of the `cluster` directory is optional because in its most basic form the GitOps repository does not oblige user to
-put the cluster definition in there, this can be added later by re-running the command with additional flags. Re-running works
-in such case, because `cluster` directory is initially empty. Note however, in order to populate it user must have a
-working base and reference it by the `--base` flag when running the command. User may customize the referenced base with
+The content of the `cluster` directory is optional because in its most basic form, the GitOps repository does not require you to
+put the cluster definition in there. It can be added later by re-running the command with additional flags. Re-running works
+in such case, because `cluster` directory is initially empty. Note however, in order to populate it, you must have a
+working base and reference it by the `--base` flag when running the command. You may customize the referenced base with
 the `--cluster-user-config` and `--default-apps-user-config` flags when needed.
 
-**Note**, the latest recommendation mandates creation of the `mapi` directory. However, users who have not yet migrated to it,
-but still want to use automation for their repositories, may skip `mapi` layer by using the `--skip-mapi` flag. Migration is
+**Note:** the latest recommendation mandates creation of the `mapi` directory. However, users who have not yet migrated to it,
+but still want to use automation for their repositories, may skip the `mapi` layer by using the `--skip-mapi` flag. Migration is
 nevertheless mandatory, and hence this flag is planned to be removed from `kubectl-gs` at some point.
-
-## Flags
-
-| Name                       | Description                                                             | Required |
-| -------------------------- | ----------------------------------------------------------------------- | -------- |
-| `base`                     | Path to the base directory. It must be relative to the repository root. | false    |
-| `cluster-release`          | Cluster app version.                                                    | true     |
-| `cluster-user-config`      | Cluster app user configuration to patch the base with.                  | false    |
-| `default-apps-release`     | Default apps app version.                                               | true     |
-| `default-apps-user-config` | Default apps app user configuration to patch the base with.             | false    |
-| `management-cluster`       | Codename of the Management Cluster the Workload Cluster belongs to.     | true     |
-| `name`                     | Name of the Workload Cluster.                                           | true     |
-| `organization`             | Name of the Organization the Workload Cluster belongs to.               | true     |
-| `repository-name`          | Name of the GitOps repository.                                          | true     |
-| `skip-mapi`                | Skip mapi directory when adding the app.                                | false    |
-
 
 ## Usage
 
-The command to execute is the `kubectl gs gitops add wc`.
+Basic command syntax: `kubectl gs gitops add workload-cluster FLAGS`
+
+### Flags
+
+- `--cluster-release` -- cluster-app version (required)
+- `--default-apps-release` -- default apps version (required)
+- `--management-cluster` -- name of the management cluster the workload cluster belongs to (required)
+- `--name` -- name of the workload cluster (required)
+- `--organization` -- name of the organization the workload cluster belongs to (required)
+- `--repository-name` -- name of the GitOps repository (required)
+- `--base` -- path to the base directory; must be relative to the repository root
+- `--cluster-user-config` -- cluster app user configuration to patch the base with
+- `--default-apps-user-config` -- default apps app user configuration to patch the base with
+- `--skip-mapi` -- skip mapi directory when adding the app
+
 {{% kubectl_gs_gitops_common_flags %}}
 
-To preview the objects to be created by the command, run it with the `--dry-run` flag. Fine example below.
+### Examples
 
 {{< tabs >}}
 {{< tab id="no-definition" title="No Definition" >}}
@@ -84,14 +83,18 @@ In the most basic form the GitOps repository may be populated with Workload Clus
 without the cluster-related CRs.
 
 ```nohighlight
-kubectl gs gitops add wc \
---local-path /tmp/gitops-demo \
---name demowc \
---management-cluster demomc \
---organization demoorg \
---repository-name gitops-demo \
---dry-run
+kubectl gs gitops add workload-cluster \
+  --local-path /tmp/gitops-demo \
+  --name demowc \
+  --management-cluster demomc \
+  --organization demoorg \
+  --repository-name gitops-demo \
+  --dry-run
+```
 
+Output:
+
+```nohighlight
 ## CREATE ##
 /tmp/gitops-demo/management-clusters/demomc/secrets/demowc.gpgkey.enc.yaml
 apiVersion: v1
@@ -167,17 +170,21 @@ When desired to manage cluster definition from GitOps repository, it can be adde
 `--cluster-release`, and the `--default-apps-release` flags.
 
 ```nohighlight
-kubectl gs gitops add wc \
---local-path /tmp/gitops-demo \
---name demowc \
---management-cluster demomc \
---organization demoorg \
---repository-name gitops-demo \
---base bases/cluster/capi \
---cluster-release 1.0.0 \
---default-apps-release 2.0.0 \
---dry-run
+kubectl gs gitops add workload-cluster \
+  --local-path /tmp/gitops-demo \
+  --name demowc \
+  --management-cluster demomc \
+  --organization demoorg \
+  --repository-name gitops-demo \
+  --base bases/cluster/capi \
+  --cluster-release 1.0.0 \
+  --default-apps-release 2.0.0 \
+  --dry-run
+```
 
+Output:
+
+```nohighlight
 ## CREATE ##
 /tmp/gitops-demo/management-clusters/demomc/secrets/demowc.gpgkey.enc.yaml
 apiVersion: v1
@@ -295,18 +302,22 @@ cloudConfig: demo-cloud-config
 After saving this into `/tmp/values.yaml`, it can be referenced when adding a cluster.
 
 ```nohighlight
-kubectl gs gitops add wc \
---local-path /tmp/gitops-demo \
---name demowc \
---management-cluster demomc \
---organization demoorg \
---repository-name gitops-demo \
---base bases/cluster/capi \
---cluster-release 1.0.0 \
---default-apps-release 2.0.0 \
---cluster-user-config /tmp/values.yaml
---dry-run
+kubectl gs gitops add workload-cluster \
+  --local-path /tmp/gitops-demo \
+  --name demowc \
+  --management-cluster demomc \
+  --organization demoorg \
+  --repository-name gitops-demo \
+  --base bases/cluster/capi \
+  --cluster-release 1.0.0 \
+  --default-apps-release 2.0.0 \
+  --cluster-user-config /tmp/values.yaml
+  --dry-run
+```
 
+Output:
+
+```nohighlight
 ## CREATE ##
 /tmp/gitops-demo/management-clusters/demomc/secrets/demowc.gpgkey.enc.yaml
 apiVersion: v1

--- a/src/content/ui-api/kubectl-gs/gitops/init.md
+++ b/src/content/ui-api/kubectl-gs/gitops/init.md
@@ -6,8 +6,6 @@ weight: 10
 menu:
   main:
     parent: kubectlgs-gitops
-aliases:
-  - /reference/kubectl-gs/gitops/init/
 last_review_date: 2022-08-31
 owner:
   - https://github.com/orgs/giantswarm/teams/team-honeybadger

--- a/src/content/ui-api/kubectl-gs/gitops/init.md
+++ b/src/content/ui-api/kubectl-gs/gitops/init.md
@@ -1,7 +1,7 @@
 ---
 linkTitle: init
 title: "'kubectl gs gitops init' command reference"
-description: Reference documentation on how to initialize an empty GitOps repository, so that it can be used with `kubectl-gs` plugin.
+description: Reference documentation on how to initialize an empty GitOps repository, so that it can be used with the `kubectl-gs` plugin.
 weight: 10
 menu:
   main:
@@ -13,7 +13,7 @@ user_questions:
   - What I need for a start in the GitOps repository?
 ---
 
-This command creates initial files and directories in your GitOps repository the other commands rely on.
+This command creates the initial files and directories in your GitOps repository the other commands rely on.
 
 ## Description
 
@@ -28,27 +28,36 @@ The structure created by the command is presented below.
 └── management-clusters
 ```
 
-The security architecture of GitOps repository relies on the [Mozilla SOPS](https://github.com/mozilla/sops),
-however the encryption is not performed automatically by the `kubectl-gs`, hence user is obliged to download and run the `sops`
-binary on his own. However, in order to aid security and help user the `pre-commit` hook, which is a simple shell script, has
-been introduced as a security measure for checking for unencrypted manifests before pushing the local commits.
+The security architecture of the GitOps repository relies on [Mozilla SOPS](https://github.com/mozilla/sops),
+however the encryption is not performed automatically by `kubectl-gs`. Please download and run the `sops`
+binary to be able to decrypt and encrypt secrets.
 
-**Important note**, the `.git/hooks` directory is not propagated to the repository upon pushing, hence `pre-commit`
-hook configured for a cloned copy is not shared with other Github users. Users are thus strongly encouraged to run
-the `init` command each time they clone the repository.
+In order to aid security, the `init` command also creates a pre-commit git hook. It is a simple shell script that
+checks for unencrypted manifests before pushing any local commits.
+
+**Note:** the `.git/hooks` directory is not propagated to the repository upon pushing, hence the pre-commit
+hook configured for a cloned copy is not shared with other users of the repository. We encourage you to run
+the `init` command each time you clone the repository.
 
 ## Usage
 
-The command to execute is the `kubectl gs gitops init`.
+Basic command syntax: `kubectl gs gitops init [FLAGS]`.
+
+### Flags
+
 {{% kubectl_gs_gitops_common_flags %}}
 
-To preview the objects to be created by the command, run it with the `--dry-run` flag. Example:
+## Example
 
 ```nohighlight
 kubectl gs gitops init \
---local-path /tmp/gitops-demo \
---dry-run
+  --local-path /tmp/gitops-demo \
+  --dry-run
+```
 
+will generate this output:
+
+```nohighlight
 ## CREATE ##
 /tmp/gitops-demo/management-clusters
 /tmp/gitops-demo/.sops.yaml
@@ -92,4 +101,4 @@ EOF
 fi
 ```
 
-Remove the `--dry-run` flag and re-run it to apply the changes.
+The same executed without `--dry-run` will write these changes to the target directory.

--- a/src/content/ui-api/kubectl-gs/gitops/init.md
+++ b/src/content/ui-api/kubectl-gs/gitops/init.md
@@ -6,7 +6,7 @@ weight: 10
 menu:
   main:
     parent: kubectlgs-gitops
-last_review_date: 2022-08-31
+last_review_date: 2022-09-29
 owner:
   - https://github.com/orgs/giantswarm/teams/team-honeybadger
 user_questions:

--- a/src/content/ui-api/kubectl-gs/gitops/init.md
+++ b/src/content/ui-api/kubectl-gs/gitops/init.md
@@ -40,6 +40,7 @@ the `init` command each time they clone the repository.
 ## Usage
 
 The command to execute is the `kubectl gs gitops init`.
+{{% kubectl_gs_gitops_common_flags %}}
 
 To preview the objects to be created by the command, run it with the `--dry-run` flag. Example:
 

--- a/src/layouts/shortcodes/kubectl_gs_gitops_common_flags.html
+++ b/src/layouts/shortcodes/kubectl_gs_gitops_common_flags.html
@@ -1,0 +1,4 @@
+The following flags are supported by all `gitops` subcommands:
+
+- `--dry-run` -- Print files and directories instead of creating them.
+- `--local-path` -- Path to the repository root folder (default ".").


### PR DESCRIPTION
### What does this PR do?

A bunch of structural changes to all pages under https://docs.giantswarm.io/ui-api/kubectl-gs/gitops/

- Align the command naming everywhere to use the canonical one (e. g. `add encryption` instead of `add enc`)
- Apply common structure under `## Usage` (`### Flags`, `### Examples`)
- Format flags as list and prepend `--`
- Add info regarding common flags via shortcode
- Apply indentation to multi line commands
- Sentence case instead of title case
- Fix linkTitle `add application` to `add app`
- Remove documentation on deprecated flags
- Remove aliases from front matter (aliases are only for redirects from previous URLs)

### What does it look like?

<details>
<summary>Screenshot of the `add encryption` page</summary>

![localhost_1313_ui-api_kubectl-gs_gitops_add-enc_](https://user-images.githubusercontent.com/273727/193072241-19b83897-0a3d-43df-b4e5-6f8e86784574.png)


</details>

### Any background context you can provide?

General usability improvement

### What is needed from the reviewers?

Patience

### Have you maintained the front matter?

Yes
