### PR TITLE
Remove CAPZ instructions for `kubectl gs template nodepool` reference

### DIFF
--- a/src/content/ui-api/kubectl-gs/template-nodepool.md
+++ b/src/content/ui-api/kubectl-gs/template-nodepool.md
@@ -8,7 +8,7 @@ menu:
     parent: uiapi-kubectlgs
 aliases:
   - /reference/kubectl-gs/template-nodepool/
-last_review_date: 2022-05-13
+last_review_date: 2022-10-12
 owner:
   - https://github.com/orgs/giantswarm/teams/team-rainbow
 user_questions:

--- a/src/content/ui-api/kubectl-gs/template-nodepool.md
+++ b/src/content/ui-api/kubectl-gs/template-nodepool.md
@@ -19,7 +19,12 @@ The `template nodepool` command allows to create [node pools]({{< relref "/advan
 
 ## Provider support
 
-This command **does not support Cluster API** (CAPI) based workload clusters. It supports AWS and Azure before CAPI.
+This command **does not support Cluster API** (CAPI) based workload clusters. It only supports AWS and Azure before CAPI. Adding a node pool to a CAPI workload cluster requires modification of the cluster app configuration values.
+
+| Provider | `--provider` flag value |
+|-|-|
+| AWS | `aws` |
+| Azure | `azure` |
 
 ## Resources generated
 
@@ -37,16 +42,6 @@ The resulting resources depend on the provider, set via the `--provider` flag.
 - [`MachinePool`]({{< relref "/ui-api/management-api/crd/machinepools.exp.cluster.x-k8s.io.md" >}}) (API version `exp.cluster.x-k8s.io/v1alpha3`)
 - [`AzureMachinePool`]({{< relref "/ui-api/management-api/crd/azuremachinepools.exp.infrastructure.cluster.x-k8s.io.md" >}}) (API version `exp.infrastructure.cluster.x-k8s.io/v1alpha3`)
 - [`Spark`]({{< relref "/ui-api/management-api/crd/sparks.core.giantswarm.io.md" >}}) (API version `core.giantswarm.io/v1alpha1`)
-
-{{< /tab >}}
-{{< tab id="flags-capz" title="Cluster API on Azure">}}
-
-We also support creating clusters on Azure using ClusterAPI by selecting our `v20.0.0-alpha1` release  (`--provider azure --release v20.0.0-alpha1`).
-Please be aware that this is an early alpha release. Clusters created using this release won't be monitored by GiantSwarm, and they won't be able to be upgraded to newer stable releases.
-
-- [`MachinePool`]({{< relref "/ui-api/management-api/crd/machinepools.cluster.x-k8s.io.md" >}}) (API version `cluster.x-k8s.io/v1beta1`)
-- [`AzureMachinePool`]({{< relref "/ui-api/management-api/crd/azuremachinepools.infrastructure.cluster.x-k8s.io.md" >}}) (API version `infrastructure.cluster.x-k8s.io/v1beta1`)
-- [`KubeadmConfig`]({{< relref "/ui-api/management-api/crd/kubeadmconfigs.bootstrap.cluster.x-k8s.io.md" >}}) (API version `bootstrap.cluster.x-k8s.io/v1beta1`)
 
 {{< /tab >}}
 {{< /tabs >}}

--- a/src/content/ui-api/kubectl-gs/template-nodepool.md
+++ b/src/content/ui-api/kubectl-gs/template-nodepool.md
@@ -17,6 +17,12 @@ user_questions:
 
 The `template nodepool` command allows to create [node pools]({{< relref "/advanced/node-pools" >}}), which are groups of worker nodes in a cluster sharing common configuration. The command creates a manifest for the custom resources that define a node pool. These are then meant to be applied to the management cluster, e. g. via `kubectl apply`.
 
+## Provider support
+
+This command **does not support Cluster API** (CAPI) based workload clusters. It supports AWS and Azure before CAPI.
+
+## Resources generated
+
 The resulting resources depend on the provider, set via the `--provider` flag.
 
 {{< tabs >}}


### PR DESCRIPTION
### What does this PR do?

Removes CAPZ instructions from the `kubectl gs template nodepool` command reference, because

- no customer is using it with CAPZ so far
- we don't want to encourage using this, as CAPZ support will be removed soon
- None of the CAPI providers will be supported by `template nodepool`

### What does it look like?

New provider info:

<img width="680" alt="image" src="https://user-images.githubusercontent.com/273727/195356437-318d5616-a93f-4ad7-ac23-a1050dba1793.png">

### Any background context you can provide?

See https://github.com/giantswarm/roadmap/issues/1188

### Have you maintained the front matter?

Yes