### PR TITLE
Turn off absolute redirects

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -50,6 +50,11 @@ http {
         listen 8080;
         server_name  localhost;
 
+        # To prevent sending clients to the wrong server
+        # http://docs.giantswarm.io/...
+        # https://github.com/giantswarm/roadmap/issues/1514
+        absolute_redirect off;
+
         server_tokens off;
         port_in_redirect off;
         chunked_transfer_encoding on;


### PR DESCRIPTION
### What does this PR do?

NGINX has a special behaviour if `/foo` is requested but `/foo/` is the canonical URL: It creates a permanent redirect. In our case it redirects to HTTP instead of HTTPS, which then generates another redirect.

While it would be best to enforce `https://` for the redirect URL and redirect to an absolute URL, I didn't find a way to configure this. Instead the approach here is to make the redirect use the path only (`Location: /foo/`). This will avoid the HTTP problem.

### What does it look like?

```nohighlight
$ curl -s -v http://127.0.0.1:7890/advanced/iam-roles-for-service-accounts
* ...
< Location: /advanced/iam-roles-for-service-accounts/
```

### Any background context you can provide?

Issue: https://github.com/giantswarm/roadmap/issues/1514

