### PR TITLE
kubectl gs template cluster: Fix typo.

### DIFF
--- a/src/content/ui-api/kubectl-gs/template-cluster.md
+++ b/src/content/ui-api/kubectl-gs/template-cluster.md
@@ -155,7 +155,7 @@ It supports the following flags:
 - `--node-cidr` - CIDR defining the IP range of cluster nodes. When used, new network and subnet will be created.
 - `--network-name` (optional) - Name of existing network for the cluster. Can be used when `--node-cidr` is empty. 
 - `--subnet-name` (optional) - Name of existing subnet for the cluster. Can be used when `--node-cidr` is empty. 
-- `--bastion-boot-from-volume` - If true, bation machine will use a persistent root volume instead of an ephemeral volume.
+- `--bastion-boot-from-volume` - If true, bastion machine will use a persistent root volume instead of an ephemeral volume.
 - `--bastion-disk-size` - Size of root volume attached to the cluster bastion machine in gigabytes. Must be greater than or equal to the size of the bastion source image (`--bastion-image`).
 - `--bastion-image` - Bastion image name or root volume source UUID if --bastion-boot-from-volume is set.
 - `--bastion-machine-flavor` - Flavor (a.k.a. size) of the bastion machine.


### PR DESCRIPTION
### What does this PR do?

Fixes a typo in the `kubectl gs template cluster` docs.

### What does it look like?

Better!

### Any background context you can provide?

https://docs.giantswarm.io/ui-api/kubectl-gs/template-cluster

### What is needed from the reviewers?

Your approval. ;)

### Have you maintained the front matter?

No.
