### PR TITLE
Revert gr2m/create-or-update-pull-request-action to v1.3.1

### DIFF
--- a/.github/workflows/update-changes.yml
+++ b/.github/workflows/update-changes.yml
@@ -33,7 +33,7 @@ jobs:
         run: make update-latest-versions
 
       - name: Create or update pull request
-        uses: gr2m/create-or-update-pull-request-action@v1.9.1
+        uses: gr2m/create-or-update-pull-request-action@v1.3.1
         env:
           GITHUB_TOKEN: ${{ secrets.TOKEN }}
         with:


### PR DESCRIPTION
### What does this PR do?

Fix content update automation.

Since the recent update it fails with `Error: File not found: '/home/runner/work/_actions/gr2m/create-or-update-pull-request-action/v1.9.1/dist/index.js'`.

