### PR TITLE
Use newest hugo base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN find /public \
   -iregex '.*\.(css|csv|html?|js|svg|txt|xml|json|webmanifest|ttf)' \
   -exec gzip -9 -k '{}' \;
 
-FROM quay.io/giantswarm/nginx:1.21-alpine
+FROM quay.io/giantswarm/nginx:1.23-alpine
 
 COPY nginx.conf /etc/nginx/nginx.conf
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM quay.io/giantswarm/hugo:v0.93.3 AS build
+FROM quay.io/giantswarm/hugo:v0.104.3 AS build
 
-RUN apk --no-cache add findutils gzip
+RUN apk --update --no-cache add findutils gzip
 
 WORKDIR /docs
 


### PR DESCRIPTION
### What does this PR do?

Fix CI by updating to a newer base image.

Also updating nginx while we are at it.

### Any background context you can provide?

CI was failing with

```
#11 [build 2/6] RUN apk --no-cache add findutils gzip
#11 sha256:a7eafbf0abb78345ee8c5acc6830c48ee62c65d4ac83439f32cfa2f67ac28b8e
#11 0.525 fetch https://dl-cdn.alpinelinux.org/alpine/v3.14/main/x86_64/APKINDEX.tar.gz
#11 0.727 fetch https://dl-cdn.alpinelinux.org/alpine/v3.14/community/x86_64/APKINDEX.tar.gz
#11 0.727 WARNING: Ignoring https://dl-cdn.alpinelinux.org/alpine/v3.14/main: No such file or directory
#11 0.896 WARNING: Ignoring https://dl-cdn.alpinelinux.org/alpine/v3.14/community: No such file or directory
#11 0.896 ERROR: unable to select packages:
#11 0.898   findutils (no such package):
#11 0.898     required by: world[findutils]
#11 0.898   gzip (no such package):
#11 0.898     required by: world[gzip]
#11 ERROR: executor failed running [/bin/ash -eo pipefail -c apk --no-cache add findutils gzip]: exit code: 2
```

