### PR TITLE
test environment: Support HubSpot Private App

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -52,4 +52,4 @@ services:
       - sitesearch-app
     environment:
       ELASTICSEARCH_ENDPOINT: http://sitesearch-app:9200
-      HUBSPOT_API_KEY: ${HUBSPOT_API_KEY}
+      HUBSPOT_ACCESS_TOKEN: ${HUBSPOT_ACCESS_TOKEN}


### PR DESCRIPTION
### Update docker-compose.yaml for HubSpot Private App

  * See giantswarm/giantswarm#23747
  * Use token from env var HUBSPOT_ACCESS_TOKEN
