### PR TITLE
Updating prometheus volume size public documentation

### DIFF
--- a/src/content/ui-api/observability/prometheus/volume-size/index.md
+++ b/src/content/ui-api/observability/prometheus/volume-size/index.md
@@ -75,8 +75,6 @@ spec:
 
 ## Limitations
 
-* __Expanding__: It is currently impossible to expand the Prometheus volume on OpenStack. We are working on a fix and will adjust the documentation accordingly when available. 
-
 * __Downsizing__: be aware that reducing the volume size will cause data loss.
 
 


### PR DESCRIPTION
### What does this PR do?
Updating prometheus volume size public documentation

### Any background context you can provide?
There was an issue on OpenStack with volume expanding: 
https://github.com/giantswarm/giantswarm/issues/24220

Now it's fixed, we need to remove the limitation written in the public documentation
