### PR TITLE
fix menu entry for CAPI cloud providers

### DIFF
--- a/src/content/getting-started/cloud-provider-accounts/cluster-api/_index.md
+++ b/src/content/getting-started/cloud-provider-accounts/cluster-api/_index.md
@@ -2,11 +2,11 @@
 linkTitle: Cloud provider accounts for Cluster API
 title: Cloud provider accounts for Cluster API
 description: How to set up your AWS account or your Azure subscription in for Cluster API order to run Giant Swarm management clusters and workload clusters under your jurisdiction.
-weight: 10
+weight: 80
 menu:
   main:
     identifier: gettingstarted-cloudprovider-clusterapi
-    parent: getting-started-cloudprovider
+    parent: gettingstarted-cloudprovider
 last_review_date: 2023-01-06
 owner:
   - https://github.com/orgs/giantswarm/teams/sig-docs


### PR DESCRIPTION
### What does this PR do?

Fix CAPI cloud providers menu entry and ordering weight

### What does it look like?

![image](https://user-images.githubusercontent.com/50299074/212893165-f6a83a0a-98e2-4c28-9ce5-1f0b69fcb260.png)
@LolloneS found this issue in the menu

### Any background context you can provide?

### What is needed from the reviewers?

### Have you maintained the front matter?

Only fixed issue.
