### PR TITLE
Delete empty reference section

### DIFF
--- a/src/content/reference/_index.md
+++ b/src/content/reference/_index.md
@@ -1,8 +1,0 @@
----
-linkTitle: Reference
-title: Reference
-description: Our place for those facts you never want to keep in mind. Think of it as an appendix.
-last_review_date: 2021-01-01
-owner:
-  - https://github.com/orgs/giantswarm/teams/sig-docs
----


### PR DESCRIPTION
### What does this PR do?

Removes the https://docs.giantswarm.io/reference/ which was an empty left-over.
