### PR TITLE
add promtail audit log config link

### DIFF
--- a/src/content/getting-started/observability/logging/audit-logs/index.md
+++ b/src/content/getting-started/observability/logging/audit-logs/index.md
@@ -287,4 +287,4 @@ Fluent-bit's main advantage is that it can be used for all kinds of cases (shipp
 
 ### Promtail
 
-[Promtail](https://github.com/giantswarm/promtail-app) can only be used with Loki. It provides a better integration with Kubernetes via its discovery mechanism and enriches logs with metadata by default. It can also be used to read files on the machines like the audit logs described here.
+[Promtail](https://github.com/giantswarm/promtail-app) can only be used with Loki. It provides a better integration with Kubernetes via its discovery mechanism and enriches logs with metadata by default. It can also be used to read files on the machines like the audit logs described [here](https://github.com/giantswarm/promtail-app#configuration).


### PR DESCRIPTION
### What does this PR do?

Add the missing link for Promtail audit log configuration example.

### What is needed from the reviewers?

Is this link fine or should we instead link directly to the concerned file at https://github.com/giantswarm/promtail-app/blob/master/examples/values-kubernetes-audit-logs.yaml ?