### PR TITLE
Updated 'OIDC auth for workload clusters' docs page

### DIFF
--- a/src/content/advanced/configure-dex-in-your-cluster/index.md
+++ b/src/content/advanced/configure-dex-in-your-cluster/index.md
@@ -9,7 +9,7 @@ menu:
 user_questions:
   - How can I configure OIDC in my cluster?
   - How can I add a new OIDC connector?
-last_review_date: 2022-03-04
+last_review_date: 2023-03-13
 owner:
   - https://github.com/orgs/giantswarm/teams/team-rainbow
 ---
@@ -87,6 +87,23 @@ spec:
 ```
 
 {{< /tab >}}
+{{< tab title="Cluster API">}}
+
+```yaml
+# Config map with values for the Workload Cluster app
+apiVersion: v1
+kind: ConfigMap
+data:
+  values: |
+    ...
+    oidc:
+      issuerUrl: https://dex.CLUSTER_NAME.BASE_DOMAIN
+      clientId: dex-k8s-authenticator
+      usernameClaim: email
+      groupsClaim: groups
+```
+
+{{< /tab >}}
 {{< /tabs >}}
 
 __Note__: In the above snippets you need to replace the `CLUSTER_NAME` and `BASE_DOMAIN` placeholder with the correct values, which is the name of the workload cluster you are configuring, and the base domain that you use for your installation. You can also derive them from the workload cluster's Kubernetes API endpoint, which has a URL in the format of `https://api.CLUSTER_NAME.BASE_DOMAIN`.
@@ -95,43 +112,46 @@ __Note__: In the above snippets you need to replace the `CLUSTER_NAME` and `BASE
 
 In this guide, we will use a single app deployment for each cluster that you want to authenticate towards. There are different ways to set up how you authenticate towards your Kubernetes API with Dex, but in our opinion, using a single deployment per cluster is more resilient than having a common Dex deployment for all your workload clusters.
 
-We'll use the [app platform]({{< relref "/getting-started/app-platform" >}}) to deploy the app, as it allows us to deploy apps across workload clusters using a single API endpoint. In this example, we create an `App` custom resource (CR) with the parameters to install our [`dex-app`](https://github.com/giantswarm/dex-app) in the desired cluster, and a `ConfigMap` with the configuration values.
+We'll use the [app platform]({{< relref "/getting-started/app-platform" >}}) to deploy the app, as it allows us to deploy apps across workload clusters using a single API endpoint. In this example, we create an `App` custom resource (CR) with the parameters to install our [`dex-app`](https://github.com/giantswarm/dex-app) in the desired cluster, and a `Secret` with the configuration values. The app platform also supports providing the configuration values in a `ConfigMap`, but in case of Dex some configuration values are credentials, therefore using a `Secret` is the preferred method. It is also possible to split the configuration values, provide the public part in a `ConfigMap` and the credentials in a `Secret`, but in this example we will provide the entire configuration in a `Secret`:
 
-The `connectorConfig` format can look different depending on the oidc provider you want to use. Some examples can be found below. 
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: dex-app-user-values
+  namespace: CLUSTER_NAMESPACE_NAME
+data:
+  values: ... # base64 encoded connector config
+```
+
+The format of the `connector config` content can look different depending on the oidc provider you want to use. Some examples can be found below.
 Details on all connectors and their respective configuration is available in the [Dex documentation](https://dexidp.io/docs/connectors/).
 
 {{< tabs >}}
 {{< tab title="Keycloak">}}
 
 ```yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: dex-app-user-values
-  namespace: CLUSTER_NAME
-data:
-  values: |
-    isWorkloadCluster: true
-    oidc:
-      expiry:
-        signingKeys: 6h
-        idTokens: 30m
-      customer:
-        enabled: true
-        connectors:
-        - id: customer
-          connectorName: test
-          connectorType: oidc
-          connectorConfig: >-
-            clientID: CLIENT_ID
-            clientSecret: CLIENT_SECRET
-            insecureEnableGroups: true
-            scopes:
-            - email
-            - groups
-            - profile
-            issuer: https://KEYCLOAK_HOST/auth/realms/master
-            redirectURI: https://dex.CLUSTER_NAME.BASE_DOMAIN/callback
+isWorkloadCluster: true
+oidc:
+  expiry:
+    signingKeys: 6h
+    idTokens: 30m
+  customer:
+    enabled: true
+    connectors:
+    - id: customer
+      connectorName: test
+      connectorType: oidc
+      connectorConfig: >-
+        clientID: CLIENT_ID
+        clientSecret: CLIENT_SECRET
+        insecureEnableGroups: true
+        scopes:
+        - email
+        - groups
+        - profile
+        issuer: https://KEYCLOAK_HOST/auth/realms/master
+        redirectURI: https://dex.CLUSTER_NAME.BASE_DOMAIN/callback
 ```
 
 The values for `CLIENT_ID` and `CLIENT_SECRET` are created/defined in the Keycloak OIDC client configuration. `KEYCLOAK_HOST` is the fully qualified host name of your Keycloak instance.
@@ -140,34 +160,27 @@ The values for `CLIENT_ID` and `CLIENT_SECRET` are created/defined in the Keyclo
 {{< tab title="GitHub">}}
 
 ```yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: dex-app-user-values
-  namespace: CLUSTER_NAME
-data:
-  values: |
-    isWorkloadCluster: true
-    oidc:
-      expiry:
-        signingKeys: 6h
-        idTokens: 30m
-      customer:
-        enabled: true
-        connectors:
-        - id: customer
-          connectorName: test
-          connectorType: github
-          connectorConfig: >-
-            clientID: CLIENT_ID
-            clientSecret: CLIENT_SECRET
-            loadAllGroups: false
-            teamNameField: slug
-            redirectURI: https://dex.CLUSTER_NAME.BASE_DOMAIN/callback
-            orgs:
-            - name: GITHUB_ORGANIZATION
-              teams:
-              - GITHUB_TEAM_SLUG
+isWorkloadCluster: true
+oidc:
+  expiry:
+    signingKeys: 6h
+    idTokens: 30m
+  customer:
+    enabled: true
+    connectors:
+    - id: customer
+      connectorName: test
+      connectorType: github
+      connectorConfig: >-
+        clientID: CLIENT_ID
+        clientSecret: CLIENT_SECRET
+        loadAllGroups: false
+        teamNameField: slug
+        redirectURI: https://dex.CLUSTER_NAME.BASE_DOMAIN/callback
+        orgs:
+        - name: GITHUB_ORGANIZATION
+          teams:
+          - GITHUB_TEAM_SLUG
 ```
 
 The value for `CLIENT_ID` is automatically generated by GitHub after creation of an OAuth app. Please also generate a client secret for that app and replace `CLIENT_SECRET` with the contents of that secret.
@@ -178,29 +191,22 @@ In the above example we show how to configure access for a certain GitHub team (
 {{< tab title="Active Directory">}}
 
 ```yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: dex-app-user-values
-  namespace: CLUSTER_NAME
-data:
-  values: |
-    isWorkloadCluster: true
-    oidc:
-      expiry:
-        signingKeys: 6h
-        idTokens: 30m
-      customer:
-        enabled: true
-        connectors:
-        - id: customer
-          connectorName: test
-          connectorType: microsoft
-          connectorConfig: >-
-            clientID: CLIENT_ID
-            clientSecret: CLIENT_SECRET
-            tenant: TENANT
-            redirectURI: https://dex.CLUSTER_NAME.BASE_DOMAIN/callback
+isWorkloadCluster: true
+oidc:
+  expiry:
+    signingKeys: 6h
+    idTokens: 30m
+  customer:
+    enabled: true
+    connectors:
+    - id: customer
+      connectorName: test
+      connectorType: microsoft
+      connectorConfig: >-
+        clientID: CLIENT_ID
+        clientSecret: CLIENT_SECRET
+        tenant: TENANT
+        redirectURI: https://dex.CLUSTER_NAME.BASE_DOMAIN/callback
 ```
 
 The values to be filled in as `CLIENT_ID` and `CLIENT_SECRET` are obtained when creating a client application in Active Directory. Please replace `TENANT` with your Azure AD tenant ID.
@@ -209,35 +215,28 @@ The values to be filled in as `CLIENT_ID` and `CLIENT_SECRET` are obtained when 
 {{< tab title="Okta">}}
 
 ```yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: dex-app-user-values
-  namespace: CLUSTER
-data:
-  values: |
-    isWorkloadCluster: true
-    oidc:
-      expiry:
-        signingKeys: 6h
-        idTokens: 30m
-      customer:
-        enabled: true
-        connectors:
-        - id: customer
-          connectorName: test
-          connectorType: oidc
-          connectorConfig: >-
-            clientID: CLIENT_ID
-            clientSecret: CLIENT_SECRET
-            insecureEnableGroups: true
-            getUserInfo: true
-            scopes:
-            - email
-            - groups
-            - profile
-            issuer: https://OKTA_OIDC_ENDPOINT
-            redirectURI: https://dex.CLUSTER_NAME.BASE_DOMAIN/callback
+isWorkloadCluster: true
+oidc:
+  expiry:
+    signingKeys: 6h
+    idTokens: 30m
+  customer:
+    enabled: true
+    connectors:
+    - id: customer
+      connectorName: test
+      connectorType: oidc
+      connectorConfig: >-
+        clientID: CLIENT_ID
+        clientSecret: CLIENT_SECRET
+        insecureEnableGroups: true
+        getUserInfo: true
+        scopes:
+        - email
+        - groups
+        - profile
+        issuer: https://OKTA_OIDC_ENDPOINT
+        redirectURI: https://dex.CLUSTER_NAME.BASE_DOMAIN/callback
 ```
 
 The values for `CLIENT_ID` and `CLIENT_SECRET` have to be created in the Okta configuration. `OKTA_OIDC_ENDPOINT` must be replaced using the fully qualified host name of your Okta instance.
@@ -245,12 +244,12 @@ The values for `CLIENT_ID` and `CLIENT_SECRET` have to be created in the Okta co
 {{< /tab >}}
 {{< /tabs >}}
 
-__Warning__: With `oidc` connector you might need to add `getUserInfo` in the connector configuration to force a second call to the identity provider in order to get groups. This is required for example by Okta. More info on this can be found in [dexipd/dex#1065](https://github.com/dexidp/dex/issues/1065).
+__Warning__: With `oidc` connector you might need to add `getUserInfo` in the connector configuration to force a second call to the identity provider in order to get groups. This is required for example by Okta. More info on this can be found in [dexidp/dex#1065](https://github.com/dexidp/dex/issues/1065).
 
 __Note__: In the above snippet you have to replace the `CLUSTER_NAME` variable and select a connector. Here we show examples for Keycloak, Active Directory, and GitHub.
 You can use more than one connector, but they need to have a different `id` value. We advice you to use `- id: customer` for your primary connector.
 
-After you have applied the `ConfigMap` manifest to the Management API you have to submit the App custom resource that defines the intent to install the Dex app in the given cluster.
+After you have applied the `Secret` manifest to the Management API you have to submit the App custom resource that defines the intent to install the Dex app in the given cluster.
 The easiest way to do this is [through our Web-UI]({{< relref "/platform-overview/web-interface/app-platform" >}})
 Alternatively, you can directly apply it to the Management Cluster.
 
@@ -261,7 +260,7 @@ metadata:
   labels:
     app.kubernetes.io/name: dex-app
   name: dex-app
-  namespace: CLUSTER_NAME
+  namespace: CLUSTER_NAMESPACE_NAME
 spec:
   catalog: giantswarm
   kubeConfig:
@@ -269,21 +268,55 @@ spec:
       name: CLUSTER_NAME
     secret:
       name: CLUSTER_NAME-kubeconfig
-      namespace: CLUSTER_NAME
+      namespace: CLUSTER_NAMESPACE_NAME
   name: dex-app
   namespace: dex
   userConfig:
-    configMap:
+    secret:
       name: dex-app-user-values
-      namespace: CLUSTER_NAME
+      namespace: CLUSTER_NAMESPACE_NAME
   version: 1.22.2
 ```
 
-__Note__: When applying the example in the snippet above, please replace the `CLUSTER_NAME` placeholder with the name of the workload cluster which you are configuring.
+__Note__: When applying the example in the snippet above, please replace the `CLUSTER_NAME` placeholder with the name of the workload cluster which you are configuring and the `CLUSTER_NAMESPACE_NAME` placeholder with the name of the namespace which contains the cluster.
 
 Then submit the resource to the management API and the App operator will manage it to make the actual installation and configuration. You can log in now into the cluster API with your identity provider using the login endpoint that Dex creates for you. By default, it will be `https://login.CLUSTER_NAME.BASE_DOMAIN`.
 
-__Warning__: It is assumed that you have an [ingress controller and cert-manager]({{< relref "/getting-started/app-platform/deploy-app" >}}) running in your cluster in order to make dex available for the callback request made by your identity provider securely. If you supply custom certificates when deploying dex, then you can skip cert-manager installation. Both of these apps are offered in our managed app catalog.
+__Warning__: It is assumed that you have an [ingress controller and cert-manager]({{< relref "/getting-started/app-platform/deploy-app" >}}) running in your cluster in order to make Dex available for the callback request made by your identity provider securely. Both of these apps are offered in our managed app catalog. If you supply custom certificates when deploying Dex, then you can skip cert-manager installation. 
+
+### Deploying Dex with custom certificates
+
+Dex gets certificates from the cert-manager by default. In case the cert-manager is configured to use a custom certification authority, which is not publicly trusted, Dex needs to be configured to trust it. The custom certification authority needs to be stored in a `Secret` and referenced in the `trustedRootCA` section of the `Secret` or `ConfigMap` with configuration values for the Dex app.
+
+```yaml
+trustedRootCA:
+  secretName: ... # Name of the secret, which contains the custom CA
+  name: ... # Name of the property inside the secret
+```
+
+It is also possible to disable retrieving certificates from the cert-manager and supply custom certificates to Dex directly. They can be configured in the `ingress` section of the `Secret` or `ConfigMap` with the configuration values for the Dex app:
+
+```yaml
+ingress:
+  tls:
+    letsencrypt: false
+    caPemB64: ...
+    crtPemB64: ...
+    keyPemB64: ...
+```
+
+### Running Dex in a private workload cluster
+
+When deploying Dex to a private workload cluster, it is required to specify a proxy configuration in order to ensure that Dex has access to the outside network. Proxy setup can be provided in the `proxy` section of the `Secret` or `ConfigMap` with configuration values for the Dex app. It is required to set the proxy as `enabled`, specify the URL of the HTTPS proxy in the `https_proxy` property and exclude Kubernetes API from running through the proxy by adding its IP address or network to the `no_proxy` property.  
+
+```yaml
+proxy:
+  enabled: true
+  http_proxy: ... # HTTP proxy URL
+  https_proxy: ... # HTTPS proxy URL
+  no_proxy: ... # Hostnames or networks/IP ranges excluded from going through the proxy
+
+```
 
 ## Dex Observability
 

--- a/src/content/advanced/configure-dex-in-your-cluster/index.md
+++ b/src/content/advanced/configure-dex-in-your-cluster/index.md
@@ -372,6 +372,17 @@ security:
       gsAPI: true
 ```
 
+Athena also supports custom certificates, same as the Dex app. 
+The certificates need to be provided in the `ingress` section of the configuration:
+
+```yaml
+ingress:
+  tls:
+    letsencrypt: false
+    caPemB64: ...
+    crtPemB64: ...
+    keyPemB64: ...
+```
 
 If both `Dex` and `Athena` are configured correctly and you have installed `kubectl gs` on your machine, you should be able to create a kubectl context using the management API URL.
 ```

--- a/src/content/advanced/configure-dex-in-your-cluster/index.md
+++ b/src/content/advanced/configure-dex-in-your-cluster/index.md
@@ -286,7 +286,9 @@ __Warning__: It is assumed that you have an [ingress controller and cert-manager
 
 ### Deploying Dex with custom certificates
 
-Dex gets certificates from the cert-manager by default. In case the cert-manager is configured to use a custom certification authority, which is not publicly trusted, Dex needs to be configured to trust it. The custom certification authority needs to be stored in a `Secret` and referenced in the `trustedRootCA` section of the `Secret` or `ConfigMap` with configuration values for the Dex app.
+Dex gets certificates from the cert-manager by default. 
+In case the cert-manager is configured to use a custom certification authority, which is not publicly trusted, Dex needs to be configured to trust it. 
+The custom certification authority needs to be stored in a `Secret` and referenced in the `trustedRootCA` section of the `Secret` or `ConfigMap` with configuration values for the Dex app.
 
 ```yaml
 trustedRootCA:
@@ -307,7 +309,9 @@ ingress:
 
 ### Running Dex in a private workload cluster
 
-When deploying Dex to a private workload cluster, it is required to specify a proxy configuration in order to ensure that Dex has access to the outside network. Proxy setup can be provided in the `proxy` section of the `Secret` or `ConfigMap` with configuration values for the Dex app. It is required to set the proxy as `enabled`, specify the URL of the HTTPS proxy in the `https_proxy` property and exclude Kubernetes API from running through the proxy by adding its IP address or network to the `no_proxy` property.  
+When deploying Dex to a private workload cluster, it is required to specify a proxy configuration in order to ensure that Dex has access to the outside network. 
+Proxy setup can be provided in the `proxy` section of the `Secret` or `ConfigMap` with configuration values for the Dex app. 
+It is required to set the proxy as `enabled`, specify the URL of the HTTPS proxy in the `https_proxy` property and exclude Kubernetes API from running through the proxy by adding its IP address or network to the `no_proxy` property.  
 
 ```yaml
 proxy:
@@ -367,6 +371,7 @@ security:
     restrictAccess:
       gsAPI: true
 ```
+
 
 If both `Dex` and `Athena` are configured correctly and you have installed `kubectl gs` on your machine, you should be able to create a kubectl context using the management API URL.
 ```


### PR DESCRIPTION
### What does this PR do?

Review and update of the 'OIDC auth for workload clusters' docs page, introducing the following changes:

- example of OIDC configuration in a CAPI cluster
- adjustment in the part about deploying the Dex app to use a Secret instead of a ConfigMap to provide the configuration values
- additional section about custom certificates in Dex
- additional section about running Dex in a private workload cluster

### What does it look like?

Just textual changes

### Any background context you can provide?

Dex app has a few recent changes, which need to be reflected in the documentation.

### What is needed from the reviewers?

Check if the documentation makes sense

### Have you maintained the front matter?

Last review date updated
The new content expands answers to the existing user questions (mostly "How can I configure OIDC in my cluster?")
