### PR TITLE
changed grafana-cloud to your-prometheus-instance

### DIFF
--- a/src/content/getting-started/observability/monitoring/prometheus/remotewrite/index.md
+++ b/src/content/getting-started/observability/monitoring/prometheus/remotewrite/index.md
@@ -51,7 +51,7 @@ spec:
   ## see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#labelselector-v1-meta
   clusterSelector: {}
   remoteWrite:
-    ## Configure the authentication to use using the values from the your-prometheus-instance secret
+    ## Configure the authentication to use values from the your-prometheus-instance secret
     basicAuth:
       password:
         key: password

--- a/src/content/getting-started/observability/monitoring/prometheus/remotewrite/index.md
+++ b/src/content/getting-started/observability/monitoring/prometheus/remotewrite/index.md
@@ -43,7 +43,7 @@ For example, this `RemoteWrite` Custom Resource indicates that we configure the 
 apiVersion: monitoring.giantswarm.io/v1alpha1
 kind: RemoteWrite
 metadata:
-  name: grafana-cloud
+  name: your-prometheus-instance
   namespace: monitoring
 spec:
   ## Defines the cluster to configure prometheus remote write for
@@ -51,15 +51,15 @@ spec:
   ## see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#labelselector-v1-meta
   clusterSelector: {}
   remoteWrite:
-    ## Configure the authentication to use using the values from the grafana-cloud secret
+    ## Configure the authentication to use using the values from the your-prometheus-instance secret
     basicAuth:
       password:
         key: password
-        name: grafana-cloud
+        name: your-prometheus-instance
       username:
         key: username
-        name: grafana-cloud
-    name: grafana-cloud
+        name: your-prometheus-instance
+    name: your-prometheus-instance
     queueConfig:
       capacity: 10000
       maxSamplesPerSend: 1000
@@ -70,7 +70,7 @@ spec:
   - data:
       password: ...
       username: ...
-    name: grafana-cloud
+    name: your-prometheus-instance
 ```
 
 ## RemoteWrite CRD


### PR DESCRIPTION
### What does this PR do?

changed naming of grafana-cloud to your-prometheus-instance, so it's easier to understand for the customer, where to add their prometheus instance if they want to create a remote-write to their own instance.

### What does it look like?

(If this is more than a textual change, a screenshot can help in some cases to speed up the review process.)

### Any background context you can provide?


### What is needed from the reviewers?

### Have you maintained the front matter?

(Please bump the last_review_date in case this qualifies as a review for an entire page. Provide user_questions which should be answered in the page. Provide a meaningful description.)
