### PR TITLE
Move intranet proxy list domains to public docs

### DIFF
--- a/src/content/platform-overview/security/cluster-security/domain-allowlist/index.md
+++ b/src/content/platform-overview/security/cluster-security/domain-allowlist/index.md
@@ -25,10 +25,13 @@ Below is a list of the external domains we require access to for our clusters to
 - amazonaws.com
     - domains:
         - `*.amazonaws.com`
+        - `ec2.eu-west-2.amazonaws.com`
+        - `sts.eu-central-1.amazonaws.com`
     - AWS services are used for a variety of tasks, such as etcd backup storage.
 - azurecr.io
     - domains:
         - `giantswarm.azurecr.io`
+        - `giantswarmpublic.azurecr.io`
     - Container images are hosted on Azure Container Registry.
 - cloudfront.net
     - domains:
@@ -37,6 +40,7 @@ Below is a list of the external domains we require access to for our clusters to
 - docker.com
     - domains:
         - `*.docker.com`
+        - `production.cloudflare.docker.com`
     - Container images are hosted on Dockerhub.
 - docker.io
     - domains:
@@ -54,6 +58,14 @@ Below is a list of the external domains we require access to for our clusters to
     - domains:
         - `*.github.io`
     - Helm chart tarballs are pulled from GitHub Pages.
+- gcr.io
+    - domains:
+        - `k8s.gcr.io`
+    - (Legacy) K8s container images are hosted on Google Container Registry.
+- k8s.io
+    - domains:
+        - `registry.k8s.io`
+    - Container registry and a global CDN for the K8s project’s container images.
 - keybase.io
     - domains:
         - `*.keybase.io`
@@ -66,21 +78,38 @@ Below is a list of the external domains we require access to for our clusters to
     - domains:
         - `*.quay.io`
     - Container images are hosted on Quay.
+- googleapis.com
+    - domains:
+        - `storage.googleapis.com`
+    - Google Container Registry is backed by a Google cloud storage bucket.
 - sentry.io
     - domains:
         - `o346224.ingest.sentry.io`
     - Monitoring and crash reporting for `happa`.
-- `api.opsgenie.com`
+- opsgenie.com
+    - domains:
+        - `api.opsgenie.com`
     - Opsgenie's API is used to send alerts.
-- `grafana.com`
+- grafana.com
+    - domains:
+        - `grafana.com`
     - Grafana may download plugins from the Grafana plugin registry.
-- `prometheus-us-central1.grafana.net`
+- grafana.net
+    - domains:
+        - `prometheus-us-central1.grafana.net`
     - Some metrics are pushed to our hosted Grafana tenant.
-- `vault.operations.giantswarm.io`
+- giantswarm.io
+    - domains:
+        - `vault.operations.giantswarm.io`
+        - `schema.giantswarm.io`
     - Our operations Vault is used for unsealing customer Vault servers.
-- `giantswarm.eu.auth0.com`
+- auth0.com
+    - domains:
+        - `giantswarm.eu.auth0.com`
     - Used to secure access to Grafana and Prometheus.
-- `hooks.slack.com`
+- slack.com
+    - domains:
+        - `hooks.slack.com`
     - Used to send alerts on slack channels
 
 ## On-premise installations

--- a/src/content/platform-overview/security/cluster-security/domain-allowlist/index.md
+++ b/src/content/platform-overview/security/cluster-security/domain-allowlist/index.md
@@ -83,6 +83,7 @@ Below is a list of the external domains we require access to for our clusters to
         - `vault.operations.giantswarm.io`
         - `schema.giantswarm.io`
     - Our operations Vault is used for unsealing customer Vault servers.
+    - Our schema server hosts the schema's for container image validation.
 - k8s.io
     - domains:
         - `registry.k8s.io`

--- a/src/content/platform-overview/security/cluster-security/domain-allowlist/index.md
+++ b/src/content/platform-overview/security/cluster-security/domain-allowlist/index.md
@@ -32,7 +32,7 @@ Below is a list of the external domains we require access to for our clusters to
     - domains:
         - `giantswarm.azurecr.io`
         - `giantswarmpublic.azurecr.io`
-    - Container images are hosted on Azure Container Registry.
+    - Container images and app catalogs are hosted on Azure Container Registry.
 - auth0.com
     - domains:
         - `giantswarm.eu.auth0.com`
@@ -46,6 +46,7 @@ Below is a list of the external domains we require access to for our clusters to
         - `*.docker.com`
         - `production.cloudflare.docker.com`
     - Container images are hosted on Dockerhub.
+    - Dockerhub uses Cloudflare as the CDN for serving Docker Image layer blobs, manifests, etc.
 - docker.io
     - domains:
         - `*.docker.io`

--- a/src/content/platform-overview/security/cluster-security/domain-allowlist/index.md
+++ b/src/content/platform-overview/security/cluster-security/domain-allowlist/index.md
@@ -33,6 +33,10 @@ Below is a list of the external domains we require access to for our clusters to
         - `giantswarm.azurecr.io`
         - `giantswarmpublic.azurecr.io`
     - Container images are hosted on Azure Container Registry.
+- auth0.com
+    - domains:
+        - `giantswarm.eu.auth0.com`
+    - Used to secure access to Grafana and Prometheus.
 - cloudfront.net
     - domains:
         - `*.cloudfront.net`
@@ -62,34 +66,10 @@ Below is a list of the external domains we require access to for our clusters to
     - domains:
         - `k8s.gcr.io`
     - (Legacy) K8s container images are hosted on Google Container Registry.
-- k8s.io
-    - domains:
-        - `registry.k8s.io`
-    - Container registry and a global CDN for the K8s project’s container images.
-- keybase.io
-    - domains:
-        - `*.keybase.io`
-    - Vault initialisation and unsealing requires access to Keybase.
-- letsencrypt.org
-    - domains:
-        - `*.api.letsencrypt.org`
-    - cert-manager will request certificates from Lets Encrypt.
-- quay.io
-    - domains:
-        - `*.quay.io`
-    - Container images are hosted on Quay.
 - googleapis.com
     - domains:
         - `storage.googleapis.com`
     - Google Container Registry is backed by a Google cloud storage bucket.
-- sentry.io
-    - domains:
-        - `o346224.ingest.sentry.io`
-    - Monitoring and crash reporting for `happa`.
-- opsgenie.com
-    - domains:
-        - `api.opsgenie.com`
-    - Opsgenie's API is used to send alerts.
 - grafana.com
     - domains:
         - `grafana.com`
@@ -103,10 +83,30 @@ Below is a list of the external domains we require access to for our clusters to
         - `vault.operations.giantswarm.io`
         - `schema.giantswarm.io`
     - Our operations Vault is used for unsealing customer Vault servers.
-- auth0.com
+- k8s.io
     - domains:
-        - `giantswarm.eu.auth0.com`
-    - Used to secure access to Grafana and Prometheus.
+        - `registry.k8s.io`
+    - Container registry and a global CDN for the K8s project’s container images.
+- keybase.io
+    - domains:
+        - `*.keybase.io`
+    - Vault initialisation and unsealing requires access to Keybase.
+- letsencrypt.org
+    - domains:
+        - `*.api.letsencrypt.org`
+    - cert-manager will request certificates from Lets Encrypt.
+- opsgenie.com
+    - domains:
+        - `api.opsgenie.com`
+    - Opsgenie's API is used to send alerts.
+- quay.io
+    - domains:
+        - `*.quay.io`
+    - Container images are hosted on Quay.
+- sentry.io
+    - domains:
+        - `o346224.ingest.sentry.io`
+    - Monitoring and crash reporting for `happa`.
 - slack.com
     - domains:
         - `hooks.slack.com`


### PR DESCRIPTION
Towards - https://github.com/giantswarm/giantswarm/issues/26558

### What does this PR do?

(Please set a descriptive PR title. Use this space for additional explanations.)

Move [intranet proxy list domains](https://intranet.giantswarm.io/docs/customers/info/talanx/#http-proxy) to [public docs](https://docs.giantswarm.io/platform-overview/security/cluster-security/domain-allowlist/).

### What does it look like?

(If this is more than a textual change, a screenshot can help in some cases to speed up the review process.)

### Any background context you can provide?

(Please link public issues or summarize if not public.)

### What is needed from the reviewers?


### Have you maintained the front matter?

(Please bump the last_review_date in case this qualifies as a review for an entire page. Provide user_questions which should be answered in the page. Provide a meaningful description.)
