### PR TITLE
Review "installing kubectl gs"

### DIFF
--- a/src/content/use-the-api/kubectl-gs/installation.md
+++ b/src/content/use-the-api/kubectl-gs/installation.md
@@ -11,7 +11,7 @@ aliases:
   - /ui-api/kubectl-gs/installation/
 owner:
   - https://github.com/orgs/giantswarm/teams/team-rainbow
-last_review_date: 2022-04-13
+last_review_date: 2023-05-03
 user_questions:
   - Where can I find the Giant Swarm plugin for kubectl?
   - How can I install the Giant Swarm plugin for kubectl?


### PR DESCRIPTION
### What does this PR do?

Update the review date of `use-the-api/kubectl-gs/installation/`
[Link](https://docs.giantswarm.io/use-the-api/kubectl-gs/installation/)

Everything is up to date.

### What does it look like?

No changes.

### Any background context you can provide?

Closes https://github.com/giantswarm/giantswarm/issues/26612

### What is needed from the reviewers?

### Have you maintained the front matter?
