### PR TITLE
remove opsctl usage step from wc login

### DIFF
--- a/src/content/getting-started/capz-cluster-creation/index.md
+++ b/src/content/getting-started/capz-cluster-creation/index.md
@@ -355,10 +355,10 @@ bzm29   bzm29     True                       bzm29            6b1f6e4a-6d0e-4aa4
 
 ### login
 
-Once the cluster got created, `opsctl` could be used to login into the workload cluster by running
+Once the cluster got created, `kubectl-gs` could be used to login into the workload cluster by running
 
 ```noghighlight
-$ opsctl login glippy jrp45
+$ kubectl gs login glippy --workload-cluster jrp45 --certificate-group system:masters
 ```
 
 With the changed context, you are able to list the newly created nodes within a cluster:
@@ -411,3 +411,7 @@ Cluster/jrp45                                  True                             
     │           └─Available                    True                               90m                                                                       
     └─3 Machines...                            True                               90m    See jrp45-md00-7b9fb977c8-rzkmw, jrp45-md00-7b9fb977c8-ssjph, ...  
 ```
+
+## Related
+
+- [`kubectl gs login`]({{< relref "/use-the-api/kubectl-gs/login" >}}) - Ensure an authenticated kubectl context.


### PR DESCRIPTION
as opsctl is only for internal use, the workload cluster login step should point to kubectl-gs

### What does this PR do?

(Please set a descriptive PR title. Use this space for additional explanations.)

### What does it look like?

(If this is more than a textual change, a screenshot can help in some cases to speed up the review process.)

### Any background context you can provide?

(Please link public issues or summarize if not public.)

### What is needed from the reviewers?

### Have you maintained the front matter?

(Please bump the last_review_date in case this qualifies as a review for an entire page. Provide user_questions which should be answered in the page. Provide a meaningful description.)
