### PR TITLE
Change firecracker and celestial documentation ownership to phoenix

### DIFF
--- a/src/content/advanced/accelerated-networking-azure/index.md
+++ b/src/content/advanced/accelerated-networking-azure/index.md
@@ -12,7 +12,7 @@ aliases:
   - /basics/azure-accelerated-networking/
 last_review_date: 2021-05-04
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-celestial
+  - https://github.com/orgs/giantswarm/teams/team-phoenix
 ---
 
 # Accelerated networking on Azure

--- a/src/content/advanced/authentication-azure-ad/index.md
+++ b/src/content/advanced/authentication-azure-ad/index.md
@@ -13,7 +13,7 @@ last_review_date: 2021-03-15
 aliases:
   - /guides/authenticating-with-microsoft-azure-active-directory/
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-celestial
+  - https://github.com/orgs/giantswarm/teams/team-phoenix
 ---
 
 # Authenticating with Microsoft Azure Active Directory

--- a/src/content/advanced/automatic-node-termination/index.md
+++ b/src/content/advanced/automatic-node-termination/index.md
@@ -14,7 +14,7 @@ user_questions:
 aliases:
   - /basics/automatic-termination-of-bad-nodes/
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-firecracker
+  - https://github.com/orgs/giantswarm/teams/team-phoenix
 ---
 
 # Automatic termination of unhealthy nodes

--- a/src/content/advanced/cluster-autoscaler/index.md
+++ b/src/content/advanced/cluster-autoscaler/index.md
@@ -13,7 +13,7 @@ user_questions:
   - Where can I find the ConfigMap to configure cluster-autoscaler?
   - What cluster-autoscaler options can I configure?
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-firecracker
+  - https://github.com/orgs/giantswarm/teams/team-phoenix
 ---
 
 # Advanced cluster autoscaler configuration

--- a/src/content/advanced/egress-ip-address-azure/index.md
+++ b/src/content/advanced/egress-ip-address-azure/index.md
@@ -7,7 +7,7 @@ menu:
   main:
     parent: advanced
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-celestial
+  - https://github.com/orgs/giantswarm/teams/team-phoenix
 last_review_date: 2021-07-13
 user_questions:
   - How can I customize the public IP address for egress traffic on Azure?

--- a/src/content/advanced/high-availability/control-plane/index.md
+++ b/src/content/advanced/high-availability/control-plane/index.md
@@ -16,7 +16,7 @@ aliases:
   - /basics/ha-masters/
   - /advanced/high-availability/masters/
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-firecracker
+  - https://github.com/orgs/giantswarm/teams/team-phoenix
 ---
 
 # High-availability Kubernetes control plane

--- a/src/content/advanced/high-availability/multi-az/index.md
+++ b/src/content/advanced/high-availability/multi-az/index.md
@@ -21,7 +21,7 @@ user_questions:
 aliases:
   - /basics/multiaz/
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-celestial
+  - https://github.com/orgs/giantswarm/teams/team-phoenix
 ---
 
 # Clusters over multiple availability zones

--- a/src/content/advanced/multi-account/index.md
+++ b/src/content/advanced/multi-account/index.md
@@ -13,7 +13,7 @@ user_questions:
 aliases:
   - /basics/multi-account/
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-celestial
+  - https://github.com/orgs/giantswarm/teams/team-phoenix
 last_review_date: 2021-01-01
 ---
 

--- a/src/content/advanced/network-pools/index.md
+++ b/src/content/advanced/network-pools/index.md
@@ -14,7 +14,7 @@ user_questions:
 aliases:
   - /basics/networkpools/
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-firecracker
+  - https://github.com/orgs/giantswarm/teams/team-phoenix
 last_review_date: 2021-01-01
 ---
 

--- a/src/content/advanced/node-pools/index.md
+++ b/src/content/advanced/node-pools/index.md
@@ -14,7 +14,7 @@ user_questions:
 aliases:
   - /basics/nodepools/
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-firecracker
+  - https://github.com/orgs/giantswarm/teams/team-phoenix
 last_review_date: 2021-01-01
 ---
 

--- a/src/content/advanced/spot-instances/_index.md
+++ b/src/content/advanced/spot-instances/_index.md
@@ -10,8 +10,7 @@ menu:
 aliases:
   - /basics/spot-instances/
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-celestial
-  - https://github.com/orgs/giantswarm/teams/team-firecracker
+  - https://github.com/orgs/giantswarm/teams/team-phoenix
 last_review_date: 2021-01-01
 ---
 

--- a/src/content/advanced/spot-instances/aws/_index.md
+++ b/src/content/advanced/spot-instances/aws/_index.md
@@ -8,7 +8,7 @@ menu:
     identifier: advanced-spotinstances-aws
     parent: advanced-spotinstances
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-firecracker
+  - https://github.com/orgs/giantswarm/teams/team-phoenix
 last_review_date: 2021-01-01
 ---
 

--- a/src/content/advanced/spot-instances/aws/ondemand-fallback/index.md
+++ b/src/content/advanced/spot-instances/aws/ondemand-fallback/index.md
@@ -12,7 +12,7 @@ user_questions:
 aliases:
   - /advanced/spot-instances/aws/on-demand-fallback/
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-firecracker
+  - https://github.com/orgs/giantswarm/teams/team-phoenix
 last_review_date: 2021-01-01
 ---
 

--- a/src/content/advanced/spot-instances/aws/overview/index.md
+++ b/src/content/advanced/spot-instances/aws/overview/index.md
@@ -12,7 +12,7 @@ user_questions:
   - As of which release are AWS EC2 spot instances supported?
   - What's the difference between spot instances and on-demand instances on AWS?
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-firecracker
+  - https://github.com/orgs/giantswarm/teams/team-phoenix
 last_review_date: 2021-01-01
 ---
 

--- a/src/content/advanced/spot-instances/azure/_index.md
+++ b/src/content/advanced/spot-instances/azure/_index.md
@@ -8,7 +8,7 @@ menu:
     identifier: advanced-spotinstances-azure
     parent: advanced-spotinstances
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-celestial
+  - https://github.com/orgs/giantswarm/teams/team-phoenix
 last_review_date: 2021-01-01
 ---
 

--- a/src/content/advanced/spot-instances/azure/ondemand-fallback/index.md
+++ b/src/content/advanced/spot-instances/azure/ondemand-fallback/index.md
@@ -12,7 +12,7 @@ user_questions:
 aliases:
   - /advanced/spot-instances/azure/on-demand-fallback/
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-celestial
+  - https://github.com/orgs/giantswarm/teams/team-phoenix
 last_review_date: 2021-01-01
 ---
 

--- a/src/content/advanced/spot-instances/azure/overview/index.md
+++ b/src/content/advanced/spot-instances/azure/overview/index.md
@@ -13,7 +13,7 @@ user_questions:
   - As of which release are Azure spot VMs supported?
   - What's the difference between spot VMs and on-demand VMs on Azure?
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-celestial
+  - https://github.com/orgs/giantswarm/teams/team-phoenix
 last_review_date: 2021-01-01
 ---
 

--- a/src/content/advanced/storage/azure-pvc-encryption/index.md
+++ b/src/content/advanced/storage/azure-pvc-encryption/index.md
@@ -13,7 +13,7 @@ user_questions:
 aliases:
   - /guides/encrypting-persistent-volumes-on-azure-with-azure-key-vault/
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-celestial
+  - https://github.com/orgs/giantswarm/teams/team-phoenix
 last_review_date: 2021-01-01
 ---
 

--- a/src/content/advanced/storage/ebs-csi/index.md
+++ b/src/content/advanced/storage/ebs-csi/index.md
@@ -14,7 +14,7 @@ user_questions:
 aliases:
   - /guides/using-persistent-volumes-on-aws-with-ebs-csi-driver/
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-firecracker
+  - https://github.com/orgs/giantswarm/teams/team-phoenix
 last_review_date: 2021-01-01
 ---
 

--- a/src/content/advanced/storage/ebs-troubleshooting/index.md
+++ b/src/content/advanced/storage/ebs-troubleshooting/index.md
@@ -9,7 +9,7 @@ menu:
 aliases:
   - /guides/aws-impaired-volumes/
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-firecracker
+  - https://github.com/orgs/giantswarm/teams/team-phoenix
 user_questions:
   - How can I deal with impaired EBS volumes in my AWS cluster?
 last_review_date: 2021-01-01

--- a/src/content/advanced/storage/efs/index.md
+++ b/src/content/advanced/storage/efs/index.md
@@ -15,7 +15,7 @@ user_questions:
 aliases:
   - /guides/using-persistent-volumes-on-aws-with-efs-csi-driver/
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-firecracker
+  - https://github.com/orgs/giantswarm/teams/team-phoenix
 last_review_date: 2021-01-01
 ---
 

--- a/src/content/advanced/upgrade-disruption/index.md
+++ b/src/content/advanced/upgrade-disruption/index.md
@@ -11,7 +11,7 @@ aliases:
 user_questions:
   - How can I influence the disruption a cluster upgrade will cause?
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-firecracker
+  - https://github.com/orgs/giantswarm/teams/team-phoenix
 last_review_date: 2021-01-01
 ---
 

--- a/src/content/general/architcture/aws/index.md
+++ b/src/content/general/architcture/aws/index.md
@@ -24,7 +24,7 @@ user_questions:
 aliases:
   - /basics/aws-architecture/
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-firecracker
+  - https://github.com/orgs/giantswarm/teams/team-phoenix
 ---
 
 # The Giant Swarm AWS platform

--- a/src/content/general/architcture/azure/index.md
+++ b/src/content/general/architcture/azure/index.md
@@ -12,7 +12,7 @@ aliases:
 user_questions:
   - What's the high level architecture of a Giant Swarm installation on Azure?
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-celestial
+  - https://github.com/orgs/giantswarm/teams/team-phoenix
 ---
 
 # The Giant Swarm Azure architecture

--- a/src/content/general/cluster-upgrades/index.md
+++ b/src/content/general/cluster-upgrades/index.md
@@ -16,7 +16,7 @@ user_questions:
   - What is a patch upgrade?
 last_review_date: 2021-01-01
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-celestial
+  - https://github.com/orgs/giantswarm/teams/team-phoenix
 ---
 
 # Cluster upgrades

--- a/src/content/getting-started/cloud-provider-accounts/aws/index.md
+++ b/src/content/getting-started/cloud-provider-accounts/aws/index.md
@@ -15,7 +15,7 @@ aliases:
   - /guides/prepare-aws-account-for-tenant-clusters/
   - /guides/prepare-aws-account/
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-firecracker
+  - https://github.com/orgs/giantswarm/teams/team-phoenix
 last_review_date: 2021-01-01
 ---
 

--- a/src/content/getting-started/cloud-provider-accounts/azure/index.md
+++ b/src/content/getting-started/cloud-provider-accounts/azure/index.md
@@ -8,7 +8,7 @@ user_questions:
   - How do I prepare my Azure subscription for use with Giant Swarm?
   - What do I need to configure in Azure in order to run Giant Swarm clusters?
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-celestial
+  - https://github.com/orgs/giantswarm/teams/team-phoenix
 last_review_date: 2021-01-01
 ---
 

--- a/src/content/getting-started/persistent-volumes/aws/index.md
+++ b/src/content/getting-started/persistent-volumes/aws/index.md
@@ -12,7 +12,7 @@ aliases:
 user_questions:
   - How can I use persistent volumes in my AWS clusters?
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-firecracker
+  - https://github.com/orgs/giantswarm/teams/team-phoenix
 last_review_date: 2021-01-01
 ---
 

--- a/src/content/getting-started/persistent-volumes/azure/index.md
+++ b/src/content/getting-started/persistent-volumes/azure/index.md
@@ -12,7 +12,7 @@ aliases:
 user_questions:
   - How can I use persistent volumes in my Azure clusters?
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-celestial
+  - https://github.com/orgs/giantswarm/teams/team-phoenix
 last_review_date: 2021-01-01
 ---
 

--- a/src/content/reference/similar-ec2-instance-types/index.md
+++ b/src/content/reference/similar-ec2-instance-types/index.md
@@ -9,7 +9,7 @@ menu:
 user_questions:
   - Which EC2 instance types are used when I activate the use of similar instance types?
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-firecracker
+  - https://github.com/orgs/giantswarm/teams/team-phoenix
 last_review_date: 2021-01-01
 ---
 

--- a/src/content/ui-api/management-api/crd/awsclusters.infrastructure.giantswarm.io.md
+++ b/src/content/ui-api/management-api/crd/awsclusters.infrastructure.giantswarm.io.md
@@ -24,7 +24,7 @@ crd:
     info: This CRD will be removed once Cluster API resources are used for all AWS workload clusters.
 layout: crd
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-firecracker
+  - https://github.com/orgs/giantswarm/teams/team-phoenix
 aliases:
   - /reference/cp-k8s-api/awsclusters.infrastructure.giantswarm.io/
 technical_name: awsclusters.infrastructure.giantswarm.io

--- a/src/content/ui-api/management-api/crd/awscontrolplanes.infrastructure.giantswarm.io.md
+++ b/src/content/ui-api/management-api/crd/awscontrolplanes.infrastructure.giantswarm.io.md
@@ -24,7 +24,7 @@ crd:
     info: This CRD will be removed once Cluster API resources are used for all AWS workload clusters.
 layout: crd
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-firecracker
+  - https://github.com/orgs/giantswarm/teams/team-phoenix
 aliases:
   - /reference/cp-k8s-api/awscontrolplanes.infrastructure.giantswarm.io/
 technical_name: awscontrolplanes.infrastructure.giantswarm.io

--- a/src/content/ui-api/management-api/crd/awsmachinedeployments.infrastructure.giantswarm.io.md
+++ b/src/content/ui-api/management-api/crd/awsmachinedeployments.infrastructure.giantswarm.io.md
@@ -22,7 +22,7 @@ crd:
     - aws
 layout: crd
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-firecracker
+  - https://github.com/orgs/giantswarm/teams/team-phoenix
 aliases:
   - /reference/cp-k8s-api/awsmachinedeployments.infrastructure.giantswarm.io/
 technical_name: awsmachinedeployments.infrastructure.giantswarm.io

--- a/src/content/ui-api/management-api/crd/azureclusters.infrastructure.cluster.x-k8s.io.md
+++ b/src/content/ui-api/management-api/crd/azureclusters.infrastructure.cluster.x-k8s.io.md
@@ -22,7 +22,7 @@ crd:
     - azure
 layout: crd
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-celestial
+  - https://github.com/orgs/giantswarm/teams/team-phoenix
 aliases:
   - /reference/cp-k8s-api/azureclusters.infrastructure.cluster.x-k8s.io/
 technical_name: azureclusters.infrastructure.cluster.x-k8s.io

--- a/src/content/ui-api/management-api/crd/azuremachinepools.exp.infrastructure.cluster.x-k8s.io.md
+++ b/src/content/ui-api/management-api/crd/azuremachinepools.exp.infrastructure.cluster.x-k8s.io.md
@@ -21,7 +21,7 @@ crd:
     - azure
 layout: crd
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-celestial
+  - https://github.com/orgs/giantswarm/teams/team-phoenix
 aliases:
   - /reference/cp-k8s-api/azuremachinepools.exp.infrastructure.cluster.x-k8s.io/
 technical_name: azuremachinepools.exp.infrastructure.cluster.x-k8s.io

--- a/src/content/ui-api/management-api/crd/azuremachines.infrastructure.cluster.x-k8s.io.md
+++ b/src/content/ui-api/management-api/crd/azuremachines.infrastructure.cluster.x-k8s.io.md
@@ -22,7 +22,7 @@ crd:
     - azure
 layout: crd
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-celestial
+  - https://github.com/orgs/giantswarm/teams/team-phoenix
 aliases:
   - /reference/cp-k8s-api/azuremachines.infrastructure.cluster.x-k8s.io/
 technical_name: azuremachines.infrastructure.cluster.x-k8s.io

--- a/src/content/ui-api/management-api/crd/clusters.cluster.x-k8s.io.md
+++ b/src/content/ui-api/management-api/crd/clusters.cluster.x-k8s.io.md
@@ -23,8 +23,7 @@ crd:
     - azure
 layout: crd
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-celestial
-  - https://github.com/orgs/giantswarm/teams/team-firecracker
+  - https://github.com/orgs/giantswarm/teams/team-phoenix
 aliases:
   - /reference/cp-k8s-api/clusters.cluster.x-k8s.io/
 technical_name: clusters.cluster.x-k8s.io

--- a/src/content/ui-api/management-api/crd/g8scontrolplanes.infrastructure.giantswarm.io.md
+++ b/src/content/ui-api/management-api/crd/g8scontrolplanes.infrastructure.giantswarm.io.md
@@ -24,7 +24,7 @@ crd:
     info: This CRD will be removed once Cluster API resources are used for all AWS workload clusters.
 layout: crd
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-firecracker
+  - https://github.com/orgs/giantswarm/teams/team-phoenix
 aliases:
   - /reference/cp-k8s-api/g8scontrolplanes.infrastructure.giantswarm.io/
 technical_name: g8scontrolplanes.infrastructure.giantswarm.io

--- a/src/content/ui-api/management-api/crd/machinedeployments.cluster.x-k8s.io.md
+++ b/src/content/ui-api/management-api/crd/machinedeployments.cluster.x-k8s.io.md
@@ -22,7 +22,7 @@ crd:
     - aws
 layout: crd
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-firecracker
+  - https://github.com/orgs/giantswarm/teams/team-phoenix
 aliases:
   - /reference/cp-k8s-api/machinedeployments.cluster.x-k8s.io/
 technical_name: machinedeployments.cluster.x-k8s.io

--- a/src/content/ui-api/management-api/crd/machinepools.exp.cluster.x-k8s.io.md
+++ b/src/content/ui-api/management-api/crd/machinepools.exp.cluster.x-k8s.io.md
@@ -21,7 +21,7 @@ crd:
     - azure
 layout: crd
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-celestial
+  - https://github.com/orgs/giantswarm/teams/team-phoenix
 aliases:
   - /reference/cp-k8s-api/machinepools.exp.cluster.x-k8s.io/
 technical_name: machinepools.exp.cluster.x-k8s.io

--- a/src/content/ui-api/management-api/crd/networkpools.infrastructure.giantswarm.io.md
+++ b/src/content/ui-api/management-api/crd/networkpools.infrastructure.giantswarm.io.md
@@ -22,7 +22,7 @@ crd:
     - aws
 layout: crd
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-firecracker
+  - https://github.com/orgs/giantswarm/teams/team-phoenix
 aliases:
   - /reference/cp-k8s-api/networkpools.infrastructure.giantswarm.io/
 technical_name: networkpools.infrastructure.giantswarm.io

--- a/src/content/ui-api/management-api/crd/sparks.core.giantswarm.io.md
+++ b/src/content/ui-api/management-api/crd/sparks.core.giantswarm.io.md
@@ -21,7 +21,7 @@ crd:
     - azure
 layout: crd
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-celestial
+  - https://github.com/orgs/giantswarm/teams/team-phoenix
 aliases:
   - /reference/cp-k8s-api/sparks.core.giantswarm.io/
 technical_name: sparks.core.giantswarm.io

--- a/src/content/ui-api/management-api/creating-workload-clusters/aws/index.md
+++ b/src/content/ui-api/management-api/creating-workload-clusters/aws/index.md
@@ -12,7 +12,7 @@ aliases:
 user_questions:
   - How can I create an AWS cluster via the Management API?
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-firecracker
+  - https://github.com/orgs/giantswarm/teams/team-phoenix
 last_review_date: 2021-01-01
 ---
 

--- a/src/content/ui-api/management-api/creating-workload-clusters/azure/index.md
+++ b/src/content/ui-api/management-api/creating-workload-clusters/azure/index.md
@@ -12,7 +12,7 @@ aliases:
 user_questions:
   - How can I create an Azure cluster via the Management API?
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-celestial
+  - https://github.com/orgs/giantswarm/teams/team-phoenix
 last_review_date: 2021-01-01
 ---
 


### PR DESCRIPTION
Towards [issue](https://github.com/giantswarm/giantswarm/issues/26587).

Change firecracker and celestial documentation ownership to phoenix.