### PR TITLE
Update sysctl examples

### DIFF
--- a/src/content/advanced/security-policy-enforcement/index.md
+++ b/src/content/advanced/security-policy-enforcement/index.md
@@ -657,6 +657,7 @@ spec:
     securityContext:
       sysctls:
         - name: net.ipv4.ip_local_port_range
+          value: "32768 60999"
 ```
 
 This Pod does NOT satisfy the policy, because it attempts to add a non-approved sysctl:
@@ -673,6 +674,7 @@ spec:
     securityContext:
       sysctls:
         - name: kernel.stack_erasing
+          value: "0"
 ```
 
 {{% /details %}}


### PR DESCRIPTION
Just updating the example Pods for the sysctl policy. Those fields require values as well as names, so the example was incorrect.
