### PR TITLE
Update PSP/RBAC doc for PSS

### DIFF
--- a/src/content/getting-started/rbac-and-psp/index.md
+++ b/src/content/getting-started/rbac-and-psp/index.md
@@ -1,6 +1,6 @@
 ---
-title: Securing your cluster with RBAC and PSP
-description: Introduction to using role-based access control (RBAC) and pod security policies (PSP) to secure your cluster and manage access control.
+title: Securing your cluster with RBAC and PSS
+description: Introduction to using role-based access control (RBAC) and pod security standards (PSS) to secure your cluster and manage access control.
 weight: 110
 menu:
   main:
@@ -17,10 +17,10 @@ aliases:
   - /guides/securing-with-rbac-and-psp/
 owner:
   - https://github.com/orgs/giantswarm/teams/sig-security
-last_review_date: 2021-01-01
+last_review_date: 2023-06-30
 ---
 
-Two of the most central mechanisms to secure your cluster in Kubernetes are Role Based Access Control (RBAC) and Pod Security Policies (PSP). Together, they allow you to create fine-grained roles and policies to manage access control for users and software running on your cluster. Both are enabled by default on Giant Swarm clusters.
+Two of the most central mechanisms to secure your cluster in Kubernetes are Role Based Access Control (RBAC) and Pod Security Standards (PSS). Together, they allow you to create fine-grained roles and policies to manage access control for users and software running on your cluster. Both are enabled by default on Giant Swarm clusters.
 
 ## Role based access control
 
@@ -271,23 +271,40 @@ $ kubectl auth can-i get pods --as-group=system:masters
 yes
 ```
 
-## Pod Security Policies
+## Pod Security Standards (PSS)
 
-A `PodSecurityPolicy` object defines a set of conditions that a pod must run with in order to be accepted into the system. It governs the ability to make requests on a Pod that affect the `SecurityContext` that will be applied to a Pod and container.
+**Note:** Prior to Kubernetes v1.25, pod-level security configuration was controlled by Pod Security Policies (PSP). PSPs were a Kubernetes API resource which allowed cluster administrators to restrict the values a pod could use for certain security-relevant configuration. Due to limitations of the specification, the PSP type was deprecated in v1.21 and removed in v1.25.
 
-By default, Giant Swarm clusters come with two PSPs defined - a `privileged` policy that allows almost any Security Context and a `restricted` policy that mainly restricts users from running privileged containers, running containers as root, or mounting host paths as volumes.
+The Kubernetes maintainers publish a set of policies called Pod Security Standards, which describe acceptable pod configurations for different levels of risk. The policies apply to several pod and container specification-level fields which have security implications for the workload, and are grouped into three increasingly restrictive levels.
 
-Additionally, there are two respective cluster roles defined - `privileged-psp-user` and `restricted-psp-user`.
+For example, the `baseline` policy level limits the capabilities a pod can use to a limited subset (~14 possibilities). The `restricted` level takes this policy further and requires each pod to explicitly drop all capabilities in its Pod spec, and allows adding back only a single capability (`NET_BIND_SERVICE`). The least restrictive level, `privileged`, is a no-op policy which does not perform any validation or impose any rules. Refer to the [official Pod Security Standards docs][upstream-pss] for more information.
 
-By default all authenticated users have the `restricted-psp-user` role assigned.
+The Pod Security Standards provide only a set of suggested policies intended to be enforced by other implementations of actual controls which validate pods against the PSS rules.
 
-If you need to run privileged or root containers in a Pod, you need to either use a cluster admin user or bind the `privileged-psp-user` role to your desired user or group.
+```mermaid
+flowchart TD
+    A["Pod Security Standards (PSS)"] -->|Enforced by| B("Kyverno <br/> (outside API Server)")
+    A --> |Enforced by| C("Pod Security Admission (PSA) <br/> (inside API Server)")
 
-Note that your user's PSP only comes into play when you directly create Pods. If you are using Deployments, Daemonsets, or other means to spawn Pods in your cluster, you need to make sure these have the right PSP by using [Service Accounts](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/).
+```
 
-You need to either bind the already existing `privileged-psp-user` role, or create a PSP that caters specifically to your desired Security Context. Keep in mind that after creating a PSP you also need to have a role that is allowed to `use` that specific PSP and bind that to the Service Account you're using. For an example see [Running Applications that need Privileged Access](#running-applications-that-need-privileged-access).
+### Pod Security Admission (PSA)
 
-For details on PSPs we defer to the [official PSP documentation](https://kubernetes.io/docs/concepts/policy/pod-security-policy/).
+The Kubernetes API includes a built-in admission controller called Pod Security Admission, which a specific implementation of a technical control for the Pod Security Standards. It is an admission controller which is built into the API server, and can be configured using labels on cluster namespaces.
+
+Due to perceived limitations in the initial implementation of PSA and to keep feature parity with PSPs for our customers, Giant Swarm uses an external admission controller to enforce these policies instead of PSA.
+
+To learn more about builtin PSA, please refer to the [upstream Kubernetes Pod Security Admission documentation][upstream-psa]. We've also written [a blog post outlining our decision not to use PSA][farewell-psp-blog].
+
+### Pod Security Standards with Kyverno
+
+Instead of the Pod Security Admission controller, Giant Swarm clusters use Kyverno along with a set of Kyverno ClusterPolicies which map to the Kubernetes Pod Security Standards.
+
+By default, Giant Swarm clusters enforce the `restricted` level Pod Security Standards. This level aligns with our other "secure by default" principles, and is intended to ensure our clusters are hardened according to community best practices.
+
+Cluster administrators have complete flexibility and control over their policy enforcement, and may choose to ease their security requirements or enforce additional policies to suit their risk tolerance and business needs.
+
+[A detailed guide to working with Kyverno PSS Policies and PolicyExceptions][policy-enforcement-guide] is available as a standalone resource.
 
 ## User management with Giant Swarm
 
@@ -484,6 +501,7 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 ```
 
+
 ### Running applications that need privileged access
 
 Applications running inside your cluster that need to run in a privileged Security Context, e.g. as privileged containers, mounting host paths or exposing host ports, need the right permissions in the form of Pod Security Policies bound to them. For this the Pods again need to use a Service Account.
@@ -563,7 +581,7 @@ spec:
 
 Note, how the above PSP allows the use volumes of type `configMap` and `hostPath`, but restricts the latter to only two specific paths (and their sub-paths). Furthermore, the PSP allows the use of a single host port, namely `9001`.
 
-We strongly recommend to create such specifc rules, so that no further privilege escalation can occur.
+We strongly recommend to create such specific rules, so that no further privilege escalation can occur.
 
 #### 4. Create a Role for your app {#app-privileged-create-role}
 
@@ -636,7 +654,14 @@ Note that bindings that come with the cluster by default like `system:masters` c
 ## Further reading
 
 - [Using RBAC Authorization](https://kubernetes.io/docs/reference/access-authn-authz/)
-- [Pod Security Policies](https://kubernetes.io/docs/concepts/policy/pod-security-policy/)
+- [Pod Security Admission][upstream-psa]
+- [Pod Security Standards][upstream-pss]
+- [Giant Swarm's farewell to PSP blog][farewell-psp-blog]
 - [Configuring Service Accounts](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/)
 - [Creating a kubeconfig with gsctl]({{< relref "/use-the-api/gsctl/create-kubeconfig" >}})
 - [Creating a key pair with gsctl]({{< relref "/use-the-api/gsctl/create-keypair" >}})
+
+[farewell-psp-blog]: https://www.giantswarm.io/blog/giant-swarms-farewell-to-psp
+[upstream-psa]: https://kubernetes.io/docs/concepts/security/pod-security-admission/
+[upstream-pss]: https://kubernetes.io/docs/concepts/security/pod-security-standards/
+[policy-enforcement-guide]: {{< relref "/advanced/security-policy-enforcement" >}}

--- a/src/content/getting-started/rbac-and-psp/index.md
+++ b/src/content/getting-started/rbac-and-psp/index.md
@@ -273,7 +273,7 @@ yes
 
 ## Pod Security Standards (PSS)
 
-**Note:** Prior to Kubernetes v1.25, pod-level security configuration was controlled by Pod Security Policies (PSP). PSPs were a Kubernetes API resource which allowed cluster administrators to restrict the values a pod could use for certain security-relevant configuration. Due to limitations of the specification, the PSP type was deprecated in v1.21 and removed in v1.25.
+__Note__: Prior to Kubernetes v1.25, pod-level security configuration was controlled by Pod Security Policies (PSP). PSPs were a Kubernetes API resource which allowed cluster administrators to restrict the values a pod could use for certain security-relevant configuration. Due to limitations of the specification, the PSP type was deprecated in v1.21 and removed in v1.25.
 
 The Kubernetes maintainers publish a set of policies called Pod Security Standards, which describe acceptable pod configurations for different levels of risk. The policies apply to several pod and container specification-level fields which have security implications for the workload, and are grouped into three increasingly restrictive levels.
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/26092

### What does this PR do?

This removes the PSP section from the RBAC and PSP page and references our separate page on working with policies.

I have not revised the sections on user management, which could still use a refresh from the appropriate team.

### What does it look like?

Mostly textual changes.
Mermaid diagram:
![image](https://github.com/giantswarm/docs/assets/10408416/e15453ae-bb42-417e-b82b-06cc39d2f681)


### Any background context you can provide?

PSP has been removed from the Kubernetes API, and Giant Swarm chose to use Kyverno instead of the in-tree Pod Security Admission controller as a replacement. This doc needs to change to reflect the updated security controls.

### What is needed from the reviewers?

Opinions: should we change the link for this page? It still references PSP, but this page is mostly about RBAC anyway and is likely linked to in several places.

### Have you maintained the front matter?

Yes!
