### PR TITLE
Highlight selected item in menu

### DIFF
--- a/src/assets/styles/_menu.sass
+++ b/src/assets/styles/_menu.sass
@@ -83,7 +83,8 @@ $indent: 14px
       color: #1c91d5
       text-decoration: none
     &.current
-      color: #000
+      color: #136391
+      font-weight: 400
 
 .acnav__list--level1
   padding-bottom: 30px


### PR DESCRIPTION
### What does this PR do?

This fixes a main annoyance with the menu – the currently selected article _does_ have a somewhat different color, but it's barely distinguishable and hence the reader may not see which page is active.

### What does it look like?

Switch to a more link-like color and making it slightly bold (not fully bold because the main articles such as "Platform overview" are already bold):

<img width="1283" alt="Screenshot" src="https://github.com/giantswarm/docs/assets/1376043/12482a91-161e-46f0-bac3-72704acc61bd">

### Have you maintained the front matter?

No