### PR TITLE
Move implementation titles into site parameters so they can be consistently used as tab titles

### DIFF
--- a/src/config.yaml
+++ b/src/config.yaml
@@ -53,3 +53,19 @@ taxonomies:
 
 permalinks:
   changes_categories: /changes/:slug
+
+# Populate the `.Site.Params` variable for use in templates and shortcodes
+params:
+  impl_titles:
+    capi_any: "CAPI (any)"
+    vintage_any: "Vintage (any)"
+
+    capa_ec2: "CAPA (AWS EC2)"
+    capa_eks: "CAPA (AWS EKS)"
+    capg_vms: "CAPG (GCP VMs)"
+    capv: "CAPV (VMware vSphere)"
+    capvcd: "CAPVCD (VMware Cloud Director)"
+    capz_vms: "CAPZ (Azure VMs)"
+    vintage_aws: "Vintage (AWS)"
+    vintage_azure: "Vintage (Azure)"
+    vintage_kvm: "Vintage (KVM)"

--- a/src/content/advanced/private-clusters/index.md
+++ b/src/content/advanced/private-clusters/index.md
@@ -18,8 +18,8 @@ By default, Giant Swarm clusters expose the Kubernetes API endpoint publicly and
 
 The following products offer private cluster features:
 
-- CAPA (AWS EC2)
-- CAPZ (Azure VMs)
+- {{% impl_title "capa_ec2" %}}
+- {{% impl_title "capz_vms" %}}
 
 Private clusters have special requirements:
 
@@ -40,7 +40,7 @@ At the moment, we have these [`kubectl gs template cluster` command line options
 We have a few provider-specific hints:
 
 {{< tabs >}}
-{{< tab id="private-cluster-capz-azure-vms" title="CAPZ (Azure VMs)">}}
+{{< tab id="private-cluster-capz-azure-vms" for-impl="capz_vms">}}
 
 As getting the correct CIDR depend on the installation, please get in contact with your platform team to check for the next CIDR range to use. This step might become obsolete once a dedicated IPAM operator got implemented for private Azure clusters.
 

--- a/src/content/getting-started/create-workload-cluster/index.md
+++ b/src/content/getting-started/create-workload-cluster/index.md
@@ -52,7 +52,7 @@ You will now create resources with `kubectl gs`. In particular, this tutorial us
 First, template a cluster ([command reference]({{< relref "/use-the-api/kubectl-gs/template-cluster" >}})):
 
 {{< tabs >}}
-{{< tab id="cluster-vintage-azure" title="Vintage (Azure)">}}
+{{< tab id="cluster-vintage-azure" for-impl="vintage_azure" >}}
 
 [Choose a release version here](https://docs.giantswarm.io/changes/workload-cluster-releases-for-azure), or use `kubectl gs get releases`, and fill it into this example command:
 
@@ -66,7 +66,7 @@ kubectl gs template cluster \
 ```
 
 {{< /tab >}}
-{{< tab id="cluster-vintage-aws" title="Vintage (AWS)">}}
+{{< tab id="cluster-vintage-aws" for-impl="vintage_aws">}}
 
 [Choose a release version here](https://docs.giantswarm.io/changes/workload-cluster-releases-for-aws), or use `kubectl gs get releases`, and fill it into this example command:
 
@@ -80,7 +80,7 @@ kubectl gs template cluster \
 ```
 
 {{< /tab >}}
-{{< tab id="cluster-capa-ec2" title="CAPA (AWS EC2)">}}
+{{< tab id="cluster-capa-ec2" for-impl="capa_ec2">}}
 
 This will automatically use the latest release of the relevant Helm charts [cluster-aws](https://github.com/giantswarm/cluster-aws/blob/master/CHANGELOG.md) and [default-apps-aws](https://github.com/giantswarm/default-apps-aws/blob/master/CHANGELOG.md) (bundle of default apps):
 
@@ -93,7 +93,7 @@ kubectl gs template cluster \
 ```
 
 {{< /tab >}}
-{{< tab id="cluster-capz-azure-vms" title="CAPZ (Azure VMs)">}}
+{{< tab id="cluster-capz-azure-vms" for-impl="capz_vms">}}
 
 This will automatically use the latest release of the relevant Helm charts [cluster-azure](https://github.com/giantswarm/cluster-azure/blob/master/CHANGELOG.md) and [default-apps-azure](https://github.com/giantswarm/default-apps-azure/blob/master/CHANGELOG.md) (bundle of default apps):
 
@@ -119,7 +119,7 @@ For the [Cluster API (CAPI)]({{< relref "/platform-overview/cluster-management/c
 In the vintage product family, no worker node pool is created by default, so you should attach one:
 
 {{< tabs >}}
-{{< tab id="nodepool-vintage-azure" title="Vintage (Azure)">}}
+{{< tab id="nodepool-vintage-azure" for-impl="vintage_azure">}}
 
 ```sh
 kubectl gs template nodepool \
@@ -134,7 +134,7 @@ kubectl gs template nodepool \
 This will create a `nodepool.yaml` file with all the CRs needed for attaching a node pool to the cluster created in the previous step.
 
 {{< /tab >}}
-{{< tab id="nodepool-capi" title="CAPI (any)">}}
+{{< tab id="nodepool-capi" for-impl="capi_any">}}
 
 This is not needed for CAPI. The `nodePools` value in the cluster app has a default. For example, see [nodePools configuration for cluster-aws](https://github.com/giantswarm/cluster-aws/blob/master/helm/cluster-aws/README.md#node-pools) when using the CAPA-based product (AWS cloud).
 
@@ -169,7 +169,7 @@ For the vintage product family, if you did not yet attach a node pool to the WC 
 Using the command line, you can also watch the creation and status of the workload cluster:
 
 {{< tabs >}}
-{{< tab id="status-vintage" title="Vintage (any)">}}
+{{< tab id="status-vintage" for-impl="vintage_any">}}
 
 ```sh
 kubectl gs get clusters -A
@@ -178,7 +178,7 @@ kubectl gs get nodepools -A
 ```
 
 {{< /tab >}}
-{{< tab id="status-capi" title="CAPI (any)">}}
+{{< tab id="status-capi" for-impl="capi_any">}}
 
 Either use kubectl-gs:
 

--- a/src/content/platform-overview/cluster-management/cloud-provider-implementations/_index.md
+++ b/src/content/platform-overview/cluster-management/cloud-provider-implementations/_index.md
@@ -36,12 +36,12 @@ For certain cloud providers, there are even different options available: for exa
 
 The open-source cloud infrastructure providers of CAPI are separate projects – named CAPA for the AWS cloud, CAPZ for Azure, etc. Since they provide a major part of the cluster management, we name our implementations after them. We offer the following cloud provider-specific implementations:
 
-- **{{% cluster_mgmt_impl_capa_ec2 %}}**
-- **{{% cluster_mgmt_impl_capa_eks %}}**
-- **{{% cluster_mgmt_impl_capg_gcp_vms %}}**
-- **{{% cluster_mgmt_impl_capv %}}**
-- **{{% cluster_mgmt_impl_capvcd %}}**
-- **{{% cluster_mgmt_impl_capz_vms %}}**
+- **{{% impl_title "capa_ec2" %}}**
+- **{{% impl_title "capa_eks" %}}**
+- **{{% impl_title "capg_vms" %}}**
+- **{{% impl_title "capv" %}}**
+- **{{% impl_title "capvcd" %}}**
+- **{{% impl_title "capz_vms" %}}**
 
 ## Vintage generation
 
@@ -49,9 +49,9 @@ This is the previous generation and is still in production with many of our cust
 
 We offer the following cloud provider-specific implementations:
 
-- **{{% cluster_mgmt_impl_vintage_aws %}}**
-- **{{% cluster_mgmt_impl_vintage_azure %}}**
-- **{{% cluster_mgmt_impl_vintage_kvm %}}** – _deprecated and being phased out_
+- **{{% impl_title "vintage_aws" %}}**
+- **{{% impl_title "vintage_azure" %}}**
+- **{{% impl_title "vintage_kvm" %}}** – _deprecated and being phased out_
 
 ## Choice of cloud provider and implementation
 

--- a/src/layouts/shortcodes/cluster_mgmt_impl_capa_ec2.html
+++ b/src/layouts/shortcodes/cluster_mgmt_impl_capa_ec2.html
@@ -1,1 +1,0 @@
-CAPA (AWS EC2)

--- a/src/layouts/shortcodes/cluster_mgmt_impl_capa_eks.html
+++ b/src/layouts/shortcodes/cluster_mgmt_impl_capa_eks.html
@@ -1,1 +1,0 @@
-CAPA (AWS EKS)

--- a/src/layouts/shortcodes/cluster_mgmt_impl_capg_gcp_vms.html
+++ b/src/layouts/shortcodes/cluster_mgmt_impl_capg_gcp_vms.html
@@ -1,1 +1,0 @@
-CAPG (GCP VMs)

--- a/src/layouts/shortcodes/cluster_mgmt_impl_capv.html
+++ b/src/layouts/shortcodes/cluster_mgmt_impl_capv.html
@@ -1,1 +1,0 @@
-CAPV (VMware vSphere)

--- a/src/layouts/shortcodes/cluster_mgmt_impl_capvcd.html
+++ b/src/layouts/shortcodes/cluster_mgmt_impl_capvcd.html
@@ -1,1 +1,0 @@
-CAPVCD (VMware Cloud Director)

--- a/src/layouts/shortcodes/cluster_mgmt_impl_capz_vms.html
+++ b/src/layouts/shortcodes/cluster_mgmt_impl_capz_vms.html
@@ -1,1 +1,0 @@
-CAPZ (Azure VMs)

--- a/src/layouts/shortcodes/cluster_mgmt_impl_vintage_aws.html
+++ b/src/layouts/shortcodes/cluster_mgmt_impl_vintage_aws.html
@@ -1,1 +1,0 @@
-Vintage (AWS)

--- a/src/layouts/shortcodes/cluster_mgmt_impl_vintage_azure.html
+++ b/src/layouts/shortcodes/cluster_mgmt_impl_vintage_azure.html
@@ -1,1 +1,0 @@
-Vintage (Azure)

--- a/src/layouts/shortcodes/cluster_mgmt_impl_vintage_kvm.html
+++ b/src/layouts/shortcodes/cluster_mgmt_impl_vintage_kvm.html
@@ -1,1 +1,0 @@
-Vintage (KVM)

--- a/src/layouts/shortcodes/impl_title.html
+++ b/src/layouts/shortcodes/impl_title.html
@@ -1,0 +1,5 @@
+{{- $title := (index (index $.Site.Params "impl_titles") (.Get 0)) -}}
+{{- if not $title -}}
+{{- errorf "Please use a valid argument for `impl_title` shortcodes in %q (argument value %q must be listed in `src/config.yaml`)" .Page.File.Path (.Get 0) -}}
+{{- end -}}
+{{- $title -}}

--- a/src/layouts/shortcodes/tab.html
+++ b/src/layouts/shortcodes/tab.html
@@ -1,13 +1,21 @@
 {{/* The tab counter is needed to activate the first tab by default. */}}
 {{- .Parent.Scratch.Add "tabcount" 1 }}
 
+{{/*
+    For cluster management implementation names, you can use `for-impl` instead of `title`.
+    This lookup is needed because Hugo does not support using a shortcode for the value of `title="..."`.
+*/}}
+{{ $title := default (.Get "title") (index (index $.Site.Params "impl_titles") (.Get "for-impl")) }}
+{{ if not $title }}
+{{ errorf "Please use a valid `title` or `for-impl` value for tabs in %q (`for-impl` value %q must be listed in `src/config.yaml`)" .Page.File.Path (.Get "for-impl") }}
+{{ end }}
 {{/* Making tab titles and IDs available to the parent, to create the header. */}}
 {{ $titles := .Parent.Scratch.Get "titles" }}
 {{- if $titles }}
-{{ $titles = $titles | append (.Get "title") }}
+{{ $titles = $titles | append $title }}
 {{ .Parent.Scratch.Set "titles" $titles }}
 {{- else }}
-{{ $titles := slice (.Get "title") }}
+{{ $titles := slice $title }}
 {{ .Parent.Scratch.Set "titles" $titles }}
 {{- end }}
 
@@ -20,7 +28,7 @@
 {{ .Parent.Scratch.Set "ids" $ids }}
 {{- end }}
 
-<div role="tabpanel" class="tab-pane{{ if eq (.Parent.Scratch.Get `tabcount`) 1 }} active{{ end }}" id="{{ if .Get `id` }}{{ .Get `id` | urlize }}{{ else }}{{ .Get `title` | urlize }}{{ end }}">
+<div role="tabpanel" class="tab-pane{{ if eq (.Parent.Scratch.Get `tabcount`) 1 }} active{{ end }}" id="{{ if .Get `id` }}{{ .Get `id` | urlize }}{{ else }}{{ $title | urlize }}{{ end }}">
 
 {{ .Inner | markdownify }}
 


### PR DESCRIPTION
### What does this PR do?

I wanted to have consistent tab titles. Since you cannot nest shortcodes like this

```
{{< tab id="cluster-vintage-azure" title="{% cluster_mgmt_impl_vintage_azure %}">}}
```

there is now a translation layer using site parameters. So we can change the titles in exactly one spot.

### What does it look like?

No changes to rendered text

### Any background context you can provide?

https://github.com/giantswarm/roadmap/issues/2393

### Have you maintained the front matter?

No