### PR TITLE
Fix Markdown linting and annotate in PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,16 +9,12 @@ jobs:
     executor: "architect/architect"
     environment:
       DOCKER_BUILDKIT: "1"
-    
+
     steps:
       - checkout
 
       - setup_remote_docker:
           version: 20.10.11
-
-      - run:
-          name: Check Markdown structure
-          command: make lint
 
       - architect/push-to-docker:
           image: "quay.io/giantswarm/docs"

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -7,7 +7,7 @@ on:
       - 'src/**.md'
 
 jobs:
-  front-matter:
+  validate:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -22,12 +22,37 @@ jobs:
           git diff --name-only "refs/heads/${GITHUB_BASE_REF}" -- . | tee files.txt
           cat files.txt | python3 scripts/validate-front-matter/script.py
 
-      - name: Verify annotations
+      - name: Print front matter annotations
         run: cat ./annotations.json
 
-      - name: Send annotations
+      - name: Send front matter annotations
         uses: giantswarm/annotations-action@8028d6604d2db401d4dcd30c21a99fa26e662544
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           title: Front matter problems
           input: ./annotations.json
+
+      - name: markdownlint
+        run: |
+          make RUNNING_IN_CI=true lint || true
+
+          # Only fail if the run didn't work for technical reasons
+          if [ ! -e markdownlint.out ]; then
+            echo "ERROR: Linting did not write output file with findings"
+            exit 1
+          fi
+
+          # Otherwise create annotations
+          cat markdownlint.out \
+            | jq -R '[inputs | (. | capture("(?<filename>[^:]+):(?<line>[0-9]+)(:(?<col>[0-9]+))?\\s+(?<description>.+)") | {"file": .filename, "line": (.line | tonumber), "end_line": (.line | tonumber), "title": "markdownlint problem", "message": .description, "annotation_level": "error"})]' \
+            > markdownlint-annotations.json
+
+      - name: Print markdownlint annotations
+        run: cat ./markdownlint-annotations.json
+
+      - name: Send markdownlint annotations
+        uses: giantswarm/annotations-action@8028d6604d2db401d4dcd30c21a99fa26e662544
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          title: markdownlint problems
+          input: ./markdownlint-annotations.json

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -54,3 +54,11 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           title: markdownlint problems
           input: ./markdownlint-annotations.json
+
+      - name: Fail if markdownlint had findings
+        run: |
+          # If there are non-empty lines, we had linting findings
+          if [ "$(awk 1 < markdownlint.out | wc -l | awk '{print $1}')" != 0 ]; then
+            echo "ERROR: See markdownlint findings (annotated as errors in the PR when you click on 'Files changed')"
+            exit 1
+          fi

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -3,8 +3,6 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - 'src/**.md'
 
 jobs:
   validate:

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,10 @@
 *.pyc
 /.idea
 /.vscode
+/annotations.json
 /build/
+/markdownlint-annotations.json
+/markdownlint.out
 /vendor/
 /volumes
 /src/resources

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -16,6 +16,13 @@ MD004:
 MD007:
   indent: 4
 
+# MD009/no-trailing-spaces
+#
+# We explicitly don't want trailing spaces. Authors' editors should be configured to trim them. The Markdown feature of
+# using two spaces at the end of a line should not be used (use the alternative `<br>` only if really necessary, or
+# better use normal paragraphs).
+MD009: true
+
 # Ignore front matter in headline linting
 MD025:
   front_matter_title: ""
@@ -35,3 +42,16 @@ MD034: false
 
 # Don't lint for line length
 MD013: false
+
+# MD051/link-fragments
+#
+# We use GitHub's format (`## My heading {#explicit-reference-name}`) in some cases but markdownlint only supports
+# the regular CommonMark specification for the aliases (see https://github.com/DavidAnson/markdownlint/blob/main/doc/md051.md).
+# The lint is therefore not helpful.
+MD051: false
+
+# MD052/reference-links-images
+#
+# We use the Hugo functionality such as `[1]: {{< relref "..." >}}` which markdownlint recognizes as undefined reference,
+# so the lint is not helpful.
+MD052: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,11 @@ This repository is public to facilitate content quality and encourage contributi
 
 The best way to contribute changes are pull requests. Please note the following regarding pull requests:
 
+- Configure your editor to match linting rules
+
+    - Use markdownlint
+    - Trim trailing whitespace on save
+
 - Please make one pull request per topic/issue. Avoid putting several non-related issues in a single pull request!
 
 - When creating a pull request, please remember you accept that your contribution will be published under the Creative Commons license mentioned in `README.md`. Giant Swarm will be able to use your content without restriction. Giant Swarm is not obliged to list you as the author of your contribution, but will attempt to do so where possible.
-

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,9 @@ PROJECT=docs
 COMPANY=giantswarm
 REGISTRY=quay.io
 SHELL=bash
-MARKDOWNLINT_IMAGE=06kellyjac/markdownlint-cli:0.23.0-alpine
+MARKDOWNLINT_IMAGE=ghcr.io/igorshubovych/markdownlint-cli:v0.35.0@sha256:22cf4699a448a7bbc311a940e0600019423d7671cbedae9c35cd32b51f560350
 APPLICATION=docs-app
+RUNNING_IN_CI ?= false
 
 include Makefile.*.mk
 
@@ -56,11 +57,12 @@ lint:
 	  -v ${PWD}:/workdir \
 	  -w /workdir \
 	  $(MARKDOWNLINT_IMAGE) \
-	    --config .markdownlint.yaml \
-	    --ignore README.md \
-		--ignore ./src/content/changes \
-		--ignore ./src/content/use-the-api/management-api/crd \
-		./src
+	  --config .markdownlint.yaml \
+	  --ignore README.md \
+	  --ignore ./src/content/changes \
+	  --ignore ./src/content/use-the-api/management-api/crd \
+	  $$(if [ "$(RUNNING_IN_CI)" = "true" ]; then echo "--output markdownlint.out"; fi) \
+	  ./src
 
 # Validate front matter in all pages.
 validate-front-matter:


### PR DESCRIPTION
### What does this PR do?

The CircleCI job didn't do anything. And since it's nicer to see lints annotated into the PR diff, I moved linting to a GitHub action. The `make lint` command should now be fully usable by developers and CI.

### What does it look like?

This PR should show lots of errors. _Note_ that I have all the lint fixes ready, but that would go into a huge, separate PR mostly about `_` vs. `*`, `-` vs. `*`, many whitespace changes, and some heading fixes. So for _this one time_, we should ignore the pipeline failure of _this PR_, merge it, and I'll open a new PR to fix all linting findings.

Why errors and not warnings? Well, we piled up lots of lint errors and that shouldn't happen in the future. PRs pipelines should show a clear failure. That way, we get consistent articles, and people will configure markdownlint in their editor (e.g. [VS Code extension](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint) + trim trailing whitespace on save) to see and prevent issues already at time of writing.

### Any background context you can provide?

I didn't like that Markdown files had trailing whitespace 🧠🤯 and kept going 🤣.