### PR TITLE
Set pointer cursor for summaries since otherwise it defaults to text selection, making users think the box is not expandable

### DIFF
--- a/src/assets/styles/base.sass
+++ b/src/assets/styles/base.sass
@@ -573,6 +573,9 @@ details
   padding: 10px 0
   border-bottom: 1px solid #ccc
 
+details.summary > summary > a
+  cursor: pointer
+
 .details-content
   margin-top: 22px
 


### PR DESCRIPTION
### What does this PR do?

(Please set a descriptive PR title. Use this space for additional explanations.)

### What does it look like?

The `details` shortcode is only used on the "Security policy enforcement" article right now, and turns into this instead of the text selection cursor:

<img width="1117" alt="Screenshot 2023-08-29 at 11 38 25" src="https://github.com/giantswarm/docs/assets/1376043/473c5b09-c27e-448b-af97-f9150ad06fbd">