### PR TITLE
Remove dex-k8s-authenticator

### DIFF
--- a/src/content/platform-overview/architecture/index.md
+++ b/src/content/platform-overview/architecture/index.md
@@ -152,5 +152,3 @@ To support customers in their use of Flux and the CI/CD features available to th
 - [Giant Swarm Management API]({{< relref "/platform-overview/management-api" >}})
 - [Giant Swarm support model]({{< relref "/support" >}})
 - [Giant Swarm operational layers]({{< relref "/platform-overview/security/operational-layers" >}})
-
-

--- a/src/content/platform-overview/security/operational-layers/index.md
+++ b/src/content/platform-overview/security/operational-layers/index.md
@@ -62,7 +62,6 @@ A customer has *tenant admin* and *view* access via OpenID Connect (OIDC), confi
 #### Management API access for Customers
 
 The Kubernetes API on every management cluster has [dex](https://github.com/dexidp/dex) installed as an OIDC issuer. Dex is configured with an identity provider chosen by the customer. A list of supported providers can be found in the [dex github repository](https://github.com/dexidp/dex/tree/master/connector).
-[dex-k8s-authenticator](https://github.com/mintel/dex-k8s-authenticator) is also installed, it is a web app that helps in JWT token retrieval and kubectl configuration
 
 ##### Authorization
 

--- a/src/content/use-the-api/management-api/authentication/user/index.md
+++ b/src/content/use-the-api/management-api/authentication/user/index.md
@@ -63,36 +63,6 @@ This context is selected automatically as the current context, so you are ready 
 
 When switching back to this context, it should not be necessary to go through the web-based authentication flow again. `kubectl` will automatically refresh the authentication token when needed, without your interaction.
 
-## Alternative method
-
-You can alternatively initiate the single sign-on authentication directly in a browser, without the need of installing the `kubectl gs` plug-in.
-
-We provide a web-based login helper utility named [Dex K8s Authenticator](https://github.com/mintel/dex-k8s-authenticator), available under a URL specific for each installation. If you know your installation's Management API endpoint URL, you can construct the utility's URL by prepending `login.` to it.
-
-If, for example, your Management API URL is
-
-```nohighlight
-https://g8s.example.domain.tld
-```
-
-then the login utility can be accessed via
-
-```nohighlight
-https://login.g8s.example.domain.tld
-```
-
-The tool will immediately redirect you to your identity provider's authentication flow where you proceed providing your credentials as usual. After that, or if you are already authenticated in the current browser, you will be redirected to a resulting page.
-
-The screenshot shows an example of that result page.
-
-![Login helper screenshot](login-utility-results.png)
-
-Here you can inspect the details that will be passed to the Management API as part of the ID token. You can use this to verify the details coming from your identity provider, especially the `email` (which is used as your user identifier) and `groups` claim.
-
-This page will also present your Management API endpoint's certificate authority (CA) certificate. In order to connect to your Management API endpoint, you should add this CA certificate to your client's trusted (root) certificates.
-
-The rest of the page helps you set up `kubectl` manually, adaptable for various operating systems.
-
 ## Web UI login {#web-ui}
 
 Our Web UI provides a simple single sign-on mechanism that will send each user through your chosen identity provider's authentication process and finally redirect to the web UI. Behind the scenes, the same mechanism is used as in the examples above.

--- a/src/content/use-the-api/management-api/authentication/user/index.md
+++ b/src/content/use-the-api/management-api/authentication/user/index.md
@@ -23,7 +23,7 @@ As a user of the Management API for any given installation, you need:
 - A **user account** in the identity provider used by the installation (single sign-on).
 - The Management API **endpoint URL** of the installation. Alternatively, the web user interface URL.
 
-The recommended method for authentication, as it's the fastest and most convenient one, uses our `kubectl` plug-in and is explained next. Further down we also provide instructions for an [alternative method](#alternative-method) that does not require installing the plugin.
+For command-line access to the cluster using `kubectl`, authentication via our `kubectl` plugin is required. Detailed instructions are provided below. If you prefer a graphical interface, we also outline the Web UI login method.
 
 ## Using `kubectl gs login` {#kubectl-gs-login}
 


### PR DESCRIPTION
### What does this PR do?

This PR removes all references to dex-k8s-authenticator from the docs, as it is deprecated.

### Any background context you can provide?

Towards https://github.com/giantswarm/roadmap/issues/2783

### What is needed from the reviewers?
