### PR TITLE
Document private cluster creation for CAPA

### DIFF
--- a/src/content/advanced/private-clusters/index.md
+++ b/src/content/advanced/private-clusters/index.md
@@ -9,14 +9,14 @@ user_questions:
 - How do I make a workload cluster private?
 owner:
   - https://github.com/orgs/giantswarm/teams/team-phoenix
-last_review_date: 2023-06-13
+last_review_date: 2023-10-12
 ---
 
 By default, Giant Swarm clusters expose the Kubernetes API endpoint publicly and the cluster workloads have internet access. In the following sections, we will explain different options to restrict inbound access to API or outbound connectivity to the internet within the clusters.
 
 **Note**: You can skip this article unless you plan on creating clusters with strictly-limited networking.
 
-The following products offer private cluster features:
+The following implementations offer private cluster features:
 
 - {{% impl_title "capa_ec2" %}}
 - {{% impl_title "capz_vms" %}}
@@ -33,14 +33,35 @@ At the moment, we have these [`kubectl gs template cluster` command line options
 
 - `--cluster-type`
 - `--vpc-mode`
-- `--dns-mode`
 - `--api-mode`
 - `--http-proxy`/`--https-proxy`
 
 We have a few provider-specific hints:
 
 {{< tabs >}}
-{{< tab id="private-cluster-capz-azure-vms" for-impl="capz_vms">}}
+{{< tab id="private-cluster-capa-ec2-proxy" for-impl="capa_ec2" title-suffix=" (private, with proxy)" >}}
+
+A proxy-private CAPA cluster uses a proxy to connect to the internet via HTTP/HTTPS. The cluster runs in a private VPC. The VPC CIDR (range of IPs) should be chosen such that it does not overlap with other VPCs that need to communicate with it. Please follow [Create a workload cluster]({{< relref "/getting-started/create-workload-cluster" >}}), adding certain parameters when running the cluster templating command:
+
+```sh
+kubectl gs template cluster \
+  --provider capa \
+  --name mycluster \
+  --organization testing \
+  \
+  `# The following parameters are specific to creating a proxy-private cluster` \
+  --cluster-type proxy-private \
+  --vpc-mode private \
+  --api-mode private \
+  --vpc-cidr 10.226.0.0/18 `# please fill a desired, free VPC CIDR` \
+  --http-proxy "http://my-http-proxy.example.com:8000" \
+  --https-proxy "http://my-http-proxy.example.com:8000" \
+  \
+  > cluster.yaml
+```
+
+{{< /tab >}}
+{{< tab id="private-cluster-capz-azure-vms" for-impl="capz_vms" title-suffix=" (private)" >}}
 
 As getting the correct CIDR depend on the installation, please get in contact with your platform team to check for the next CIDR range to use. This step might become obsolete once a dedicated IPAM operator got implemented for private Azure clusters.
 

--- a/src/content/getting-started/create-workload-cluster/index.md
+++ b/src/content/getting-started/create-workload-cluster/index.md
@@ -57,9 +57,9 @@ First, template a cluster ([command reference]({{< relref "/use-the-api/kubectl-
 [Choose a release version here](https://docs.giantswarm.io/changes/workload-cluster-releases-for-azure), or use `kubectl gs get releases`, and fill it into this example command:
 
 ```sh
-# See hint about `--name` below!
 kubectl gs template cluster \
   --provider azure \
+  --name mycluster \
   --organization testing \
   --release 19.0.1 `# please fill in your desired release version` \
   > cluster.yaml
@@ -71,9 +71,9 @@ kubectl gs template cluster \
 [Choose a release version here](https://docs.giantswarm.io/changes/workload-cluster-releases-for-aws), or use `kubectl gs get releases`, and fill it into this example command:
 
 ```sh
-# See hint about `--name` below!
 kubectl gs template cluster \
   --provider aws \
+  --name mycluster \
   --organization testing \
   --release 19.0.0 `# please fill in your desired release version` \
   > cluster.yaml
@@ -85,9 +85,9 @@ kubectl gs template cluster \
 This will automatically use the latest release of the relevant Helm charts [cluster-aws](https://github.com/giantswarm/cluster-aws/blob/master/CHANGELOG.md) and [default-apps-aws](https://github.com/giantswarm/default-apps-aws/blob/master/CHANGELOG.md) (bundle of default apps):
 
 ```sh
-# See hint about `--name` below!
 kubectl gs template cluster \
   --provider capa \
+  --name mycluster \
   --organization testing \
   > cluster.yaml
 ```
@@ -98,9 +98,9 @@ kubectl gs template cluster \
 This will automatically use the latest release of the relevant Helm charts [cluster-azure](https://github.com/giantswarm/cluster-azure/blob/master/CHANGELOG.md) and [default-apps-azure](https://github.com/giantswarm/default-apps-azure/blob/master/CHANGELOG.md) (bundle of default apps):
 
 ```sh
-# See hint about `--name` below!
 kubectl gs template cluster \
   --provider capz \
+  --name mycluster \
   --organization testing \
   --region westeurope \
   --azure-subscription-id 00000000-0000-0000-0000-000000000000 `# fill in your subscription ID` \

--- a/src/layouts/shortcodes/tab.html
+++ b/src/layouts/shortcodes/tab.html
@@ -4,8 +4,11 @@
 {{/*
     For cluster management implementation names, you can use `for-impl` instead of `title`.
     This lookup is needed because Hugo does not support using a shortcode for the value of `title="..."`.
+
+    Sometimes, you want more distinction, such as "CAPA (private)", "CAPA (private with proxy)".
+    Use `for-impl="..." title-suffix=" (private)"` for such cases and mind using different tab `id`s.
 */}}
-{{ $title := default (.Get "title") (index (index $.Site.Params "impl_titles") (.Get "for-impl")) }}
+{{ $title := print (default (.Get "title") (index (index $.Site.Params "impl_titles") (.Get "for-impl"))) (default (.Get "title-suffix") "") }}
 {{ if not $title }}
 {{ errorf "Please use a valid `title` or `for-impl` value for tabs in %q (`for-impl` value %q must be listed in `src/config.yaml`)" .Page.File.Path (.Get "for-impl") }}
 {{ end }}


### PR DESCRIPTION
### What does this PR do?

This was missing from https://github.com/giantswarm/roadmap/issues/2393. There may still be other adjustments to make such as tagging subnets for specific uses (`subnet.giantswarm.io/endpoints`, `subnet.giantswarm.io/control-plane`, etc.), but let's at least get the basic command documented for now.

Also, I reconsidered the `kubectl gs template cluster --name` parameter and made it explicit in our examples, since nobody should use random names.

The `--dns-mode` parameter is gone since we removed support for private DNS mode in CAPA clusters.

### Have you maintained the front matter?

yes