### PR TITLE
Update Platform Overview: `good team` vs `experienced team`

### DIFF
--- a/src/content/platform-overview/_index.md
+++ b/src/content/platform-overview/_index.md
@@ -9,6 +9,6 @@ owner:
   - https://github.com/orgs/giantswarm/teams/team-horizon
 ---
 
-An effective self-service and cloud-native developer platform enables developers to quickly and easily deploy and manage their applications in the cloud. To get the most out of this platform, it should be open-source and managed by a good team of Site Reliability Engineers (SREs).
+An effective self-service and cloud-native developer platform enables developers to quickly and easily deploy and manage their applications in the cloud. To get the most out of this platform, it should be open-source and managed by an experienced team of Site Reliability Engineers (SREs).
 
 Giant Swarm operates developer platforms in the data centers and clouds of their customers. Keeping them secure, stable, and up to date, ensuring that developers have the best experience possible.

--- a/src/content/platform-overview/_index.md
+++ b/src/content/platform-overview/_index.md
@@ -9,6 +9,6 @@ owner:
   - https://github.com/orgs/giantswarm/teams/team-horizon
 ---
 
-An effective self-service and cloud-native developer platform enables developers to quickly and easily deploy and manage their applications in the cloud. To get the most out of this platform, it should be open-source and managed by an experienced team of Site Reliability Engineers (SREs).
+An effective self-service and cloud-native developer platform enables developers to quickly and easily deploy and manage their applications in the cloud. To get the most out of this platform, it should be open-source and managed by experienced team of Site Reliability Engineers (SREs).
 
 Giant Swarm operates developer platforms in the data centers and clouds of their customers. Keeping them secure, stable, and up to date, ensuring that developers have the best experience possible.

--- a/src/content/platform-overview/_index.md
+++ b/src/content/platform-overview/_index.md
@@ -9,6 +9,6 @@ owner:
   - https://github.com/orgs/giantswarm/teams/team-horizon
 ---
 
-An effective self-service and cloud-native developer platform enables developers to quickly and easily deploy and manage their applications in the cloud. To get the most out of this platform, it should be open-source and managed by experienced team of Site Reliability Engineers (SREs).
+An effective self-service and cloud-native developer platform enables developers to quickly and easily deploy and manage their applications in the cloud. To get the most out of this platform, it should be open-source and managed by an experienced team of Site Reliability Engineers (SREs).
 
 Giant Swarm operates developer platforms in the data centers and clouds of their customers. Keeping them secure, stable, and up to date, ensuring that developers have the best experience possible.


### PR DESCRIPTION
### What does this PR do?

> The current text uses 'good team' to describe the team of Site Reliability Engineers (SREs) managing the platform. I propose changing this to "experienced team" as it enhances the description by adding confidence, and clarity. What do you think?

### What does it look like?

Just a textual change.

### Any background context you can provide?

(Please link public issues or summarize if not public.)

### What is needed from the reviewers?

### Have you maintained the front matter?

(Please bump the last_review_date in case this qualifies as a review for an entire page. Provide user_questions which should be answered in the page. Provide a meaningful description.)
