### PR TITLE
Skip emitting change Markdown file for empty release body in `docs` repo, make `date` format consistent

### DIFF
--- a/scripts/aggregate-changelogs/config.yaml
+++ b/scripts/aggregate-changelogs/config.yaml
@@ -34,6 +34,12 @@ repositories:
     category: Cluster apps for OpenStack
   giantswarm/docs:
     category: Documentation
+
+    # Don't create useless PRs only for empty changelogs in `docs`
+    skip_if_body_is_one_of:
+      - ''
+      - '- Update generated content'
+      - '- Update changes and releases'
   giantswarm/efk-stack-app:
     category: Managed Apps
   giantswarm/falco-app:


### PR DESCRIPTION
### What does this PR do?

Towards https://github.com/giantswarm/roadmap/issues/2962

On the next run, this removes existing files which match the given list of "considered empty" bodies, and doesn't emit new such files.

During manual testing, I found that the `date` field is rendered inconsistently since sometimes, a timezone-aware `datetime` object is parsed and that would add the `+00:00` suffix which we don't really want. Made that consistent.
