### PR TITLE
Fix menu style

### DIFF
--- a/src/layouts/partials/menu.html
+++ b/src/layouts/partials/menu.html
@@ -3,27 +3,28 @@
 <section class="nav-wrap">
 	<nav class="acnav" role="navigation">
 		<ul class="acnav__list acnav__list--level1">
+
 			{{ $currentPage := . }}
             {{ range .Site.Menus.main }}
                 {{ $pageForItem1 := $site.GetPage .URL }}
                 {{ if .HasChildren }}
                     <li class="has-children">
-                        <div class="acnav__label{{ if or ($currentPage.HasMenuCurrent "main" .) ($currentPage.IsMenuCurrent "main" . ) }} active{{ end }}"><a href="{{ .URL }}" class="{{ if $currentPage.IsMenuCurrent "main" . }}current{{ end }}">{{ .Name }}</a></div>
-                        {{ if $currentPage.IsDescendant $pageForItem1 }}
+                        <div class="acnav__label{{ if or ($currentPage.HasMenuCurrent "main" .) (eq $pageForItem1.Name $currentPage.Name) }} active{{ end }}"><a href="{{ .URL }}" class="{{ if $currentPage.IsMenuCurrent "main" . }}current{{ end }}">{{ .Name }}</a></div>
+                        {{ if or ($currentPage.IsDescendant $pageForItem1) (eq $pageForItem1.Name $currentPage.Name) }}
                         <ul class="acnav__list acnav__list--level2">
                             {{ range .Children }}
                                 {{ $pageForItem2 := $site.GetPage .URL }}
                                 {{ if .HasChildren }}
                                     <li class="has-children">
                                         <div class="acnav__label{{ if or ($currentPage.HasMenuCurrent "main" .) ($currentPage.IsMenuCurrent "main" . ) }} active{{ end }}"><a class="acnav__link{{ if $currentPage.IsMenuCurrent "main" . }} current{{ end }}" href="{{ .URL }}">{{ .Name }}</a></div>
-                                        {{ if $currentPage.IsDescendant $pageForItem2 }}
+                                        {{ if or ($currentPage.IsDescendant $pageForItem2) (eq $pageForItem2.Name $currentPage.Name) }}
                                             <ul class="acnav__list acnav__list--level3">
                                                 {{ range .Children }}
 													{{ $pageForItem3 := $site.GetPage .URL }}
 													{{ if .HasChildren }}
 														<li class="has-children">
 															<div class="acnav__label{{ if or ($currentPage.HasMenuCurrent "main" .) ($currentPage.IsMenuCurrent "main" . ) }} active{{ end }}"><a class="{{ if $currentPage.IsMenuCurrent "main" . }} current{{ end }}" href="{{ .URL }}">{{ .Name }}</a></div>
-															{{ if $currentPage.IsDescendant $pageForItem3 }}
+															{{ if or ($currentPage.IsDescendant $pageForItem3) (eq $pageForItem3.Name $currentPage.Name) }}
 																<ul class="acnav__list acnav__list--level4">
 																	{{ range .Children }}
 																	<li><a class="acnav__link{{ if $currentPage.IsMenuCurrent "main" . }} current{{ end }}" href="{{ .URL }}">{{ .Name }}</a></li>


### PR DESCRIPTION
### What does this PR do?

(Please set a descriptive PR title. Use this space for additional explanations.)
Fix the sidebar menu so in case the first level option is clicked the arrow is change to active and the children are shown

### What does it look like?

Before
<img width="951" alt="Screenshot 2023-11-27 at 11 11 53" src="https://github.com/giantswarm/docs/assets/892157/d451435b-d5d5-499a-a41a-10d7a6cd08c3">

After
<img width="1007" alt="Screenshot 2023-11-27 at 11 12 36" src="https://github.com/giantswarm/docs/assets/892157/2390ecee-e9a2-4960-acd7-5a34e6d3057d">

### Any background context you can provide?

(Please link public issues or summarize if not public.)

### What is needed from the reviewers?

### Have you maintained the front matter?

(Please bump the last_review_date in case this qualifies as a review for an entire page. Provide user_questions which should be answered in the page. Provide a meaningful description.)
