### PR TITLE
Add team annotation in chart.yaml

### DIFF
--- a/helm/docs-app/Chart.yaml
+++ b/helm/docs-app/Chart.yaml
@@ -3,4 +3,6 @@ name: docs-app
 appVersion: 0.0.1
 description: Giant Swarm documentation published at https://docs.giantswarm.io/
 home: https://github.com/giantswarm/docs/
+annotations:
+  application.giantswarm.io/team: "sig-docs"
 version: "[[.Version]]"


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/29088

This is mostly to be compliant with component metrics from Atlas. Uncertain how this will behave in other scenarios currently.