### PR TITLE
Add gsoci.azurecr.io and gsociprivate.azurecr.io to "Domain allowlist"

### DIFF
--- a/src/content/platform-overview/security/cluster-security/domain-allowlist/index.md
+++ b/src/content/platform-overview/security/cluster-security/domain-allowlist/index.md
@@ -32,6 +32,8 @@ Below is a list of the external domains we require access to for our clusters to
     - domains:
         - `giantswarm.azurecr.io`
         - `giantswarmpublic.azurecr.io`
+        - `gsoci.azurecr.io`
+        - `gsociprivate.azurecr.io`
         - `.blob.core.windows.net`
         - `azure.microsoft.com`
     - Container images and app catalogs are hosted on Azure Container Registry.


### PR DESCRIPTION
### What does this PR do?

Adds two entries (Azure container registry FQDNs) to the domain allowlist.

### Any background context you can provide?

Issue https://github.com/giantswarm/roadmap/issues/2882
