### PR TITLE
Reduce container image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,11 +24,11 @@ RUN find /public \
   -iregex '.*\.(css|csv|html?|js|svg|txt|xml|json|webmanifest|ttf)' \
   -exec gzip -9 -k '{}' \;
 
-# Remove uncompressed HTML files from the changes directory
+# Remove uncompressed HTML files
 # to reduce storage requirements and image size.
-RUN find /public/changes \
+RUN find /public \
   -type f \
-  -name '*.html' \
+  -name 'index.html' \
   -delete
 
 FROM gsoci.azurecr.io/giantswarm/nginx:1.23-alpine

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,12 +17,19 @@ RUN hugo \
       --destination /public \
       --cleanDestinationDir
 
-# Compress static files above 512 bytes using gzip
+# Compress files using gzip
+# (creates a copy and leaves the uncompressed version in place)
 RUN find /public \
   -type f -regextype posix-extended \
-  -size +512c \
   -iregex '.*\.(css|csv|html?|js|svg|txt|xml|json|webmanifest|ttf)' \
   -exec gzip -9 -k '{}' \;
+
+# Remove uncompressed HTML files from the changes directory
+# to reduce storage requirements and image size.
+RUN find /public/changes \
+  -type f \
+  -name '*.html' \
+  -delete
 
 FROM gsoci.azurecr.io/giantswarm/nginx:1.23-alpine
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -58,16 +58,14 @@ http {
         server_tokens off;
         port_in_redirect off;
         chunked_transfer_encoding on;
-
+         
         location / {
             root   /usr/share/nginx/html;
-            index  index.html index.htm;
-        }
 
-        # We only store compressed HTML in this directory due to the size.
-        location /changes {
-            root        /usr/share/nginx/html;
+            # We only store compressed HTML in this directory
+            # so the index directive cannot be used.
             rewrite     ^(.*)/$ $1/index.html last;
+
             gzip_static always;
             gunzip      on;
         }

--- a/nginx.conf
+++ b/nginx.conf
@@ -64,6 +64,14 @@ http {
             index  index.html index.htm;
         }
 
+        # We only store compressed HTML in this directory due to the size.
+        location /changes {
+            root        /usr/share/nginx/html;
+            rewrite     ^(.*)/$ $1/index.html last;
+            gzip_static always;
+            gunzip      on;
+        }
+
         error_page  404              /404.html;
 
         # redirect server error pages to the static page /50x.html


### PR DESCRIPTION
### What does this PR do?

This PR changes the container image and nginx config so that only compressed HTML files are stored. As a result, the image size goes from 949 MB down to 159 MB.

### Any background context you can provide?

https://github.com/giantswarm/roadmap/issues/3033
