### PR TITLE
Update review date for gitops index

### DIFF
--- a/src/content/advanced/gitops/_index.md
+++ b/src/content/advanced/gitops/_index.md
@@ -7,7 +7,7 @@ menu:
   main:
     identifier: advanced-gitops
     parent: advanced
-last_review_date: 2022-12-20
+last_review_date: 2024-01-23
 owner:
   - https://github.com/orgs/giantswarm/teams/team-honeybadger
 ---


### PR DESCRIPTION
### What does this PR do?

Towards https://github.com/giantswarm/giantswarm/issues/29565

Updates the last reviewed date for advanced/gitops

### What does it look like?

(If this is more than a textual change, a screenshot can help in some cases to speed up the review process.)

### Any background context you can provide?

(Please link public issues or summarize if not public.)

### What is needed from the reviewers?

### Have you maintained the front matter?

(Please bump the last_review_date in case this qualifies as a review for an entire page. Provide user_questions which should be answered in the page. Provide a meaningful description.)
