### PR TITLE
Dockerfile: avoid exec overhead in compression step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,8 @@ RUN hugo \
 # (creates a copy and leaves the uncompressed version in place)
 RUN find /public \
   -type f -regextype posix-extended \
-  -iregex '.*\.(css|csv|html?|js|svg|txt|xml|json|webmanifest|ttf)' \
-  -exec gzip -9 -k '{}' \;
+  -iregex '.*\.(css|csv|html?|js|svg|txt|xml|json|webmanifest|ttf)'  | \
+    xargs gzip -9 -k
 
 # Remove uncompressed HTML files
 # to reduce storage requirements and image size.


### PR DESCRIPTION
### Summary

While adapting the `gzip` compression step for Intranet and Handbook, it was noticed that the build stage took longer than expected.

A large part of that time is due to `gzip` process launch overhead for each of the individual files.

Make this scale better by using as few processes as possible by means of `find | xargs gzip`. 🥬🍃