### PR TITLE
Update crd-docs-generator to v0.11.1, change alias

### DIFF
--- a/scripts/update-crd-reference/crd.template
+++ b/scripts/update-crd-reference/crd.template
@@ -50,7 +50,7 @@ owner:
   - {{ . -}}
 {{- end }}
 aliases:
-  - /reference/cp-k8s-api/{{ .NamePlural }}.{{ .Group }}/
+  - /use-the-api/management-api/crd/{{ .NamePlural }}.{{ .Group }}/
 technical_name: {{ .NamePlural }}.{{ .Group }}
 source_repository: {{ .SourceRepository }}
 source_repository_ref: {{ .SourceRepositoryRef }}

--- a/scripts/update-crd-reference/main.sh
+++ b/scripts/update-crd-reference/main.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-CRD_DOCS_GENERATOR_VERSION=0.11.0
+CRD_DOCS_GENERATOR_VERSION=0.11.1
 DESTINATION=src/content/vintage/use-the-api/management-api/crd
 
 # Clear output folder

--- a/src/content/vintage/use-the-api/management-api/crd/appcatalogentries.application.giantswarm.io.md
+++ b/src/content/vintage/use-the-api/management-api/crd/appcatalogentries.application.giantswarm.io.md
@@ -21,8 +21,7 @@ layout: crd
 owner:
   - https://github.com/orgs/giantswarm/teams/team-honeybadger
 aliases:
-  - /use-the-api/management-api/crd
-  - /reference/cp-k8s-api/appcatalogentries.application.giantswarm.io/
+  - /use-the-api/management-api/crd/appcatalogentries.application.giantswarm.io/
 technical_name: appcatalogentries.application.giantswarm.io
 source_repository: https://github.com/giantswarm/apiextensions-application
 source_repository_ref: v0.6.1

--- a/src/content/vintage/use-the-api/management-api/crd/appcatalogs.application.giantswarm.io.md
+++ b/src/content/vintage/use-the-api/management-api/crd/appcatalogs.application.giantswarm.io.md
@@ -25,8 +25,7 @@ layout: crd
 owner:
   - https://github.com/orgs/giantswarm/teams/team-honeybadger
 aliases:
-  - /use-the-api/management-api/crd
-  - /reference/cp-k8s-api/appcatalogs.application.giantswarm.io/
+  - /use-the-api/management-api/crd/appcatalogs.application.giantswarm.io/
 technical_name: appcatalogs.application.giantswarm.io
 source_repository: https://github.com/giantswarm/apiextensions-application
 source_repository_ref: v0.6.1

--- a/src/content/vintage/use-the-api/management-api/crd/apps.application.giantswarm.io.md
+++ b/src/content/vintage/use-the-api/management-api/crd/apps.application.giantswarm.io.md
@@ -21,8 +21,7 @@ layout: crd
 owner:
   - https://github.com/orgs/giantswarm/teams/team-honeybadger
 aliases:
-  - /use-the-api/management-api/crd
-  - /reference/cp-k8s-api/apps.application.giantswarm.io/
+  - /use-the-api/management-api/crd/apps.application.giantswarm.io/
 technical_name: apps.application.giantswarm.io
 source_repository: https://github.com/giantswarm/apiextensions-application
 source_repository_ref: v0.6.1

--- a/src/content/vintage/use-the-api/management-api/crd/awsclusters.infrastructure.giantswarm.io.md
+++ b/src/content/vintage/use-the-api/management-api/crd/awsclusters.infrastructure.giantswarm.io.md
@@ -26,8 +26,7 @@ layout: crd
 owner:
   - https://github.com/orgs/giantswarm/teams/team-phoenix
 aliases:
-  - /use-the-api/management-api/crd
-  - /reference/cp-k8s-api/awsclusters.infrastructure.giantswarm.io/
+  - /use-the-api/management-api/crd/awsclusters.infrastructure.giantswarm.io/
 technical_name: awsclusters.infrastructure.giantswarm.io
 source_repository: https://github.com/giantswarm/apiextensions
 source_repository_ref: v5.0.0
@@ -866,112 +865,6 @@ spec:
 </div>
 
 
-
-
-<h3 id="annotation-details-v1alpha2">Annotations</h3>
-
-
-<div class="annotation">
-<div class="annotation-header">
-<h3 class="annotation-path" id="v1alpha2-alpha.aws.giantswarm.io/aws-subnet-size">alpha.aws.giantswarm.io/aws-subnet-size</h3>
-</div>
-<div class="annotation-body">
-<div class="annotation-meta">
-<span class="annotation-release">Since 12.7.0</span>
-</div>
-
-<div class="annotation-description">
-<p>This annotation is used to configure the workload cluster&rsquo;s control plane subnet size when used on an <code>AWSCluster</code> resource or to configure the workload cluster&rsquo;s node pool subnet size when used on an <code>AWSMachineDeployment</code> resource. The value is a number that will represent the subnet mask used when creating the subnet. It must be smaller than 28 due to AWS restrictions.</p>
-
-</div>
-
-</div>
-</div>
-
-<div class="annotation">
-<div class="annotation-header">
-<h3 class="annotation-path" id="v1alpha2-alpha.aws.giantswarm.io/update-max-batch-size">alpha.aws.giantswarm.io/update-max-batch-size</h3>
-</div>
-<div class="annotation-body">
-<div class="annotation-meta">
-<span class="annotation-release">Since 12.7.0</span>
-</div>
-
-<div class="annotation-description">
-<p>This annotation is used for configuring maximum batch size for instances termination during ASG update. The value can be either a whole number specifying the number of instances or a percentage of total instances as decimal number ie <code>0.3</code> for 30%. See <a href="https://docs.giantswarm.io/advanced/upgrade-disruption/">fine-tuning upgrade disruption</a> and <a href="https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatepolicy.html#cfn-attributes-updatepolicy-rollingupdate-maxbatchsize">AWS documentation</a> for additional information.</p>
-
-</div>
-
-</div>
-</div>
-
-<div class="annotation">
-<div class="annotation-header">
-<h3 class="annotation-path" id="v1alpha2-alpha.aws.giantswarm.io/update-pause-time">alpha.aws.giantswarm.io/update-pause-time</h3>
-</div>
-<div class="annotation-body">
-<div class="annotation-meta">
-<span class="annotation-release">Since 12.7.0</span>
-</div>
-
-<div class="annotation-description">
-<p>This annotation is used for configuring time pause between rolling a single batch during ASG update. The value must be in ISO 8601 duration format, e. g. &ldquo;PT5M&rdquo; for five minutes or &ldquo;PT10S&rdquo; for 10 seconds. See <a href="https://docs.giantswarm.io/advanced/upgrade-disruption/">fine-tuning upgrade disruption</a> and <a href="https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatepolicy.html#cfn-attributes-updatepolicy-rollingupdate-maxbatchsize">AWS documentation</a> for additional information.</p>
-
-</div>
-
-</div>
-</div>
-
-<div class="annotation">
-<div class="annotation-header">
-<h3 class="annotation-path" id="v1alpha2-alpha.cni.aws.giantswarm.io/minimum-ip-target">alpha.cni.aws.giantswarm.io/minimum-ip-target</h3>
-</div>
-<div class="annotation-body">
-<div class="annotation-meta">
-<span class="annotation-release">Since 14.0.0</span>
-</div>
-
-<div class="annotation-description">
-<p>This annotation allows configuration of the MINIMUM_IP_TARGET parameter for AWS CNI. See <a href="https://github.com/aws/amazon-vpc-cni-k8s#cni-configuration-variables">CNI Configuration Variables</a> and <a href="https://github.com/aws/amazon-vpc-cni-k8s/blob/master/docs/eni-and-ip-target.md">ENI and IP Target</a></p>
-
-</div>
-
-</div>
-</div>
-
-<div class="annotation">
-<div class="annotation-header">
-<h3 class="annotation-path" id="v1alpha2-alpha.cni.aws.giantswarm.io/prefix-delegation">alpha.cni.aws.giantswarm.io/prefix-delegation</h3>
-</div>
-<div class="annotation-body">
-<div class="annotation-meta">
-<span class="annotation-release">Since 16.1.0</span>
-</div>
-
-<div class="annotation-description">
-<p>This annotation allows configuration of the ENABLE_PREFIX_DELEGATION parameter for AWS CNI. See <a href="https://github.com/aws/amazon-vpc-cni-k8s#enable_prefix_delegation-v190">Enable Prefix Delegation</a></p>
-
-</div>
-
-</div>
-</div>
-
-<div class="annotation">
-<div class="annotation-header">
-<h3 class="annotation-path" id="v1alpha2-alpha.cni.aws.giantswarm.io/warm-ip-target">alpha.cni.aws.giantswarm.io/warm-ip-target</h3>
-</div>
-<div class="annotation-body">
-<div class="annotation-meta">
-<span class="annotation-release">Since 14.0.0</span>
-</div>
-
-<div class="annotation-description">
-<p>This annotation allows configuration of the WARM_IP_TARGET parameter for AWS CNI. See <a href="https://github.com/aws/amazon-vpc-cni-k8s#cni-configuration-variables">CNI Configuration Variables</a> and <a href="https://github.com/aws/amazon-vpc-cni-k8s/blob/master/docs/eni-and-ip-target.md">ENI and IP Target</a></p>
-
-</div>
-
-</div>
-</div>
 
 
 

--- a/src/content/vintage/use-the-api/management-api/crd/awscontrolplanes.infrastructure.giantswarm.io.md
+++ b/src/content/vintage/use-the-api/management-api/crd/awscontrolplanes.infrastructure.giantswarm.io.md
@@ -26,8 +26,7 @@ layout: crd
 owner:
   - https://github.com/orgs/giantswarm/teams/team-phoenix
 aliases:
-  - /use-the-api/management-api/crd
-  - /reference/cp-k8s-api/awscontrolplanes.infrastructure.giantswarm.io/
+  - /use-the-api/management-api/crd/awscontrolplanes.infrastructure.giantswarm.io/
 technical_name: awscontrolplanes.infrastructure.giantswarm.io
 source_repository: https://github.com/giantswarm/apiextensions
 source_repository_ref: v5.0.0

--- a/src/content/vintage/use-the-api/management-api/crd/awsmachinedeployments.infrastructure.giantswarm.io.md
+++ b/src/content/vintage/use-the-api/management-api/crd/awsmachinedeployments.infrastructure.giantswarm.io.md
@@ -24,8 +24,7 @@ layout: crd
 owner:
   - https://github.com/orgs/giantswarm/teams/team-phoenix
 aliases:
-  - /use-the-api/management-api/crd
-  - /reference/cp-k8s-api/awsmachinedeployments.infrastructure.giantswarm.io/
+  - /use-the-api/management-api/crd/awsmachinedeployments.infrastructure.giantswarm.io/
 technical_name: awsmachinedeployments.infrastructure.giantswarm.io
 source_repository: https://github.com/giantswarm/apiextensions
 source_repository_ref: v5.0.0
@@ -570,61 +569,6 @@ spec:
 </div>
 
 
-
-
-<h3 id="annotation-details-v1alpha2">Annotations</h3>
-
-
-<div class="annotation">
-<div class="annotation-header">
-<h3 class="annotation-path" id="v1alpha2-alpha.aws.giantswarm.io/aws-subnet-size">alpha.aws.giantswarm.io/aws-subnet-size</h3>
-</div>
-<div class="annotation-body">
-<div class="annotation-meta">
-<span class="annotation-release">Since 12.7.0</span>
-</div>
-
-<div class="annotation-description">
-<p>This annotation is used to configure the workload cluster&rsquo;s control plane subnet size when used on an <code>AWSCluster</code> resource or to configure the workload cluster&rsquo;s node pool subnet size when used on an <code>AWSMachineDeployment</code> resource. The value is a number that will represent the subnet mask used when creating the subnet. It must be smaller than 28 due to AWS restrictions.</p>
-
-</div>
-
-</div>
-</div>
-
-<div class="annotation">
-<div class="annotation-header">
-<h3 class="annotation-path" id="v1alpha2-alpha.aws.giantswarm.io/update-max-batch-size">alpha.aws.giantswarm.io/update-max-batch-size</h3>
-</div>
-<div class="annotation-body">
-<div class="annotation-meta">
-<span class="annotation-release">Since 12.7.0</span>
-</div>
-
-<div class="annotation-description">
-<p>This annotation is used for configuring maximum batch size for instances termination during ASG update. The value can be either a whole number specifying the number of instances or a percentage of total instances as decimal number ie <code>0.3</code> for 30%. See <a href="https://docs.giantswarm.io/advanced/upgrade-disruption/">fine-tuning upgrade disruption</a> and <a href="https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatepolicy.html#cfn-attributes-updatepolicy-rollingupdate-maxbatchsize">AWS documentation</a> for additional information.</p>
-
-</div>
-
-</div>
-</div>
-
-<div class="annotation">
-<div class="annotation-header">
-<h3 class="annotation-path" id="v1alpha2-alpha.aws.giantswarm.io/update-pause-time">alpha.aws.giantswarm.io/update-pause-time</h3>
-</div>
-<div class="annotation-body">
-<div class="annotation-meta">
-<span class="annotation-release">Since 12.7.0</span>
-</div>
-
-<div class="annotation-description">
-<p>This annotation is used for configuring time pause between rolling a single batch during ASG update. The value must be in ISO 8601 duration format, e. g. &ldquo;PT5M&rdquo; for five minutes or &ldquo;PT10S&rdquo; for 10 seconds. See <a href="https://docs.giantswarm.io/advanced/upgrade-disruption/">fine-tuning upgrade disruption</a> and <a href="https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatepolicy.html#cfn-attributes-updatepolicy-rollingupdate-maxbatchsize">AWS documentation</a> for additional information.</p>
-
-</div>
-
-</div>
-</div>
 
 
 

--- a/src/content/vintage/use-the-api/management-api/crd/azureclusters.infrastructure.cluster.x-k8s.io.md
+++ b/src/content/vintage/use-the-api/management-api/crd/azureclusters.infrastructure.cluster.x-k8s.io.md
@@ -25,8 +25,7 @@ layout: crd
 owner:
   - https://github.com/orgs/giantswarm/teams/team-phoenix
 aliases:
-  - /use-the-api/management-api/crd
-  - /reference/cp-k8s-api/azureclusters.infrastructure.cluster.x-k8s.io/
+  - /use-the-api/management-api/crd/azureclusters.infrastructure.cluster.x-k8s.io/
 technical_name: azureclusters.infrastructure.cluster.x-k8s.io
 source_repository: https://github.com/giantswarm/apiextensions
 source_repository_ref: v5.0.0
@@ -1400,27 +1399,6 @@ spec:
 </div>
 
 
-
-
-<h3 id="annotation-details-v1alpha3">Annotations</h3>
-
-
-<div class="annotation">
-<div class="annotation-header">
-<h3 class="annotation-path" id="v1alpha3-giantswarm.io/workers-egress-external-public-ip">giantswarm.io/workers-egress-external-public-ip</h3>
-</div>
-<div class="annotation-body">
-<div class="annotation-meta">
-<span class="annotation-release">Since 15.1.0</span>
-</div>
-
-<div class="annotation-description">
-<p>This annotation allows reusing an existing public IP address for egress traffic of worker nodes. See <a href="https://docs.giantswarm.io/advanced/egress-ip-address-azure/">Setting an egress IP address on Azure</a></p>
-
-</div>
-
-</div>
-</div>
 
 
 

--- a/src/content/vintage/use-the-api/management-api/crd/azuremachinepools.exp.infrastructure.cluster.x-k8s.io.md
+++ b/src/content/vintage/use-the-api/management-api/crd/azuremachinepools.exp.infrastructure.cluster.x-k8s.io.md
@@ -23,8 +23,7 @@ layout: crd
 owner:
   - https://github.com/orgs/giantswarm/teams/team-phoenix
 aliases:
-  - /use-the-api/management-api/crd
-  - /reference/cp-k8s-api/azuremachinepools.exp.infrastructure.cluster.x-k8s.io/
+  - /use-the-api/management-api/crd/azuremachinepools.exp.infrastructure.cluster.x-k8s.io/
 technical_name: azuremachinepools.exp.infrastructure.cluster.x-k8s.io
 source_repository: https://github.com/giantswarm/apiextensions
 source_repository_ref: v5.0.0

--- a/src/content/vintage/use-the-api/management-api/crd/azuremachinepools.infrastructure.cluster.x-k8s.io.md
+++ b/src/content/vintage/use-the-api/management-api/crd/azuremachinepools.infrastructure.cluster.x-k8s.io.md
@@ -25,8 +25,7 @@ layout: crd
 owner:
   - https://github.com/orgs/giantswarm/teams/team-phoenix
 aliases:
-  - /use-the-api/management-api/crd
-  - /reference/cp-k8s-api/azuremachinepools.infrastructure.cluster.x-k8s.io/
+  - /use-the-api/management-api/crd/azuremachinepools.infrastructure.cluster.x-k8s.io/
 technical_name: azuremachinepools.infrastructure.cluster.x-k8s.io
 source_repository: https://github.com/giantswarm/apiextensions
 source_repository_ref: v5.0.0

--- a/src/content/vintage/use-the-api/management-api/crd/azuremachines.infrastructure.cluster.x-k8s.io.md
+++ b/src/content/vintage/use-the-api/management-api/crd/azuremachines.infrastructure.cluster.x-k8s.io.md
@@ -25,8 +25,7 @@ layout: crd
 owner:
   - https://github.com/orgs/giantswarm/teams/team-phoenix
 aliases:
-  - /use-the-api/management-api/crd
-  - /reference/cp-k8s-api/azuremachines.infrastructure.cluster.x-k8s.io/
+  - /use-the-api/management-api/crd/azuremachines.infrastructure.cluster.x-k8s.io/
 technical_name: azuremachines.infrastructure.cluster.x-k8s.io
 source_repository: https://github.com/giantswarm/apiextensions
 source_repository_ref: v5.0.0

--- a/src/content/vintage/use-the-api/management-api/crd/azuremachinetemplates.infrastructure.cluster.x-k8s.io.md
+++ b/src/content/vintage/use-the-api/management-api/crd/azuremachinetemplates.infrastructure.cluster.x-k8s.io.md
@@ -26,8 +26,7 @@ layout: crd
 owner:
   - https://github.com/orgs/giantswarm/teams/team-phoenix
 aliases:
-  - /use-the-api/management-api/crd
-  - /reference/cp-k8s-api/azuremachinetemplates.infrastructure.cluster.x-k8s.io/
+  - /use-the-api/management-api/crd/azuremachinetemplates.infrastructure.cluster.x-k8s.io/
 technical_name: azuremachinetemplates.infrastructure.cluster.x-k8s.io
 source_repository: https://github.com/giantswarm/apiextensions
 source_repository_ref: v5.0.0

--- a/src/content/vintage/use-the-api/management-api/crd/catalogs.application.giantswarm.io.md
+++ b/src/content/vintage/use-the-api/management-api/crd/catalogs.application.giantswarm.io.md
@@ -21,8 +21,7 @@ layout: crd
 owner:
   - https://github.com/orgs/giantswarm/teams/team-honeybadger
 aliases:
-  - /use-the-api/management-api/crd
-  - /reference/cp-k8s-api/catalogs.application.giantswarm.io/
+  - /use-the-api/management-api/crd/catalogs.application.giantswarm.io/
 technical_name: catalogs.application.giantswarm.io
 source_repository: https://github.com/giantswarm/apiextensions-application
 source_repository_ref: v0.6.1

--- a/src/content/vintage/use-the-api/management-api/crd/certconfigs.core.giantswarm.io.md
+++ b/src/content/vintage/use-the-api/management-api/crd/certconfigs.core.giantswarm.io.md
@@ -22,8 +22,7 @@ layout: crd
 owner:
   - https://github.com/orgs/giantswarm/teams/team-phoenix
 aliases:
-  - /use-the-api/management-api/crd
-  - /reference/cp-k8s-api/certconfigs.core.giantswarm.io/
+  - /use-the-api/management-api/crd/certconfigs.core.giantswarm.io/
 technical_name: certconfigs.core.giantswarm.io
 source_repository: https://github.com/giantswarm/apiextensions
 source_repository_ref: v5.0.0

--- a/src/content/vintage/use-the-api/management-api/crd/charts.application.giantswarm.io.md
+++ b/src/content/vintage/use-the-api/management-api/crd/charts.application.giantswarm.io.md
@@ -21,8 +21,7 @@ layout: crd
 owner:
   - https://github.com/orgs/giantswarm/teams/team-honeybadger
 aliases:
-  - /use-the-api/management-api/crd
-  - /reference/cp-k8s-api/charts.application.giantswarm.io/
+  - /use-the-api/management-api/crd/charts.application.giantswarm.io/
 technical_name: charts.application.giantswarm.io
 source_repository: https://github.com/giantswarm/apiextensions-application
 source_repository_ref: v0.6.1

--- a/src/content/vintage/use-the-api/management-api/crd/clusters.cluster.x-k8s.io.md
+++ b/src/content/vintage/use-the-api/management-api/crd/clusters.cluster.x-k8s.io.md
@@ -29,8 +29,7 @@ owner:
   - https://github.com/orgs/giantswarm/teams/team-rocket
   - https://github.com/orgs/giantswarm/teams/team-phoenix
 aliases:
-  - /use-the-api/management-api/crd
-  - /reference/cp-k8s-api/clusters.cluster.x-k8s.io/
+  - /use-the-api/management-api/crd/clusters.cluster.x-k8s.io/
 technical_name: clusters.cluster.x-k8s.io
 source_repository: https://github.com/giantswarm/apiextensions
 source_repository_ref: v5.0.0
@@ -941,44 +940,6 @@ source_repository_ref: v5.0.0
 </div>
 
 
-
-
-<h3 id="annotation-details-v1alpha3">Annotations</h3>
-
-
-<div class="annotation">
-<div class="annotation-header">
-<h3 class="annotation-path" id="v1alpha3-alpha.giantswarm.io/update-schedule-target-release">alpha.giantswarm.io/update-schedule-target-release</h3>
-</div>
-<div class="annotation-body">
-<div class="annotation-meta">
-
-</div>
-
-<div class="annotation-description">
-<p>This annotation is used to define the desired target release for a scheduled upgrade of the cluster. The upgrade to the specified version will be applied if the &ldquo;update-schedule-target-time&rdquo; annotation has been set and the time defined there has been reached. The value has to be only the desired release version, e.g &ldquo;15.2.1&rdquo;.</p>
-
-</div>
-
-</div>
-</div>
-
-<div class="annotation">
-<div class="annotation-header">
-<h3 class="annotation-path" id="v1alpha3-alpha.giantswarm.io/update-schedule-target-time">alpha.giantswarm.io/update-schedule-target-time</h3>
-</div>
-<div class="annotation-body">
-<div class="annotation-meta">
-
-</div>
-
-<div class="annotation-description">
-<p>This annotation is used to define the desired target time for a scheduled upgrade of the cluster. The upgrade will be applied at the specified time if the &ldquo;update-schedule-target-release&rdquo; annotation has been set to the target release version. The value has to be in RFC822 Format and UTC time zone. e.g. &ldquo;30 Jan 21 15:04 UTC&rdquo;</p>
-
-</div>
-
-</div>
-</div>
 
 
 

--- a/src/content/vintage/use-the-api/management-api/crd/configs.core.giantswarm.io.md
+++ b/src/content/vintage/use-the-api/management-api/crd/configs.core.giantswarm.io.md
@@ -22,8 +22,7 @@ layout: crd
 owner:
   - https://github.com/orgs/giantswarm/teams/team-honeybadger
 aliases:
-  - /use-the-api/management-api/crd
-  - /reference/cp-k8s-api/configs.core.giantswarm.io/
+  - /use-the-api/management-api/crd/configs.core.giantswarm.io/
 technical_name: configs.core.giantswarm.io
 source_repository: https://github.com/giantswarm/config-controller
 source_repository_ref: v0.5.1

--- a/src/content/vintage/use-the-api/management-api/crd/g8scontrolplanes.infrastructure.giantswarm.io.md
+++ b/src/content/vintage/use-the-api/management-api/crd/g8scontrolplanes.infrastructure.giantswarm.io.md
@@ -26,8 +26,7 @@ layout: crd
 owner:
   - https://github.com/orgs/giantswarm/teams/team-phoenix
 aliases:
-  - /use-the-api/management-api/crd
-  - /reference/cp-k8s-api/g8scontrolplanes.infrastructure.giantswarm.io/
+  - /use-the-api/management-api/crd/g8scontrolplanes.infrastructure.giantswarm.io/
 technical_name: g8scontrolplanes.infrastructure.giantswarm.io
 source_repository: https://github.com/giantswarm/apiextensions
 source_repository_ref: v5.0.0

--- a/src/content/vintage/use-the-api/management-api/crd/kubeadmconfigs.bootstrap.cluster.x-k8s.io.md
+++ b/src/content/vintage/use-the-api/management-api/crd/kubeadmconfigs.bootstrap.cluster.x-k8s.io.md
@@ -27,8 +27,7 @@ owner:
   - https://github.com/orgs/giantswarm/teams/team-phoenix
   - https://github.com/orgs/giantswarm/teams/team-rocket
 aliases:
-  - /use-the-api/management-api/crd
-  - /reference/cp-k8s-api/kubeadmconfigs.bootstrap.cluster.x-k8s.io/
+  - /use-the-api/management-api/crd/kubeadmconfigs.bootstrap.cluster.x-k8s.io/
 technical_name: kubeadmconfigs.bootstrap.cluster.x-k8s.io
 source_repository: https://github.com/giantswarm/apiextensions
 source_repository_ref: v5.0.0

--- a/src/content/vintage/use-the-api/management-api/crd/kubeadmcontrolplanes.controlplane.cluster.x-k8s.io.md
+++ b/src/content/vintage/use-the-api/management-api/crd/kubeadmcontrolplanes.controlplane.cluster.x-k8s.io.md
@@ -27,8 +27,7 @@ owner:
   - https://github.com/orgs/giantswarm/teams/team-phoenix
   - https://github.com/orgs/giantswarm/teams/team-rocket
 aliases:
-  - /use-the-api/management-api/crd
-  - /reference/cp-k8s-api/kubeadmcontrolplanes.controlplane.cluster.x-k8s.io/
+  - /use-the-api/management-api/crd/kubeadmcontrolplanes.controlplane.cluster.x-k8s.io/
 technical_name: kubeadmcontrolplanes.controlplane.cluster.x-k8s.io
 source_repository: https://github.com/giantswarm/apiextensions
 source_repository_ref: v5.0.0

--- a/src/content/vintage/use-the-api/management-api/crd/kvmclusterconfigs.core.giantswarm.io.md
+++ b/src/content/vintage/use-the-api/management-api/crd/kvmclusterconfigs.core.giantswarm.io.md
@@ -25,8 +25,7 @@ layout: crd
 owner:
   - https://github.com/orgs/giantswarm/teams/team-rocket
 aliases:
-  - /use-the-api/management-api/crd
-  - /reference/cp-k8s-api/kvmclusterconfigs.core.giantswarm.io/
+  - /use-the-api/management-api/crd/kvmclusterconfigs.core.giantswarm.io/
 technical_name: kvmclusterconfigs.core.giantswarm.io
 source_repository: https://github.com/giantswarm/apiextensions
 source_repository_ref: v5.0.0

--- a/src/content/vintage/use-the-api/management-api/crd/kvmconfigs.provider.giantswarm.io.md
+++ b/src/content/vintage/use-the-api/management-api/crd/kvmconfigs.provider.giantswarm.io.md
@@ -25,8 +25,7 @@ layout: crd
 owner:
   - https://github.com/orgs/giantswarm/teams/team-rocket
 aliases:
-  - /use-the-api/management-api/crd
-  - /reference/cp-k8s-api/kvmconfigs.provider.giantswarm.io/
+  - /use-the-api/management-api/crd/kvmconfigs.provider.giantswarm.io/
 technical_name: kvmconfigs.provider.giantswarm.io
 source_repository: https://github.com/giantswarm/apiextensions
 source_repository_ref: v5.0.0

--- a/src/content/vintage/use-the-api/management-api/crd/machinedeployments.cluster.x-k8s.io.md
+++ b/src/content/vintage/use-the-api/management-api/crd/machinedeployments.cluster.x-k8s.io.md
@@ -27,8 +27,7 @@ owner:
   - https://github.com/orgs/giantswarm/teams/team-phoenix
   - https://github.com/orgs/giantswarm/teams/team-rocket
 aliases:
-  - /use-the-api/management-api/crd
-  - /reference/cp-k8s-api/machinedeployments.cluster.x-k8s.io/
+  - /use-the-api/management-api/crd/machinedeployments.cluster.x-k8s.io/
 technical_name: machinedeployments.cluster.x-k8s.io
 source_repository: https://github.com/giantswarm/apiextensions
 source_repository_ref: v5.0.0

--- a/src/content/vintage/use-the-api/management-api/crd/machinepools.cluster.x-k8s.io.md
+++ b/src/content/vintage/use-the-api/management-api/crd/machinepools.cluster.x-k8s.io.md
@@ -25,8 +25,7 @@ layout: crd
 owner:
   - https://github.com/orgs/giantswarm/teams/team-phoenix
 aliases:
-  - /use-the-api/management-api/crd
-  - /reference/cp-k8s-api/machinepools.cluster.x-k8s.io/
+  - /use-the-api/management-api/crd/machinepools.cluster.x-k8s.io/
 technical_name: machinepools.cluster.x-k8s.io
 source_repository: https://github.com/giantswarm/apiextensions
 source_repository_ref: v5.0.0

--- a/src/content/vintage/use-the-api/management-api/crd/machinepools.exp.cluster.x-k8s.io.md
+++ b/src/content/vintage/use-the-api/management-api/crd/machinepools.exp.cluster.x-k8s.io.md
@@ -23,8 +23,7 @@ layout: crd
 owner:
   - https://github.com/orgs/giantswarm/teams/team-phoenix
 aliases:
-  - /use-the-api/management-api/crd
-  - /reference/cp-k8s-api/machinepools.exp.cluster.x-k8s.io/
+  - /use-the-api/management-api/crd/machinepools.exp.cluster.x-k8s.io/
 technical_name: machinepools.exp.cluster.x-k8s.io
 source_repository: https://github.com/giantswarm/apiextensions
 source_repository_ref: v5.0.0
@@ -1613,44 +1612,6 @@ spec:
 </div>
 
 
-
-
-<h3 id="annotation-details-v1alpha3">Annotations</h3>
-
-
-<div class="annotation">
-<div class="annotation-header">
-<h3 class="annotation-path" id="v1alpha3-cluster.k8s.io/cluster-api-autoscaler-node-group-max-size">cluster.k8s.io/cluster-api-autoscaler-node-group-max-size</h3>
-</div>
-<div class="annotation-body">
-<div class="annotation-meta">
-<span class="annotation-release">Since Azure 13.1.0</span>
-</div>
-
-<div class="annotation-description">
-<p>This annotation allows setting the max size of a node pool for autoscaling purposes. See <a href="https://docs.giantswarm.io/advanced/node-pools/">node pools</a></p>
-
-</div>
-
-</div>
-</div>
-
-<div class="annotation">
-<div class="annotation-header">
-<h3 class="annotation-path" id="v1alpha3-cluster.k8s.io/cluster-api-autoscaler-node-group-min-size">cluster.k8s.io/cluster-api-autoscaler-node-group-min-size</h3>
-</div>
-<div class="annotation-body">
-<div class="annotation-meta">
-<span class="annotation-release">Since Azure 13.1.0</span>
-</div>
-
-<div class="annotation-description">
-<p>This annotation allows setting the min size of a node pool for autoscaling purposes. See <a href="https://docs.giantswarm.io/advanced/node-pools/">node pools</a></p>
-
-</div>
-
-</div>
-</div>
 
 
 

--- a/src/content/vintage/use-the-api/management-api/crd/networkpools.infrastructure.giantswarm.io.md
+++ b/src/content/vintage/use-the-api/management-api/crd/networkpools.infrastructure.giantswarm.io.md
@@ -24,8 +24,7 @@ layout: crd
 owner:
   - https://github.com/orgs/giantswarm/teams/team-phoenix
 aliases:
-  - /use-the-api/management-api/crd
-  - /reference/cp-k8s-api/networkpools.infrastructure.giantswarm.io/
+  - /use-the-api/management-api/crd/networkpools.infrastructure.giantswarm.io/
 technical_name: networkpools.infrastructure.giantswarm.io
 source_repository: https://github.com/giantswarm/apiextensions
 source_repository_ref: v5.0.0

--- a/src/content/vintage/use-the-api/management-api/crd/organizations.security.giantswarm.io.md
+++ b/src/content/vintage/use-the-api/management-api/crd/organizations.security.giantswarm.io.md
@@ -21,8 +21,7 @@ layout: crd
 owner:
   - https://github.com/orgs/giantswarm/teams/team-bigmac
 aliases:
-  - /use-the-api/management-api/crd
-  - /reference/cp-k8s-api/organizations.security.giantswarm.io/
+  - /use-the-api/management-api/crd/organizations.security.giantswarm.io/
 technical_name: organizations.security.giantswarm.io
 source_repository: https://github.com/giantswarm/organization-operator
 source_repository_ref: v1.0.2

--- a/src/content/vintage/use-the-api/management-api/crd/policyexceptiondrafts.policy.giantswarm.io.md
+++ b/src/content/vintage/use-the-api/management-api/crd/policyexceptiondrafts.policy.giantswarm.io.md
@@ -20,7 +20,7 @@ layout: crd
 owner:
   - https://github.com/orgs/giantswarm/teams/team-shield
 aliases:
-  - /reference/cp-k8s-api/policyexceptiondrafts.policy.giantswarm.io/
+  - /use-the-api/management-api/crd/policyexceptiondrafts.policy.giantswarm.io/
 technical_name: policyexceptiondrafts.policy.giantswarm.io
 source_repository: https://github.com/giantswarm/exception-recommender
 source_repository_ref: v0.1.1

--- a/src/content/vintage/use-the-api/management-api/crd/policyexceptions.policy.giantswarm.io.md
+++ b/src/content/vintage/use-the-api/management-api/crd/policyexceptions.policy.giantswarm.io.md
@@ -20,7 +20,7 @@ layout: crd
 owner:
   - https://github.com/orgs/giantswarm/teams/team-shield
 aliases:
-  - /reference/cp-k8s-api/policyexceptions.policy.giantswarm.io/
+  - /use-the-api/management-api/crd/policyexceptions.policy.giantswarm.io/
 technical_name: policyexceptions.policy.giantswarm.io
 source_repository: https://github.com/giantswarm/kyverno-policy-operator
 source_repository_ref: v0.0.7

--- a/src/content/vintage/use-the-api/management-api/crd/releases.release.giantswarm.io.md
+++ b/src/content/vintage/use-the-api/management-api/crd/releases.release.giantswarm.io.md
@@ -22,8 +22,7 @@ layout: crd
 owner:
   - https://github.com/orgs/giantswarm/teams/team-honeybadger
 aliases:
-  - /use-the-api/management-api/crd
-  - /reference/cp-k8s-api/releases.release.giantswarm.io/
+  - /use-the-api/management-api/crd/releases.release.giantswarm.io/
 technical_name: releases.release.giantswarm.io
 source_repository: https://github.com/giantswarm/release-operator
 source_repository_ref: v3.0.1

--- a/src/content/vintage/use-the-api/management-api/crd/rolebindingtemplates.auth.giantswarm.io.md
+++ b/src/content/vintage/use-the-api/management-api/crd/rolebindingtemplates.auth.giantswarm.io.md
@@ -21,8 +21,7 @@ layout: crd
 owner:
   - https://github.com/orgs/giantswarm/teams/team-bigmac
 aliases:
-  - /use-the-api/management-api/crd
-  - /reference/cp-k8s-api/rolebindingtemplates.auth.giantswarm.io/
+  - /use-the-api/management-api/crd/rolebindingtemplates.auth.giantswarm.io/
 technical_name: rolebindingtemplates.auth.giantswarm.io
 source_repository: https://github.com/giantswarm/rbac-operator
 source_repository_ref: v0.39.0

--- a/src/content/vintage/use-the-api/management-api/crd/silences.monitoring.giantswarm.io.md
+++ b/src/content/vintage/use-the-api/management-api/crd/silences.monitoring.giantswarm.io.md
@@ -21,8 +21,7 @@ layout: crd
 owner:
   - https://github.com/orgs/giantswarm/teams/team-atlas
 aliases:
-  - /use-the-api/management-api/crd
-  - /reference/cp-k8s-api/silences.monitoring.giantswarm.io/
+  - /use-the-api/management-api/crd/silences.monitoring.giantswarm.io/
 technical_name: silences.monitoring.giantswarm.io
 source_repository: https://github.com/giantswarm/silence-operator
 source_repository_ref: v0.4.0

--- a/src/content/vintage/use-the-api/management-api/crd/sparks.core.giantswarm.io.md
+++ b/src/content/vintage/use-the-api/management-api/crd/sparks.core.giantswarm.io.md
@@ -23,8 +23,7 @@ layout: crd
 owner:
   - https://github.com/orgs/giantswarm/teams/team-phoenix
 aliases:
-  - /use-the-api/management-api/crd
-  - /reference/cp-k8s-api/sparks.core.giantswarm.io/
+  - /use-the-api/management-api/crd/sparks.core.giantswarm.io/
 technical_name: sparks.core.giantswarm.io
 source_repository: https://github.com/giantswarm/apiextensions
 source_repository_ref: v5.0.0


### PR DESCRIPTION
This PR updates crd-docs-generator to the latest version. Also in the CRD ref template, the alias is updated to add an alias for the URI before the vintage move.

It looks like annotations are being removed (or rather: not added) to the generated output, so I'm checking why.