### PR TITLE
Fix local build by allowing entrypoint to run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,22 +33,12 @@ RUN find /public \
 
 COPY src/robots.txt /public/robots.txt
 
-FROM gsoci.azurecr.io/giantswarm/nginx:1.23-alpine
+FROM gsoci.azurecr.io/giantswarm/nginx:1.25-alpine
+
+# Delete default config (which we have no control over)
+RUN rm -r /etc/nginx/conf.d && rm /etc/nginx/nginx.conf
 
 COPY nginx.conf /etc/nginx/nginx.conf
-
-# Development mode
-# RUN sed -i \
-#     -e 's|listen       80;|listen 8080;|' \
-#     -e 's|listen  [::]:80;||' \
-#     /etc/nginx/conf.d/default.conf
-
-# Production mode
-RUN rm /docker-entrypoint.d/* && \
-  sed -i \
-    -e 's|listen       80;|listen 8080;|' \
-    -e 's|listen  [::]:80;||' \
-    /etc/nginx/conf.d/default.conf
 
 RUN nginx -t -c /etc/nginx/nginx.conf && \
     rm -rf /tmp/nginx.pid

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,8 +1,9 @@
 version: "3"
 services:
   docs-app:
-    # to build this image locally, execute 'make docker-build'
-    image: gsoci.azurecr.io/giantswarm/docs:latest
+    #image: gsoci.azurecr.io/giantswarm/docs:latest
+    build:
+      context: .
     container_name: docs-app
     ports:
       - "8080:8080"


### PR DESCRIPTION
Fixes https://github.com/giantswarm/giantswarm/issues/29991

### Summary

This PR introduces two changes to fix the local startup:

- rely on locally build image in `docker-compose.yml`
- remove deprecated `sed` expressions from Dockerfile (the whole `nginx.conf` is now replaced, thanks @marians)
