### PR TITLE
Fix / improve vintage disclaimer wording

### DIFF
--- a/src/layouts/partials/footer.html
+++ b/src/layouts/partials/footer.html
@@ -4,7 +4,7 @@
 
     <div id="vintage-disclaimer">
       <div id="vintage-disclaimer-inner">
-        <div id="vintage-disclaimer-wording"><p>This is part of our documentation may not be accurate because we are migrating away from our vintage product. Currently we are working actively to provide up-to-date documentation on the latest generation of our product, using the Kubernetes Cluster API.</p></div>
+        <div id="vintage-disclaimer-wording"><p>This part of our documentation may not be accurate as we are migrating away from our vintage product. Currently we are working actively to provide up-to-date documentation on the latest generation of our product, using the Kubernetes Cluster API.</p></div>
         <div id="vintage-disclaimer-button-area">
           <a href="javascript:void(0);" id="vintage-disclaimer-button" role="button">Close</a>
         </div>


### PR DESCRIPTION
### What this PR does / why we need it

There was a grammar problem and I switched "because" with "as" for simplicity.

### Things to check/remember before submitting

- If you made content changes

    - Run `make dev` to render and proofread content changes locally.
    - Bump `last_review_date` in the front matter header if you reviewed the entire page.
