### PR TITLE
rewrite-observability-platform-introduction page

### DIFF
--- a/src/content/vintage/platform-overview/observability/_index.md
+++ b/src/content/vintage/platform-overview/observability/_index.md
@@ -17,33 +17,38 @@ user_questions:
   - What app do you recommend for monitoring?
   - What app do you recommend for logging?
   - What app do you recommend for tracing?
-last_review_date: 2022-11-18
+last_review_date: 2024-02-28
 ---
 
-Observability is based on three main data sources: logs, metrics and tracing\*. To cover these needs Giant Swarm provides its customers with a managed observability stack. The apps included in this stack are listed below. We chose these apps based on our general principles of preferring open source over proprietary solutions, as well as simplicity, performance, and speed over complexity.
+Observability is based on four main data sources: __logs__, __metrics__, __traces__ and __profiles__. To cover these needs Giant Swarm provides its customers with a fully managed observability platform provided with 24//7 monitoring and alerting The tools included in the observabily platform are listed below.
 
-**What do we mean by a "managed" app?** We mean offering similar Service Level Objectives as the rest of our offering as described in [The Radical Way Giant Swarm Handles Service Level Objectives](https://www.giantswarm.io/blog/the-radical-way-giant-swarm-handles-service-level-objectives).
+We chose these applications based on our general principles of preferring open source over proprietary solutions, as well as simplicity, performance, and speed over complexity.
 
-In brief, super fast response times from engineers, 24//7 monitoring and alerting by us, and in general, having shared goals and responsibilities to keep services up and get them up when they go down.
+If you want to learn more about observability, we recommend that you read [this](https://opentelemetry.io/docs/concepts/observability-primer/)
 
-In addition, we strive to uphold our "30 Day Upgrade Promise," our commitment to keep all managed apps within 30 days of latest upstream releases.
-
-To summarize, for observability, we recommend and provide these four managed apps:
-
-## Prometheus for monitoring/metrics
-
-To get all your metrics, process, store and alert on them. Prometheus has become the de-facto standard monitoring tool in the kubernetes ecosystem.
+To summarize, for observability, we recommend and provide these tools:
 
 ## Loki for logging
 
-To fetch logs from containers, store and index them, and make them searchable. To install, go to [Loki README](https://github.com/giantswarm/loki-app/blob/master/README.md).
+To store, index and make logs (containers, kubernetes events, audit logs) searchable. You can also install our [Loki App](https://github.com/giantswarm/loki-app/blob/master/README.md) on your clusters.
 
-In addition, we understand some customers already know and use Elasticsearch. For this reason, we also provide a managed EFK stack (Elasticsearch, Fluentd, and Kibana) for logging. To install, go to [EFK Stack README](https://github.com/giantswarm/efk-stack-app/blob/master/README.md) [Elastic Stack]({{< relref "/vintage/platform-overview/observability/elastic-stack" >}}).
+## Prometheus for monitoring
 
-## Grafana as data visualization tool
+To get all your metrics, process, store and alert on them. Prometheus has become the de-facto standard monitoring tool in the kubernetes ecosystem.
 
-To analyze, visualize, and correlate metrics from Prometheus and Linkerd as well as logs from Loki.
+## Grafana for data visualization
 
-These pieces can be separately or together. Adopting them together and as fully managed apps from Giant Swarm gives you the benefit of using vetted open source tools that you know work together to provide you with consistency and coverage.
+To analyze, visualize, and correlate any kind of observability data.
 
-We are currently not offering a fully managed app for tracing due to the low priority it has with our customers. We believe that at this time the [tracing options provided by Linkerd](https://www.giantswarm.io/blog/part-5-traces-of-your-microservices-0) (that require no code changes) are sufficient.
+## Tempo for distributed tracing
+
+We are currently offering Grafana Tempo a part of our observability platform on demand and without any availability garantees due to the low priority it has with our customers.
+
+## Pyroscope for continuous profiling
+
+Profiling is quite a new kid on the block when it comes to observability.
+Same as with Grafana Tempo, we are currently offering Grafana Tempo a part of our observability platform on demand and without any availability garantees due to the low priority it has with our customers.
+
+---
+
+If you want to learn more about our monitoring platform, feel free to dive into our [`Getting Started`]({{< relref "/vintage/getting-started/observability" >}}) section.

--- a/src/content/vintage/platform-overview/observability/_index.md
+++ b/src/content/vintage/platform-overview/observability/_index.md
@@ -20,7 +20,7 @@ user_questions:
 last_review_date: 2024-02-28
 ---
 
-Observability is based on four main data sources: __logs__, __metrics__, __traces__ and __profiles__. To cover these needs Giant Swarm provides its customers with a fully managed observability platform provided with 24//7 monitoring and alerting The tools included in the observabily platform are listed below.
+Observability is based on four main data sources: __logs__, __metrics__, __traces__ and __profiles__. To cover these needs, Giant Swarm provides its customers with a fully managed observability platform supported by 24//7 monitoring and alerting The tools included in the observabily platform are listed below.
 
 We chose these applications based on our general principles of preferring open source over proprietary solutions, as well as simplicity, performance, and speed over complexity.
 

--- a/src/content/vintage/platform-overview/observability/_index.md
+++ b/src/content/vintage/platform-overview/observability/_index.md
@@ -20,7 +20,7 @@ user_questions:
 last_review_date: 2024-02-28
 ---
 
-Observability is based on four main data sources: __logs__, __metrics__, __traces__ and __profiles__. To cover these needs, Giant Swarm provides its customers with a fully managed observability platform supported by 24//7 monitoring and alerting The tools included in the observabily platform are listed below.
+Observability is based on four main data sources: __logs__, __metrics__, __traces__ and __profiles__. To cover these needs, Giant Swarm provides its customers with a fully managed observability platform supported by 24//7 monitoring and alerting. The tools included in the observabily platform are listed below.
 
 We chose these applications based on our general principles of preferring open source over proprietary solutions, as well as simplicity, performance, and speed over complexity.
 

--- a/src/content/vintage/platform-overview/observability/_index.md
+++ b/src/content/vintage/platform-overview/observability/_index.md
@@ -47,7 +47,7 @@ We are currently offering Grafana Tempo a part of our observability platform on 
 ## Pyroscope for continuous profiling
 
 Profiling is quite a new kid on the block when it comes to observability.
-Same as with Grafana Tempo, we are currently offering Grafana Tempo a part of our observability platform on demand and without any availability garantees due to the low priority it has with our customers.
+Same as with Grafana Tempo, we are currently offering Grafana Pyroscope a part of our observability platform on demand and without any availability garantees due to the low priority it has with our customers.
 
 ---
 

--- a/src/content/vintage/platform-overview/observability/_index.md
+++ b/src/content/vintage/platform-overview/observability/_index.md
@@ -30,7 +30,7 @@ To summarize, for observability, we recommend and provide these tools:
 
 ## Loki for logging
 
-To store, index and make logs (containers, kubernetes events, audit logs) searchable. You can also install our [Loki App](https://github.com/giantswarm/loki-app/blob/master/README.md) on your clusters.
+To store, index, and make logs (containers, kubernetes events, audit logs) searchable. You can also install our [Loki App](https://github.com/giantswarm/loki-app/blob/master/README.md) on your clusters.
 
 ## Prometheus for monitoring
 


### PR DESCRIPTION
### What this PR does / why we need it

Towards https://github.com/giantswarm/giantswarm/issues/28925

This page is quite outdated.

We also deprecated EFK stack a while back. Should I remove the section about this app? 

Because it is weird that we have this at the end:

![image](https://github.com/giantswarm/docs/assets/2787548/acfb2488-a610-4c49-9a5c-ffc47d8228f9)

### Things to check/remember before submitting

- If you made content changes

    - Run `make dev` to render and proofread content changes locally.
    - Bump `last_review_date` in the front matter header if you reviewed the entire page.
