### PR TITLE
Update aliases for all CRD page to enable redirect from previous URL

### DIFF
--- a/scripts/update-crd-reference/crd.template
+++ b/scripts/update-crd-reference/crd.template
@@ -50,7 +50,7 @@ owner:
   - {{ . -}}
 {{- end }}
 aliases:
-  - /reference/cp-k8s-api/{{ .NamePlural }}.{{ .Group }}/
+  - /use-the-api/management-api/crd/{{ .NamePlural }}.{{ .Group }}/
 technical_name: {{ .NamePlural }}.{{ .Group }}
 source_repository: {{ .SourceRepository }}
 source_repository_ref: {{ .SourceRepositoryRef }}


### PR DESCRIPTION
Taking the alias (redirect) fix from https://github.com/giantswarm/docs/pull/2131