### PR TITLE
Do not render last_review_date in generated helm charts docs

### DIFF
--- a/scripts/update-helm-chart-reference/chart.template
+++ b/scripts/update-helm-chart-reference/chart.template
@@ -12,7 +12,6 @@ menu:
     identifier: {{ .Title | nospace }}
     parent: uiapi-cluster-apps
 layout: cluster-app
-last_review_date: {{currentDate "2006-01-02"}}
 user_questions:
  - What properties can I configure for {{ .Title }}?
 {{- if .Team }}

--- a/scripts/validate-front-matter/script.py
+++ b/scripts/validate-front-matter/script.py
@@ -15,7 +15,7 @@ except ImportError:
 # Some path config
 path         = 'src/content'
 vintage_path = 'src/content/vintage'
-changes_path = 'src/content/changes/'
+changes_path = 'src/content/vintage/changes/'
 crds_path    = 'src/content/vintage/use-the-api/management-api/crd/'
 docs_host    = 'https://github.com/giantswarm/docs/blob/main/'
 


### PR DESCRIPTION
Goal: Avoid changing chart content every day, keep diffs for generated content as small as possible.