### PR TITLE
Run "Update generated content" only once per hour

### DIFF
--- a/.github/workflows/update-changes.yml
+++ b/.github/workflows/update-changes.yml
@@ -9,8 +9,8 @@ name: Update generated content
 # Trigger by cronjob
 on:
   schedule:
-    # Every 20 minutes on Monday to Friday, between 7:00 and 18:00 UTC
-    - cron: "13,33,53 7-18 * * MON-FRI"
+    # Every hour from 7:13 to 18:13 on Monday to Friday
+    - cron: "13 7-18 * * MON-FRI"
   workflow_dispatch: {} # Allow manual triggering
 
 jobs:


### PR DESCRIPTION
We decided to reduce notification noise and also resource usage for this action.

Also the action can now be triggered manually when needed.

## Why run at :13?

Most people run their cronjobs exactly at `:00`, which creates immense load spikes on Github's side at that time. :13 is as good as any other minute.