### PR TITLE
Vintage: Add missing quote in patch command

### DIFF
--- a/src/content/vintage/advanced/cluster-management/high-availability/control-plane/index.md
+++ b/src/content/vintage/advanced/cluster-management/high-availability/control-plane/index.md
@@ -3,7 +3,7 @@ linkTitle: High-availability control plane
 title: High-Availability Kubernetes control plane
 description: For production clusters with high availability requirements, Giant Swarm on AWS enables control planes with three control plane nodes and three etcd replicas spread over multiple availability zones.
 weight: 10
-last_review_date: 2023-04-04
+last_review_date: 2023-04-08
 menu:
   main:
     parent: advanced-high-availability

--- a/src/content/vintage/advanced/cluster-management/high-availability/control-plane/index.md
+++ b/src/content/vintage/advanced/cluster-management/high-availability/control-plane/index.md
@@ -139,7 +139,7 @@ For non-interactive patching:
 
 ```nohighlight
 kubectl patch g8scontrolplanes.infrastructure.giantswarm.io <NAME> \
-  --type merge -p '{"spec": {"replicas": 3}}
+  --type merge -p '{"spec": {"replicas": 3}}'
 ```
 
 Once that is done, the operators will reconcile the desired state and create the


### PR DESCRIPTION
### What this PR does / why we need it

<!-- Please mention any GitHub issue, set a descriptive PR title, and use this space for additional explanations. -->
Fixes this:
```
kubectl patch g8scontrolplanes.infrastructure.giantswarm.io qx6qoe5yai --type merge -p '{"spec": {"replicas": 3}} -n org-giantswarm
quote>
```



### Things to check/remember before submitting

- If you made content changes

    - Run `make dev` to render and proofread content changes locally.
    - Bump `last_review_date` in the front matter header if you reviewed the entire page.
