### PR TITLE
Update Dex OIDC docs with CAPA EKS cluster changes

### DIFF
--- a/src/content/vintage/advanced/access-management/configure-dex-in-your-cluster/index.md
+++ b/src/content/vintage/advanced/access-management/configure-dex-in-your-cluster/index.md
@@ -9,7 +9,7 @@ menu:
 user_questions:
   - How can I configure OIDC in my cluster?
   - How can I add a new OIDC connector?
-last_review_date: 2023-09-13
+last_review_date: 2024-04-25
 aliases:
   - /advanced/access-management/configure-dex-in-your-cluster
   - /guides/configure-dex-in-your-cluster/

--- a/src/content/vintage/advanced/access-management/configure-dex-in-your-cluster/index.md
+++ b/src/content/vintage/advanced/access-management/configure-dex-in-your-cluster/index.md
@@ -407,6 +407,7 @@ oidc:
 ```
 
 **IMPORTANT:** For workload cluster using CAPI `eks` provider (CAPA - AWS EKS), you'll need to configure Athena to use AWS-assigned EKS API server endpoint. This API server endpoint is uniquely allocated to your EKS cluster and can be easily accessed through the AWS EKS console by navigating to "Overview" tab and under Details section from the EKS cluster information page. For example:
+
 ```yaml
 kubernetes
   api:

--- a/src/content/vintage/advanced/access-management/configure-dex-in-your-cluster/index.md
+++ b/src/content/vintage/advanced/access-management/configure-dex-in-your-cluster/index.md
@@ -384,6 +384,13 @@ oidc:
   issuerAddress: https://dex.test.example.io
 ```
 
+**IMPORTANT:** For workload cluster using CAPI `eks` provider (CAPA - AWS EKS), you'll need to configure Athena to use AWS-assigned EKS API server endpoint. This API server endpoint is uniquely allocated to your EKS cluster and can be easily accessed through the AWS EKS console by navigating to "Overview" tab and under Details section from the EKS cluster information page. For example:
+```yaml
+kubernetes
+  api:
+    address: https://6EAE2F2E28XUD92EXZF54DFEF7C37081D.gr7.eu-central-1.eks.amazonaws.com
+```
+
 Access to Athena can be restricted to certain CIDRs.
 
 ```yaml

--- a/src/content/vintage/advanced/access-management/configure-dex-in-your-cluster/index.md
+++ b/src/content/vintage/advanced/access-management/configure-dex-in-your-cluster/index.md
@@ -406,7 +406,7 @@ oidc:
   issuerAddress: https://dex.test.example.io
 ```
 
-**IMPORTANT:** For workload cluster using CAPI `eks` provider (CAPA - AWS EKS), you'll need to configure Athena to use AWS-assigned EKS API server endpoint. This API server endpoint is uniquely allocated to your EKS cluster and can be easily accessed through the AWS EKS console by navigating to "Overview" tab and under Details section from the EKS cluster information page. For example:
+__warning__: For workload cluster using [Cluster API `EKS`](https://github.com/giantswarm/cluster-eks) provider, you'll need to configure Athena to use an AWS-managed EKS API server endpoint. This API server endpoint is uniquely allocated to your EKS cluster and can be easily accessed through the AWS EKS console by navigating to the `Overview` tab and under the `Details` section from the EKS cluster information page. For example:
 
 ```yaml
 kubernetes

--- a/src/content/vintage/advanced/access-management/configure-dex-in-your-cluster/index.md
+++ b/src/content/vintage/advanced/access-management/configure-dex-in-your-cluster/index.md
@@ -91,7 +91,7 @@ spec:
 ```
 
 {{< /tab >}}
-{{< tab title="Cluster API">}}
+{{< tab title="Cluster API (any)">}}
 
 ```yaml
 # Config map with values for the Workload Cluster app
@@ -100,11 +100,33 @@ kind: ConfigMap
 data:
   values: |
     ...
-    oidc:
-      issuerUrl: https://dex.CLUSTER_NAME.BASE_DOMAIN
-      clientId: dex-k8s-authenticator
-      usernameClaim: email
-      groupsClaim: groups
+    global:
+      controlPlane:
+        oidc:
+          issuerUrl: https://dex.CLUSTER_NAME.BASE_DOMAIN
+          clientId: dex-k8s-authenticator
+          usernameClaim: email
+          groupsClaim: groups
+```
+
+{{< /tab >}}
+{{< tab title="Cluster API (AWS EKS)">}}
+
+```yaml
+# Config map with values for the Workload Cluster app
+apiVersion: v1
+kind: ConfigMap
+data:
+  values: |
+    ...
+    global:
+      controlPlane:
+        oidcIdentityProviderConfig:
+          issuerUrl: https://dex.CLUSTER_NAME.BASE_DOMAIN
+          clientId: dex-k8s-authenticator
+          usernameClaim: email
+          groupsClaim: groups
+          identityProviderConfigName: dex-k8s-authenticator
 ```
 
 {{< /tab >}}


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/3389


### What this PR does / why we need it

<!-- Please mention any GitHub issue, set a descriptive PR title, and use this space for additional explanations. -->

- In order to get Dex working for CAPA EKS workload cluster, Athena needs to be configured to use AWS-provided EKS API server endpoint. This PR fixes the docs to mention that.
- The `oidc` property on EKS is different (`global.controlPlane. oidcIdentityProviderConfig` than other CAPI provider (`global.controlPlane.oidc`), as such added new section for it.

### Things to check/remember before submitting

- If you made content changes

    - Run `make dev` to render and proofread content changes locally.
    - Bump `last_review_date` in the front matter header if you reviewed the entire page.
