### PR TITLE
Improve prose linting configuration

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -4,9 +4,27 @@ Vocab = docs
 
 Packages = Hugo, Microsoft
 
-[*.md]
+[src/content/*.md]
 MinAlertLevel = suggestion
 BasedOnStyles = Vale, Microsoft
 
-# Microsoft.We disallows the use of "we" or "us". We are using this in many places for now.
+# Microsoft.We disallows the use of "we" or "us". At Giant Swarm we are using this in many places for now.
 Microsoft.We = NO
+
+# No linting at all for the /vintage section
+[src/content/vintage/*.md]
+MinAlertLevel = error
+BasedOnStyles = Vale
+Vale.Avoid = NO
+Vale.Repetition = NO
+Vale.Spelling = NO
+Vale.Terms = NO
+
+# No linting at all for the /changes section
+[src/content/changes/*.md]
+MinAlertLevel = error
+BasedOnStyles = Vale
+Vale.Avoid = NO
+Vale.Repetition = NO
+Vale.Spelling = NO
+Vale.Terms = NO

--- a/.vale/styles/Microsoft/HeadingPunctuation.yml
+++ b/.vale/styles/Microsoft/HeadingPunctuation.yml
@@ -10,4 +10,4 @@ action:
     - trim_right
     - ".?!"
 tokens:
-  - '[a-z][.?!](?:\s|$)'
+  - "[a-z][.?!]$"

--- a/.vale/styles/config/vocabularies/docs/reject.txt
+++ b/.vale/styles/config/vocabularies/docs/reject.txt
@@ -1,3 +1,2 @@
-giantnetes
-k8s
-K8s
+[gG]iantnetes
+[kK]8s(?!-initiator-app)

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,6 @@ lint-prose:
 		-w /workdir \
 		$(VALE_IMAGE) \
 		--config=/workdir/.vale.ini \
-		--glob '!{src/content/vintage/**,src/content/changes/**}' \
 		--no-wrap \
 		src/content
 


### PR DESCRIPTION
This PR improves the vale config in two ways:

1. Exclusion of the `vintage` and `changes` directories is now done in the main config file. This way, the `--glob` flag is no longer necessary. Also linting in VS code works on the same files as executing `make lint-prose` or `vale .` does.
2. The term `k8s-initiator-app` now is excluded from the rule to avoid the term `k8s`

Regarding (2): once we need to exclude several terms from this rule, we have to update the matching pattern in reject.txt.

Also I updated 3rd party rules via `make lint-prose-update`.
