### PR TITLE
crd.template: add alias for release docs link

### DIFF
--- a/scripts/update-crd-reference/crd.template
+++ b/scripts/update-crd-reference/crd.template
@@ -51,6 +51,7 @@ owner:
 {{- end }}
 aliases:
   - /use-the-api/management-api/crd/{{ .NamePlural }}.{{ .Group }}/
+  - /reference/cp-k8s-api/{{ .NamePlural }}.{{ .Group }}/
 technical_name: {{ .NamePlural }}.{{ .Group }}
 source_repository: {{ .SourceRepository }}
 source_repository_ref: {{ .SourceRepositoryRef }}


### PR DESCRIPTION
### Summary

This PR adds an alias to `crd.template` to fix the 404 when following the link in the annotation in: https://github.com/giantswarm/releases/blob/master/aws/v20.1.1/release.yaml

Slack thread: https://gigantic.slack.com/archives/C03FYAV8U/p1718274391921489
