### PR TITLE
Adapt automated content scripts to Azure releases

### DIFF
--- a/scripts/aggregate-changelogs/script.py
+++ b/scripts/aggregate-changelogs/script.py
@@ -147,7 +147,7 @@ def get_cluster_releases(repo_shortname):
             for root, version_dirs, _ in os.walk(tmpdir+"/"+repo+"/"+provider):
                 for version_dir in version_dirs:
 
-                    // Skip archived releases
+                    print(f'Skipping archived releases for {provider}')
                     if version_dir == 'archived':
                         continue
 

--- a/scripts/aggregate-changelogs/script.py
+++ b/scripts/aggregate-changelogs/script.py
@@ -143,9 +143,14 @@ def get_cluster_releases(repo_shortname):
         (org, repo) = repo_shortname.split("/", maxsplit=1)
 
         provider = None
-        for provider in ['aws', 'azure', 'capa', 'capz', 'capv', 'capvcd']:
+        for provider in ['aws', 'azure', 'capa', 'vsphere', 'cloud-director']:
             for root, version_dirs, _ in os.walk(tmpdir+"/"+repo+"/"+provider):
                 for version_dir in version_dirs:
+
+                    // Skip archived releases
+                    if version_dir == 'archived':
+                        continue
+
                     print(f'Parsing provider in {provider} -  dir in {version_dir}')
                     for root_dir, _, files in os.walk(path.join(root, version_dir)):
                         relative_dir_path = root_dir[len(tmpdir + "/" + repo + "/"):]
@@ -238,7 +243,7 @@ def generate_release_file(repo_shortname, repo_config, release, delete):
             provider_label = 'Azure'
         categories = [f'Workload cluster releases for {provider_label}']
         # CAPI releases already have provider
-        if release['provider'] in ['capa', 'capz', 'capv', 'capvcd']:
+        if release['provider'] in ['azure', 'capa', 'vsphere', 'cloud-director']:
             filename = f"{release['version_tag']}.md"
             title = f'Workload cluster release {version} for {provider_label}'
             description = f'Release notes for {provider_label} workload cluster release {version}, published on {release["date"].strftime("%d %B %Y, %H:%M")}.'

--- a/scripts/aggregate-changelogs/script.py
+++ b/scripts/aggregate-changelogs/script.py
@@ -144,12 +144,10 @@ def get_cluster_releases(repo_shortname):
 
         provider = None
         for provider in ['aws', 'azure', 'capa', 'vsphere', 'cloud-director']:
-            for root, version_dirs, _ in os.walk(tmpdir+"/"+repo+"/"+provider):
-                for version_dir in version_dirs:
+            for root, version_dirs, _ in os.walk(tmpdir+"/"+repo+"/"+provider, topdown=True):
+                version_dirs[:] = [d for d in version_dirs if d != "archived"]
 
-                    print(f'Skipping archived releases for {provider}')
-                    if version_dir == 'archived':
-                        continue
+                for version_dir in version_dirs:
 
                     print(f'Parsing provider in {provider} -  dir in {version_dir}')
                     for root_dir, _, files in os.walk(path.join(root, version_dir)):


### PR DESCRIPTION
### What this PR does / why we need it

This fixes two problems with the [latest automated PR](https://github.com/giantswarm/docs/pull/2264):
* The provider name was being added twice in the path name for azure (`/changes/tenant-cluster-releases-azure/releases/azure-azure-25.0.0/`).
* The PR was adding all archived released for Azure to the docs so we need to skip publishing docs for archived releases.

<!-- Please mention any GitHub issue, set a descriptive PR title, and use this space for additional explanations. -->

### Things to check/remember before submitting

- If you made content changes

    - Run `make lint dev` to render and proofread content changes locally.
    - Bump `last_review_date` in the front matter header if you reviewed the entire page.
