### PR TITLE
Add TelemetryDeck script to template

### DIFF
--- a/src/layouts/partials/scripts.html
+++ b/src/layouts/partials/scripts.html
@@ -11,4 +11,4 @@
 <!-- Start of HubSpot Embed Code -->
 <script type="text/javascript" id="hs-script-loader" async defer src="//js.hs-scripts.com/430224.js"></script>
 <!-- End of HubSpot Embed Code -->
-<script src="https://cdn.telemetrydeck.com/websdk/telemetrydeck.min.js" data-app-id="E5CE9FFF-1EA0-456D-9227-B90193F33F94"></script>
+<script async src="https://cdn.telemetrydeck.com/websdk/telemetrydeck.min.js" data-app-id="E5CE9FFF-1EA0-456D-9227-B90193F33F94"></script>

--- a/src/layouts/partials/scripts.html
+++ b/src/layouts/partials/scripts.html
@@ -11,3 +11,4 @@
 <!-- Start of HubSpot Embed Code -->
 <script type="text/javascript" id="hs-script-loader" async defer src="//js.hs-scripts.com/430224.js"></script>
 <!-- End of HubSpot Embed Code -->
+<script src="https://cdn.telemetrydeck.com/websdk/telemetrydeck.min.js" data-app-id="E5CE9FFF-1EA0-456D-9227-B90193F33F94"></script>


### PR DESCRIPTION
### What this PR does / why we need it

Towards https://github.com/giantswarm/giantswarm/issues/31025

We want general usage data of our UIs and documentation site. For that we are testing TelemetryDeck as a privacy-friendly solution.

Merging this PR will result in pageview signals being sent to TelemetryDeck servers, without any personally identifiable information.