### PR TITLE
Remove outdated content from happa usage tracking info

### DIFF
--- a/src/content/vintage/platform-overview/web-interface/usage-data.md
+++ b/src/content/vintage/platform-overview/web-interface/usage-data.md
@@ -18,45 +18,6 @@ user_questions:
 last_review_date: 2023-03-20
 ---
 
-In general, when using the Giant Swarm web interface, usage data is collected on these levels:
-
-- The REST API level
-- Usage monitoring
-- Error data collection
-
-Here we explain the different purposes and what data is recorded.
-
-## REST API level
-
-Each request to our [REST API]({{< relref "/vintage/use-the-api/rest-api" >}}) is logged for auditing purposes, in case a customer wants to understand modifications made to resources, e. g. the creation or deletion of a cluster.
-
-Note: This is not only the case when using the web interface, but occurs independent of the type of client using the API.
-
-The data stored for each log entry consists of:
-
-- The unique user ID associated with the session token authenticating the request.
-- The Path of the API method called (e. g. `/v4/clusters/:clusterID/status/`).
-- The HTTP method (e. g. `GET`, `POST`, `DELETE`).
-- The date and time when the request has been received.
-
-## Usage monitoring
-
-When using the web interface, some anonymous usage data is collected using a dedicated monitoring service. The recorded data serves several purposes:
-
-- to help Giant Swarm understand how users use the web interface
-- to identify performance problems in real world usage
-
-The data recorded consists of:
-
-- Timestamp
-- Client data: Browser brand and version, device type, display and viewport size.
-- The URL viewed.
-- Performance related data related to network transfers, content rendering, application readiness.
-
-The data is submitted to a service in the Giant Swarm management cluster.
-
-## Error data collection
-
 We like to learn about any exceptions (unexpected errors) happening during web interface usage, hence we forward information about exceptions to [Sentry](https://sentry.io/welcome/).
 
 Data submitted to sentry includes:


### PR DESCRIPTION
### What this PR does / why we need it

Since happa no longer interacts with the Rest API, and we are removing the Real User Monitoring code, only Sentry is left.

Towards https://github.com/giantswarm/giantswarm/issues/31025
