### PR TITLE
Replace "UIs and APIs" vintage link with "Reference"

### DIFF
--- a/src/layouts/index.html
+++ b/src/layouts/index.html
@@ -45,8 +45,8 @@
 
   <div class="row">
     <div class="col-xs-12 col-sm-4">
-      <h3><a href="/vintage/use-the-api/">UIs and APIs</a></h3>
-      <p class="intro">Ways to interact with your infrastructure and apps, from the web user interface to CLIs and APIs.</p>
+      <h3><a href="/reference/">Reference</a></h3>
+      <p class="intro">API documentation and CLI command reference.</p>
     </div>
     <div class="col-xs-12 col-sm-4">
       <h3><a href="/vintage/support/">Support & Training</a></h3>


### PR DESCRIPTION
This PR swaps the front page link "UIs and APIs" with "Reference".

![image](https://github.com/user-attachments/assets/1a0b5207-3688-46eb-9050-5ce37b3ed7cb)
