### PR TITLE
sidebarSearchForm: set absolute width/height to prevent reflow

### DIFF
--- a/src/assets/styles/base.sass
+++ b/src/assets/styles/base.sass
@@ -76,6 +76,9 @@ abbr[title]
 #sidebarSearchForm
   font-size: 14px
   margin: 28px 0 28px auto
+  // match Inkeep's dimensions to avoid visible reflow
+  width: 262.5px
+  height: 40px
 
   input
     width: 160px

--- a/src/assets/styles/base.sass
+++ b/src/assets/styles/base.sass
@@ -80,21 +80,21 @@ abbr[title]
   width: 262.5px
   height: 40px
 
-  input
-    width: 160px
-    font-size: 14px
-    padding: 2px
-    padding-bottom: 2px
-    padding-top: 2px
-    padding-left: 4px
-    padding-right: 2px
-    line-height: 17px
-    height: 32px
+  //input
+  //  width: 160px
+  //  font-size: 14px
+  //  padding: 2px
+  //  padding-bottom: 2px
+  //  padding-top: 2px
+  //  padding-left: 4px
+  //  padding-right: 2px
+  //  line-height: 17px
+  //  height: 32px
 
-  button
-    height: 32px
-    border: none
-    padding: 0px 4px
+  //button
+  //  height: 32px
+  //  border: none
+  //  padding: 0px 4px
 
   .form-group
     display: inline-block


### PR DESCRIPTION
### Summary

Set `width` and `height` to empty search button container to avoid ugly visible reflow of sidebar menu during navigation.

@marians Not sure if this is the correct or best way to do it, but it leads to the desired result on a desktop browser.

### Note

Eyesore originally detected while reviewing: https://github.com/giantswarm/docs/pull/2346
