### PR TITLE
Use title instead of linkTitle in list layout

### DIFF
--- a/src/layouts/_default/list.html
+++ b/src/layouts/_default/list.html
@@ -12,7 +12,7 @@
     {{ partial "menu" . }}
   </div>
   <div class="col-sm-12 col-md-8 col-lg-7 list-content">
-    <h1 id="title">{{ .LinkTitle }}</h1>
+    <h1 id="title">{{ .Title }}</h1>
 
     {{ if or .Description .Content }}
       {{- with .Description -}}
@@ -29,7 +29,7 @@
       <ul class="linklist">
         {{ range .Pages.ByWeight }}
         <li>
-          <a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a>
+          <a href="{{ .RelPermalink }}">{{ .Title }}</a>
           <div class="meta">{{ .Description }}</div>
         </li>
         {{ end }}


### PR DESCRIPTION
In general, I think, we should use the long title form as the header in list templates.

The short title form (`linkTitle`) should only be used in the menu and breadcrumb, where space is heavily constrained.

This PR makes the according switch. I expect that we want to tweak some titles as a consequence, as they might be too long.

Before:

![image](https://github.com/user-attachments/assets/cfcb2d86-93e5-493c-a6d4-71f892a37bbb)

After:

![image](https://github.com/user-attachments/assets/c2d598e1-0a40-4061-a6a7-c5b53496235e)
