### PR TITLE
Fix duplicate identifier in menu

### DIFF
--- a/src/content/tutorials/security/tls-certificates/index.md
+++ b/src/content/tutorials/security/tls-certificates/index.md
@@ -6,7 +6,7 @@ weight: 50
 menu:
   principal:
     parent: tutorials-security
-    identifier: tutorials-security-rbac
+    identifier: tutorials-security-ingresstls
 user_questions:
   - How do I obtain TLS certificates?
 last_review_date: 2024-12-03


### PR DESCRIPTION
The `tutorials-security-rbac` was used twice.