### PR TITLE
Remove link check for changes section

### DIFF
--- a/.github/workflows/check-links-in-prod.yaml
+++ b/.github/workflows/check-links-in-prod.yaml
@@ -89,24 +89,6 @@ jobs:
             || echo "failed5=true" >> "$GITHUB_ENV"
         continue-on-error: true
 
-      - name: check-links-in-changelogs
-        run: |
-          docker run --rm --name linkchecker \
-            --volume ${PWD}/output:/workdir --workdir /workdir \
-            ghcr.io/linkchecker/linkchecker:latest \
-            https://docs.giantswarm.io/changes/ \
-            --threads 1 \
-            --recursion-level 2 \
-            --no-status \
-            --file-output html/utf8/changes.html \
-            --ignore-url="^https://github.com/giantswarm/docs/.*" \
-            --ignore-url="^https://.*example\.com/.*" \
-            --ignore-url="^https://my-org\.github\.com/.*" \
-            --ignore-url="^https://github\.com/giantswarm/giantswarm/.*" \
-            --ignore-url=".*gigantic\.io.*" \
-            || echo "failed6=true" >> "$GITHUB_ENV"
-        continue-on-error: true
-
       - name: Store reports as artifacts
         uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.2
         with:
@@ -135,10 +117,6 @@ jobs:
           fi
           if [[ $failed5 == "true" ]]; then
             echo "There has been some errors in support checks, please check the step."
-            failed=true
-          fi
-          if [[ $failed6 == "true" ]]; then
-            echo "There has been some errors in changelogs checks, please check the step."
             failed=true
           fi
           if [[ $failed == "true" ]]; then


### PR DESCRIPTION
This removes the link checking for the Changes and Releases sections, as it's not realistic that we maintain outgoing links in changelogs.