### PR TITLE
Fix menu for vintage cluster sizing page

### DIFF
--- a/src/content/vintage/getting-started/sizing-multi-tenancy/index.md
+++ b/src/content/vintage/getting-started/sizing-multi-tenancy/index.md
@@ -5,12 +5,7 @@ description: Recommendations and best practices around cluster and node sizing a
 weight: 50
 menu:
   main:
-    parent: support-training
-aliases:
-  - /getting-started/sizing-multi-tenancy
-  - /getting-started/best-practices/
-  - /guides/recommendations-and-best-practices/
-  - /kubernetes/best-practices/
+    parent: getting-started
 owner:
   - https://github.com/orgs/giantswarm/teams/team-teddyfriends
 user_questions:


### PR DESCRIPTION
For this bad boy:

![image](https://github.com/user-attachments/assets/05b16246-d8d7-4a07-aad1-43a18fce6b3e)
