### PR TITLE
Update list of Observability Platform repositories watched for changes

### DIFF
--- a/scripts/aggregate-changelogs/config.yaml
+++ b/scripts/aggregate-changelogs/config.yaml
@@ -83,8 +83,6 @@ repositories:
     category: Observability Platform
   giantswarm/grafana-agent-app:
     category: Observability Platform
-  giantswarm/grafana-multi-tenant-proxy:
-    category: Observability Platform
   giantswarm/happa:
     category: Web UI
   giantswarm/hello-world-app:

--- a/scripts/aggregate-changelogs/config.yaml
+++ b/scripts/aggregate-changelogs/config.yaml
@@ -14,6 +14,8 @@ repositories:
     category: Platform API
   giantswarm/alloy-app:
     category: Observability Platform
+  giantswarm/alloy-gateway-app:
+    category: Observability Platform
   giantswarm/aws-admission-controller:
     category: Platform API
   giantswarm/azure-admission-controller:
@@ -81,6 +83,8 @@ repositories:
     category: Observability Platform
   giantswarm/grafana-agent-app:
     category: Observability Platform
+  giantswarm/grafana-multi-tenant-proxy:
+    category: Observability Platform
   giantswarm/happa:
     category: Web UI
   giantswarm/hello-world-app:
@@ -111,6 +115,8 @@ repositories:
     category: Platform API
   giantswarm/mimir-app:
     category: Observability Platform
+  giantswarm/observability-bundle:
+    category: Observability Platform
   giantswarm/prometheus-operator-app:
     category: Observability Platform
   giantswarm/promtail-app:
@@ -119,6 +125,10 @@ repositories:
     category: Managed Apps
   giantswarm/rook-operator-app:
     category: Managed Apps
+  giantswarm/silence-operator:
+    category: Observability Platform
+  giantswarm/sloth-app:
+    category: Observability Platform
   giantswarm/starboard-app:
     category: Managed Apps
   giantswarm/starboard-exporter:
@@ -158,6 +168,8 @@ categories:
     color: "#8081b2"
   - name: Managed Apps
     color: "#7ac271"
+  - name: Observability Platform
+    color: "#f69917"
   - name: Workload cluster releases for AWS
     color: "#ff9900"
   - name: Workload cluster releases for CAPA


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/3788

Updating the list of watched repositories for changes to includes some of the newer observability related repositories.

Also brings more joy and a new color to the Observability Platform category.