### PR TITLE
Removing all references to api-spec

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -70,12 +70,10 @@ jobs:
           input: ./markdownlint-annotations.json
 
       - name: Fail if markdownlint had findings
+        if: ${{ env.found_markdown_issues == 'true' }}
         run: |
-          # If there are non-empty lines, we had linting findings
-          if [ "$(awk 1 < markdownlint.out | wc -l | awk '{print $1}')" != 0 ]; then
-            echo "ERROR: See markdownlint findings (annotated as errors in the PR when you click on 'Files changed')"
-            exit 1
-          fi
+          echo "ERROR: See markdownlint findings (annotated as errors in the PR when you click on 'Files changed')"
+          exit 1
 
       - name: Check file and folder names in content
         shell: python {0}

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -26,8 +26,11 @@ jobs:
             # Print for debugging
             printf "\nAnnotations JSON:\n"
             cat ./annotations.json
+
             # Save as environment variable for next step
-            echo "found_front_matter_issues=true" >> $GITHUB_ENV
+            if [ $(jq length < ./annotations.json) -gt 0 ]; then
+              echo "found_front_matter_issues=true" >> $GITHUB_ENV
+            fi
           fi
           rm files.txt
 

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -58,8 +58,9 @@ jobs:
           printf "\nAnnotations JSON:\n"
           cat ./markdownlint-annotations.json
           
-          # Save as environment variable for next step
-          echo "found_markdown_issues=true" >> $GITHUB_ENV
+          if [ $(jq length < ./markdownlint-annotations.json) -gt 0 ]; then
+            echo "found_markdown_issues=true" >> $GITHUB_ENV
+          fi
 
       - name: Send markdownlint annotations
         if: ${{ env.found_markdown_issues == 'true' }}

--- a/src/content/vintage/advanced/cluster-management/high-availability/control-plane/index.md
+++ b/src/content/vintage/advanced/cluster-management/high-availability/control-plane/index.md
@@ -107,11 +107,6 @@ The `gsctl` CLI as of v0.23.1 provides the
 [gsctl update cluster]({{< relref "/vintage/use-the-api/gsctl/update-cluster" >}}) to change cluster details.
 Check the reference for the `--master-ha` flag.
 
-### Via the REST API {#rest-api}
-
-Check the [v5 cluster modification API reference](https://giantswarm.github.io/api-spec/#operation/modifyClusterV5)
-to find out how to convert a cluster programmatically using the Giant Swarm REST API.
-
 ### Via the Management API {#management-api}
 
 In order to convert a single node control plane to high availability, the cluster's

--- a/src/content/vintage/advanced/cluster-management/high-availability/multi-az/index.md
+++ b/src/content/vintage/advanced/cluster-management/high-availability/multi-az/index.md
@@ -113,7 +113,6 @@ You can create clusters in several ways:
 
 - In the [web interface]({{< relref "/vintage/platform-overview/web-interface/" >}}).
 - In `gsctl` using the [`create cluster`]({{< relref "/vintage/use-the-api/gsctl/create-cluster" >}}) command with the appropriate details set in a [cluster definition]({{< relref "/vintage/use-the-api/gsctl/cluster-definition" >}}).
-- Via the [Giant Swarm REST API](https://giantswarm.github.io/api-spec/#operation/addCluster).
 
 When inspecting details of such a cluster, or using the [`gsctl show cluster`]({{< relref "/vintage/use-the-api/gsctl/show-cluster" >}}) command, we display the list of availability zones used by the cluster.
 

--- a/src/content/vintage/advanced/cluster-management/node-pools-vintage/index.md
+++ b/src/content/vintage/advanced/cluster-management/node-pools-vintage/index.md
@@ -162,20 +162,6 @@ Using multiple instance types in a node pool has some benefits:
 
 Instances that contain the same amount of CPU and RAM are considered similar. We provide more information regarding which instance types are considered similar in our [reference]({{< relref "/vintage/advanced/cluster-management/spot-instances/aws/similar-instance-types" >}}).
 
-## Node pools and the Giant Swarm REST API {#restapi}
-
-Handling clusters with node pools requires an API schema different from the one used for clusters
-with homogeneous worker nodes. To account for this need, we introduced a new API version path `v5`.
-
-Using the v5 API endpoints, you can
-
-- [Create a new cluster supporting node pools](https://giantswarm.github.io/api-spec/#operation/addClusterV5)
-- [Get node pools of a cluster](https://giantswarm.github.io/api-spec/#operation/getNodePools)
-- [Create a new node pool](https://giantswarm.github.io/api-spec/#operation/addNodePool)
-- [Modify a cluster](https://giantswarm.github.io/api-spec/#operation/modifyClusterV5)
-- [Modify a node pool](https://giantswarm.github.io/api-spec/#operation/modifyNodePool)
-- [Delete a node pool](https://giantswarm.github.io/api-spec/#operation/deleteNodePool)
-
 ## Node pools and the cluster definition YAML format
 
 Just as the Giant Swarm REST API schema for v4 (without node pools) and v5 (with node pools) clusters are different, the

--- a/src/content/vintage/advanced/infrastructure-management/multi-account/index.md
+++ b/src/content/vintage/advanced/infrastructure-management/multi-account/index.md
@@ -64,7 +64,7 @@ Details of the implementation differ between AWS and Azure.
 
 ## Get started
 
-To create clusters in a new cloud provider account, you first need to provide the credentials to the organization you'd like to use for this purpose. You are free to create a new organization for this purpose if you like. Organizations can be created in the Giant Swarm web UI, or via the [Giant Swarm REST API](https://giantswarm.github.io/api-spec/#operation/addOrganization).
+To create clusters in a new cloud provider account, you first need to provide the credentials to the organization you'd like to use for this purpose. You are free to create a new organization for this purpose if you like. Organizations can be created in the Giant Swarm web UI.
 
 To prepare your credentials, either as AWS account roles or as an Azure service principle, please follow our specific guides:
 
@@ -75,7 +75,6 @@ You can then assign the credentials to your organization in several ways:
 
 - In the Giant Swarm web UI via the organization details page
 - In `gsctl` using the [`update organization set-credentials`]({{< relref "/vintage/use-the-api/gsctl/update-org-set-credentials" >}}) command
-- Via the [Giant Swarm REST API](https://giantswarm.github.io/api-spec/#operation/addCredentials)
 
 All workload clusters created for that organization will then use the credentials provided to the organization and will reside in the account/subscription associated with them.
 

--- a/src/content/vintage/getting-started/app-platform/app-configuration/index.md
+++ b/src/content/vintage/getting-started/app-platform/app-configuration/index.md
@@ -405,17 +405,6 @@ colors:
    secretColor: "blue"
 ```
 
-### Using the REST API (deprecated) {#giant-swarm-api}
-
-The [Giant Swarm REST API]({{< relref "/vintage/use-the-api/rest-api" >}}) acts as an interface between you and the [Management
-API]({{< relref "/vintage/use-the-api/management-api" >}}). It is deprecated since we are currently in the process of allowing you direct
-access to the Management API. However, for the time being, our web interface makes use of the Giant Swarm REST API.
-
-By supplying a JSON body with the values you would like to set, the Giant Swarm REST API will
-create a ConfigMap or Secret in the right format and wire it up correctly for you.
-
-- [REST API App Configs reference](https://giantswarm.github.io/api-spec/#tag/app-configs) for adding configuration values
-- [REST API App Secrets reference](https://giantswarm.github.io/api-spec/#tag/app-secrets) for adding secret values
 
 ### Using the Management API {#management-api}
 

--- a/src/content/vintage/getting-started/app-platform/app-configuration/index.md
+++ b/src/content/vintage/getting-started/app-platform/app-configuration/index.md
@@ -405,7 +405,6 @@ colors:
    secretColor: "blue"
 ```
 
-
 ### Using the Management API {#management-api}
 
 There are many approaches to managing resources in Kubernetes, which go beyond

--- a/src/content/vintage/getting-started/cloud-provider-accounts/cluster-api/aws/_index.md
+++ b/src/content/vintage/getting-started/cloud-provider-accounts/cluster-api/aws/_index.md
@@ -101,8 +101,6 @@ This CR needs to be created only once for each AWS Account. It can be then refer
 ## Further reading
 
 - [Basics and Concepts: Multi Account Support]({{< relref "/vintage/advanced/infrastructure-management/multi-account" >}})
-- [API: Set credentials](https://giantswarm.github.io/api-spec/#operation/addCredentials)
 - [Giant Swarm Architecture]({{< relref "/vintage/platform-overview/cluster-management/vintage/aws" >}})
-- [Giant Swarm REST API documentation](https://giantswarm.github.io/api-spec/)
 - [AWS Service Limits](https://docs.aws.amazon.com/general/latest/gr/aws_service_limits.html)
 - [AWS Support Center](https://console.aws.amazon.com/support/home)

--- a/src/content/vintage/getting-started/cloud-provider-accounts/vintage/aws/index.md
+++ b/src/content/vintage/getting-started/cloud-provider-accounts/vintage/aws/index.md
@@ -277,9 +277,7 @@ organization. These clusters' resources will be created in your AWS account.
 
 - [Basics and Concepts: Multi Account Support]({{< relref "/vintage/advanced/infrastructure-management/multi-account" >}})
 - [gsctl Reference: `update organization set-credentials`]({{< relref "/vintage/use-the-api/gsctl/update-org-set-credentials" >}})
-- [API: Set credentials](https://giantswarm.github.io/api-spec/#operation/addCredentials)
 - [Giant Swarm Architecture]({{< relref "/vintage/platform-overview/cluster-management/vintage/aws" >}})
-- [Giant Swarm REST API documentation](https://giantswarm.github.io/api-spec/)
 - [AWS Service Limits](https://docs.aws.amazon.com/general/latest/gr/aws_service_limits.html)
 - [AWS Support Center](https://console.aws.amazon.com/support/home)
 

--- a/src/content/vintage/getting-started/operations/autoscaling/cluster-size/index.md
+++ b/src/content/vintage/getting-started/operations/autoscaling/cluster-size/index.md
@@ -93,8 +93,4 @@ In workload clusters without autoscaling support, the number of Ingress Controll
 - [`gsctl create cluster`]({{< relref "/vintage/use-the-api/gsctl/create-cluster" >}}): Creating a cluster
 - [`gsctl scale cluster`]({{< relref "/vintage/use-the-api/gsctl/scale-cluster" >}}): Scaling a cluster
 - [`gsctl show cluster`]({{< relref "/vintage/use-the-api/gsctl/show-cluster" >}}): Inspecting a cluster
-- [API: Create cluster](https://giantswarm.github.io/api-spec/#operation/addCluster)
-- [API: Modify cluster](https://giantswarm.github.io/api-spec/#operation/modifyCluster)
-- [API: Get cluster details](https://giantswarm.github.io/api-spec/#operation/getCluster)
-- [API: Get cluster status](https://giantswarm.github.io/api-spec/#operation/getClusterStatus)
 - [Kubernetes autoscaler FAQ](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md)

--- a/src/content/vintage/platform-overview/app-platform/index.md
+++ b/src/content/vintage/platform-overview/app-platform/index.md
@@ -141,7 +141,6 @@ You can interact with the Giant Swarm App Platform through creating App custom r
 
 - [App CRD reference]({{< relref "/vintage/use-the-api/management-api/crd/apps.application.giantswarm.io.md" >}})
 - [Web Interface Reference: The Giant Swarm App Platform]({{< relref "/vintage/platform-overview/web-interface/app-platform" >}})
-- [Apps and App Configs in the API reference](https://giantswarm.github.io/api-spec/#tag/apps)
 
 Both our web interface and REST API are used to create (or update) a set of App Custom Resources on your Kubernetes management cluster.
 

--- a/src/content/vintage/platform-overview/cluster-management/cluster-upgrades/index.md
+++ b/src/content/vintage/platform-overview/cluster-management/cluster-upgrades/index.md
@@ -108,8 +108,6 @@ Note that by default, our user interfaces upgrade to the next active workload cl
 
 - In **kubectl-gs**, the [`update cluster`]({{< relref "/reference/kubectl-gs/update-cluster" >}})) command provides an optional flag `--release-version` which allows to specify the version to upgrade to.
 
-- Alternatively, you can use the [Giant Swarm REST API](https://giantswarm.github.io/api-spec/#operation/modifyClusterV5) or the [Management API]({{< relref "/vintage/use-the-api/management-api" >}}) to trigger the upgrade. Please talk to your Account Engineer in case you have any questions regarding this.
-
 ## How upgrades work
 
 All levels of upgrades, patch, minor, or major, are happening at runtime.

--- a/src/content/vintage/use-the-api/gsctl/cluster-definition.md
+++ b/src/content/vintage/use-the-api/gsctl/cluster-definition.md
@@ -86,7 +86,7 @@ workers:
 - `owner`: Name of the owner organization.
 - `name`: Friendly name of the cluster. If not specified, a name will be generated.
 - `release_version`: Allows to select a specific release version. The value must be the semantic version number (SemVer) of an active release. To get information on all available releases, use the [`gsctl list releases`]({{< relref "/vintage/use-the-api/gsctl/list-releases" >}}) command.
-- `availability_zones`: Number of availability zones to use for worker nodes (on AWS and Azure only). Both the default value and the maximum can be obtained via the [Info endpoint](https://giantswarm.github.io/api-spec/#operation/getInfo) of the Giant Swarm REST API.
+- `availability_zones`: Number of availability zones to use for worker nodes (on AWS and Azure only).
 - `workers`: Array of node definition objects describing each worker node. See below for possible keys. If not specified, the default number of worker nodes with default settings will be created.
 
 #### Node definition keys {#node-keys}
@@ -218,6 +218,3 @@ Chances are that you already work with YAML in various places. If not, here are 
 - [`gsctl create cluster`]({{< relref "/vintage/use-the-api/gsctl/create-cluster" >}}): Create a cluster based on flags, or a definition file
 - [`gsctl create nodepool`]({{< relref "/vintage/use-the-api/gsctl/create-nodepool" >}})
 - [`gsctl list releases`]({{< relref "/vintage/use-the-api/gsctl/list-releases" >}}): Listing available releases
-- [API: Create cluster (v4)](https://giantswarm.github.io/api-spec/#operation/addCluster)
-- [API: Create cluster (v5)](https://giantswarm.github.io/api-spec/#operation/addClusterV5)
-- [API: Create node pool](https://giantswarm.github.io/api-spec/#operation/addNodePool)

--- a/src/content/vintage/use-the-api/gsctl/create-cluster.md
+++ b/src/content/vintage/use-the-api/gsctl/create-cluster.md
@@ -113,5 +113,3 @@ When requesting cluster creation with workload cluster release v{{% first_aws_no
 - [`gsctl create kubeconfig`]({{< relref "/vintage/use-the-api/gsctl/create-kubeconfig" >}}) - Getting a key pair and enabling `kubectl` to access a cluster
 - [`gsctl delete cluster`]({{< relref "/vintage/use-the-api/gsctl/delete-cluster" >}}) - Deleting a cluster
 - [Basics: Cluster Size and Autoscaling]({{< relref "/vintage/getting-started/operations/autoscaling/cluster-size" >}})
-- [API: Create cluster (v4)](https://giantswarm.github.io/api-spec/#operation/addCluster)
-- [API: Create cluster (v5)](https://giantswarm.github.io/api-spec/#operation/addClusterV5)

--- a/src/content/vintage/use-the-api/gsctl/create-keypair.md
+++ b/src/content/vintage/use-the-api/gsctl/create-keypair.md
@@ -79,4 +79,3 @@ __Warning:__ Setting `system:masters` as an organization means the user who uses
 
 - [Creating workload cluster key pairs via the Management API]({{< relref "/vintage/use-the-api/management-api/wc-key-pairs" >}})
 - [`gsctl create kubeconfig`]({{< relref "/vintage/use-the-api/gsctl/create-kubeconfig" >}}): Create a key pair and prepare your kubectl configuration to access the cluster.
-- [Rest API: Create key pair](https://giantswarm.github.io/api-spec/#operation/addKeyPair)

--- a/src/content/vintage/use-the-api/gsctl/create-kubeconfig.md
+++ b/src/content/vintage/use-the-api/gsctl/create-kubeconfig.md
@@ -226,5 +226,4 @@ Passing flag `--output` with value `json` to `gsctl create kubeconfig` changes t
 - [Creating workload cluster key pairs via the Management API]({{< relref "/vintage/use-the-api/management-api/wc-key-pairs" >}})
 - [`gsctl create keypair`]({{< relref "/vintage/use-the-api/gsctl/create-keypair" >}}): Create and download a key pair
 - [kubectl reference](https://kubernetes.io/docs/reference/kubectl/overview/)
-- [API: Create key pair](https://giantswarm.github.io/api-spec/#operation/addKeyPair)
 - [Kubie](https://github.com/sbstp/kubie)

--- a/src/content/vintage/use-the-api/gsctl/delete-cluster.md
+++ b/src/content/vintage/use-the-api/gsctl/delete-cluster.md
@@ -82,4 +82,3 @@ Passing flag `--output` with value `json` to `gsctl delete cluster` changes the 
 
 - [`gsctl scale cluster`]({{< relref "/vintage/use-the-api/gsctl/scale-cluster" >}})
 - [`gsctl` reference overview]({{< relref "/vintage/use-the-api/gsctl" >}})
-- [API: Delete cluster](https://giantswarm.github.io/api-spec/#operation/deleteCluster)

--- a/src/content/vintage/use-the-api/gsctl/info.md
+++ b/src/content/vintage/use-the-api/gsctl/info.md
@@ -100,4 +100,3 @@ Maximum workers per cluster:  20
 ## Related
 
 - [`gsctl select endpoint`]({{< relref "/vintage/use-the-api/gsctl/select-endpoint" >}})
-- [API: Get information on the installation](https://giantswarm.github.io/api-spec/#operation/getInfo)

--- a/src/content/vintage/use-the-api/gsctl/list-clusters.md
+++ b/src/content/vintage/use-the-api/gsctl/list-clusters.md
@@ -63,4 +63,3 @@ Providing a small part of the column name is also accepted: `d`/`del`/`deleting`
 - [`gsctl create cluster`]({{< relref "/vintage/use-the-api/gsctl/create-cluster" >}})
 - [`gsctl scale cluster`]({{< relref "/vintage/use-the-api/gsctl/scale-cluster" >}})
 - [`gsctl delete cluster`]({{< relref "/vintage/use-the-api/gsctl/delete-cluster" >}})
-- [API: Get clusters](https://giantswarm.github.io/api-spec/#operation/getClusters)

--- a/src/content/vintage/use-the-api/gsctl/list-keypairs.md
+++ b/src/content/vintage/use-the-api/gsctl/list-keypairs.md
@@ -82,5 +82,4 @@ CREATED                 EXPIRES                 ID          DESCRIPTION         
 - [`gsctl create keypair`]({{< relref "/vintage/use-the-api/gsctl/create-keypair" >}})
 - [`gsctl create kubeconfig`]({{< relref "/vintage/use-the-api/gsctl/create-kubeconfig" >}})
 - [Securing your cluster with RBAC and PSP]({{< relref "/vintage/getting-started/security" >}})
-- [API: Get key pairs](https://giantswarm.github.io/api-spec/#operation/getKeyPairs)
 - [X.509 on Wikipedia](https://en.wikipedia.org/wiki/X.509)

--- a/src/content/vintage/use-the-api/gsctl/list-releases.md
+++ b/src/content/vintage/use-the-api/gsctl/list-releases.md
@@ -83,5 +83,4 @@ Output details:
 
 - [`gsctl create cluster`]({{< relref "/vintage/use-the-api/gsctl/create-cluster" >}})
 - [`gsctl show cluster`]({{< relref "/vintage/use-the-api/gsctl/show-cluster" >}})
-- [API: Get releases](https://giantswarm.github.io/api-spec/#operation/getReleases)
 - [`kubectl gs get releases`]({{< relref "/reference/kubectl-gs/get-releases" >}})

--- a/src/content/vintage/use-the-api/gsctl/login.md
+++ b/src/content/vintage/use-the-api/gsctl/login.md
@@ -50,7 +50,3 @@ syntax is as follows:
 ```nohighlight
 gsctl login <email> -e <endpoint> -p <password>
 ```
-
-## Related
-
-- [API: Create auth token](https://giantswarm.github.io/api-spec/#operation/createAuthToken)

--- a/src/content/vintage/use-the-api/gsctl/scale-cluster.md
+++ b/src/content/vintage/use-the-api/gsctl/scale-cluster.md
@@ -58,4 +58,3 @@ Use `gsctl scale cluster --help` for a additional (global) arguments.
 - [`gsctl update nodepool`]({{< relref "/vintage/use-the-api/gsctl/update-nodepool" >}}): Among others, allows to scale a node pool
 - [`gsctl delete cluster`]({{< relref "/vintage/use-the-api/gsctl/delete-cluster" >}}): Delete a cluster
 - [Basics: Cluster Size and Autoscaling]({{< relref "/vintage/getting-started/operations/autoscaling/cluster-size" >}})
-- [API: Modify cluster](https://giantswarm.github.io/api-spec/#operation/modifyCluster)

--- a/src/content/vintage/use-the-api/gsctl/show-cluster.md
+++ b/src/content/vintage/use-the-api/gsctl/show-cluster.md
@@ -109,4 +109,3 @@ Note that some dynamic pieces of information, like the current number of workers
 - [`gsctl list clusters`]({{< relref "/vintage/use-the-api/gsctl/list-clusters" >}})
 - [`gsctl scale cluster`]({{< relref "/vintage/use-the-api/gsctl/scale-cluster" >}})
 - [`gsctl delete cluster`]({{< relref "/vintage/use-the-api/gsctl/delete-cluster" >}})
-- [API: Get cluster details](https://giantswarm.github.io/api-spec/#operation/getCluster)

--- a/src/content/vintage/use-the-api/gsctl/update-cluster.md
+++ b/src/content/vintage/use-the-api/gsctl/update-cluster.md
@@ -71,7 +71,4 @@ To remove a label, set its key to an empty string (`labeltodelete=`).
 
 - [`gsctl create cluster`]({{< relref "/vintage/use-the-api/gsctl/create-cluster" >}}) - Add a node pool to a cluster
 - [`gsctl list clusters`]({{< relref "/vintage/use-the-api/gsctl/list-clusters" >}}) - List all node pools of a cluster
-- [API: Modify cluster (v4)](https://giantswarm.github.io/api-spec/#operation/modifyCluster)
-- [API: Modify cluster (v5)](https://giantswarm.github.io/api-spec/#operation/modifyClusterV5)
-- [API: Update cluster labels](https://giantswarm.github.io/api-spec/#operation/setClusterLabels)
 - [Labelling workload clusters]({{< relref "/vintage/advanced/cluster-management/labelling-workload-clusters" >}})

--- a/src/content/vintage/use-the-api/gsctl/update-org-set-credentials.md
+++ b/src/content/vintage/use-the-api/gsctl/update-org-set-credentials.md
@@ -79,4 +79,3 @@ The flags mean:
 - [Basics and Concepts: Multi-Account Support]({{< relref "/vintage/advanced/infrastructure-management/multi-account" >}})
 - [Guides: Prepare an AWS account to run Giant Swarm workload clusters]({{< relref "/vintage/getting-started/cloud-provider-accounts/vintage/aws" >}})
 - [Guides: Prepare an Azure subscription to run Giant Swarm workload clusters]({{< relref "/vintage/getting-started/cloud-provider-accounts/vintage/azure" >}})
-- [API: Set credentials](https://giantswarm.github.io/api-spec/#operation/addCredentials)

--- a/src/content/vintage/use-the-api/gsctl/upgrade-cluster.md
+++ b/src/content/vintage/use-the-api/gsctl/upgrade-cluster.md
@@ -49,4 +49,3 @@ You can list available workload cluster releases with `gsctl list releases`.
 - [`gsctl create cluster`]({{< relref "/vintage/use-the-api/gsctl/create-cluster" >}}): Reference for creating a cluster
 - [`gsctl delete cluster`]({{< relref "/vintage/use-the-api/gsctl/delete-cluster" >}}): Reference for deleting a cluster
 - [`gsctl list releases`]({{< relref "/vintage/use-the-api/gsctl/list-releases" >}}): Reference for listing available workload cluster releases
-- [API: Upgrade cluster](https://giantswarm.github.io/api-spec/#operation/upgradeCluster)

--- a/src/content/vintage/use-the-api/rest-api/index.md
+++ b/src/content/vintage/use-the-api/rest-api/index.md
@@ -25,4 +25,3 @@ Since its inception at Giant Swarm, we learned that there are always more use ca
 With this realization, we made the decision to **phase out the development of the REST API** in favor of providing access to the [Management API]({{< relref "/vintage/use-the-api/management-api" >}}) instead.
 
 As of now, there is no termination date for the REST API. It is however **not available anymore for [newer generations of the platform]({{< relref "/vintage/platform-overview/cluster-management/cloud-provider-implementations" >}})**.
-

--- a/src/content/vintage/use-the-api/rest-api/index.md
+++ b/src/content/vintage/use-the-api/rest-api/index.md
@@ -26,6 +26,3 @@ With this realization, we made the decision to **phase out the development of th
 
 As of now, there is no termination date for the REST API. It is however **not available anymore for [newer generations of the platform]({{< relref "/vintage/platform-overview/cluster-management/cloud-provider-implementations" >}})**.
 
-## Further reading
-
-- [REST API documentation](https://giantswarm.github.io/api-spec/)


### PR DESCRIPTION
Removes all pointers to api-spec.

Part of a larger removal of REST API related content.

This also adapts the validate workflow, which failed at the wrong place without the adaptation. The reason I think is that ubuntu-latest is now 24.04 and there are some shell tool changes.