### PR TITLE
Add mention to China ICP Recordal process

### DIFF
--- a/src/content/getting-started/prepare-your-provider-infrastructure/aws/_index.md
+++ b/src/content/getting-started/prepare-your-provider-infrastructure/aws/_index.md
@@ -225,9 +225,7 @@ In the [next step]({{< relref "/getting-started/provision-your-first-workload-cl
 
 **Note**: In case you are working with a Giant Swarm partner, you might not have access to the platform API. In that case, please provide the role ARNs values, CAPA controller and staff to your partner contact.
 
-## China
-
-If you AWS account is a China account, make sure to follow [the ICP Filing process](https://www.amazonaws.cn/en/support/icp/).
+**Warning**: If you AWS account is a China account, make sure to follow [the ICP Filing process](https://www.amazonaws.cn/en/support/icp/).
 
 ## Next steps
 

--- a/src/content/getting-started/prepare-your-provider-infrastructure/aws/_index.md
+++ b/src/content/getting-started/prepare-your-provider-infrastructure/aws/_index.md
@@ -225,6 +225,10 @@ In the [next step]({{< relref "/getting-started/provision-your-first-workload-cl
 
 **Note**: In case you are working with a Giant Swarm partner, you might not have access to the platform API. In that case, please provide the role ARNs values, CAPA controller and staff to your partner contact.
 
+## China
+
+If you AWS account is a China account, make sure to follow [the ICP Filing process](https://www.amazonaws.cn/en/support/icp/).
+
 ## Next steps
 
 Contact your Giant Swarm account engineer to verify the setup and proceed with the provisioning of the management cluster. For sharing any secret with us please read [this article]({{< relref "/overview/security/sharing-secrets" >}}) first. In case you have already set up the management cluster and you have just configured a new AWS account, you can proceed with the [creation of the workload cluster]({{< relref "/getting-started/provision-your-first-workload-cluster" >}}).


### PR DESCRIPTION
### What this PR does / why we need it

When creating the new MC on China, the S3 bucket configuration couldn't be accessed publicly, because the ICP process was not followed by the customer.
