### PR TITLE
Fix exception handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,0 @@
-#### Changelog.md dummy

--- a/scripts/aggregate-changelogs/script.py
+++ b/scripts/aggregate-changelogs/script.py
@@ -8,7 +8,7 @@ import tempfile
 from dateutil.parser import parse
 import git
 from github import Github
-from github.GithubException import UnknownObjectException
+from github.GithubException import UnknownObjectException, GithubException
 from yaml import load, dump, CLoader, CDumper
 
 CONFIG_PATH = sys.argv[1]
@@ -55,7 +55,7 @@ def get_changelog_file(client, repo_shortname):
     try:
         remote_file = repo.get_contents('CHANGELOG.md')
         return remote_file.decoded_content.decode('utf-8')
-    except UnknownObjectException:
+    except (UnknownObjectException, GithubException) as e:
         return None
 
 def parse_changelog(body, repo_shortname):


### PR DESCRIPTION
Added handling of Github exception, as it started failing for repos with no changelog while running `update-generated-content` as:

```
Repo giantswarm/docs
Getting releases for giantswarm/docs
Traceback (most recent call last):
  File "/workdir/script.py", line 333, in <module>
    changelog = get_changelog_file(g, repo_short)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workdir/script.py", line 56, in get_changelog_file
    remote_file = repo.get_contents('CHANGELOG.md')
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/github/Repository.py", line 2151, in get_contents
    headers, data = self._requester.requestJsonAndCheck(
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/github/Requester.py", line 494, in requestJsonAndCheck
    return self.__check(*self.requestJson(verb, url, parameters, headers, input, self.__customConnection(url)))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/github/Requester.py", line 525, in __check
    raise self.createException(status, responseHeaders, data)
github.GithubException.GithubException: 404 {"message": "No object found for the path CHANGELOG.md", "documentation_url": "https://docs.github.com/v3/repos/contents/", "status": "404"}
make: *** [Makefile:25: changes] Error 1
```

Successful action run: https://github.com/giantswarm/docs/pull/2461/files