### PR TITLE
dashboards: update doc according to multi-tenancy

### DIFF
--- a/src/content/getting-started/observe-your-clusters-and-apps/index.md
+++ b/src/content/getting-started/observe-your-clusters-and-apps/index.md
@@ -79,14 +79,14 @@ data:
 kind: ConfigMap
 metadata:
   annotations:
-    k8s-sidecar-target-directory: /var/lib/grafana/dashboards/customer
+    observability.giantswarm.io/organization: Customer
   labels:
     app.giantswarm.io/kind: dashboard
   name: my-grafana-dashboard
   namespace: my-namespace
 ```
 
-It's important to have an annotation with the key `k8s-sidecar-target-directory` pointing to the location where the dashboard will be stored in the `Grafana UI`. Also notice the label `app.giantswarm.io/kind` has to be set to `dashboard` in order to be recognized by the platform.
+It's important to have an annotation with the key `observability.giantswarm.io/organization` pointing to the organization where the dashboard will be stored in Grafana. Also notice the label `app.giantswarm.io/kind` has to be set to `dashboard` in order to be recognized by the platform.
 
 The easiest way to build a dashboard is using the Grafana UI. There, you can create panels with the desired visualizations and then export them by selecting `Share > Export`` in the dashboard context menu or by accessing the JSON Model in the dashboard settings.
 

--- a/src/content/getting-started/observe-your-clusters-and-apps/index.md
+++ b/src/content/getting-started/observe-your-clusters-and-apps/index.md
@@ -2,7 +2,7 @@
 title: Observe your clusters and apps
 description: Check cluster and app metrics with the observability tools provided with the Giant Swarm platform.
 weight: 60
-last_review_date: 2024-11-28
+last_review_date: 2025-02-10
 menu:
   principal:
     parent: getting-started
@@ -104,7 +104,7 @@ Then replace the `__DASHBOARD_JSON__` placeholder in the `ConfigMap` with the mi
 kubectl apply -f config-map.yaml
 ```
 
-After a few seconds, you can open the `Dashboards` view in the `Grafana` UI and find your custom dashboard in the `Customer` folder.
+After a few seconds, you can open the `Dashboards` view in the `Grafana` UI and, switch to the organization you selected, and find your custom dashboard.
 
 ![custom-dashboard](custom-dashboard.png)
 

--- a/src/content/tutorials/observability/data-exploration/creating-custom-dashboards/_index.md
+++ b/src/content/tutorials/observability/data-exploration/creating-custom-dashboards/_index.md
@@ -7,7 +7,7 @@ menu:
     identifier: tutorials-observability-data-exploration-create-custom-dashboards
     parent: tutorials-observability-data-exploration
 weight: 40
-last_review_date: 2024-07-17
+last_review_date: 2025-02-10
 user_questions:
   - How to customize dashboards?
   - How to create my own dashboards?
@@ -40,4 +40,5 @@ metadata:
 
 ### Limitations
 
-__Beware__ that the dashboard name must be unique so don't override one of your own.
+* the dashboard's json must contain an `uid` otherwise it won't be provisioned.
+* the dashboard name and uid must be unique in each grafana organization.

--- a/src/content/tutorials/observability/data-exploration/creating-custom-dashboards/_index.md
+++ b/src/content/tutorials/observability/data-exploration/creating-custom-dashboards/_index.md
@@ -25,14 +25,14 @@ To create your own dashboard, you can create a `configmap` resource in the manag
 apiVersion: v1
 data:
   my-dashboard.json: |-
-    { ... my dashboard in json format }
+    { ... my dashboard in JSON format }
 kind: ConfigMap
 metadata:
   annotations:
-    ## Define the organization in grafana where the dashboard will be added
+    ## Define the organization in Grafana where the dashboard will be added
     observability.giantswarm.io/organization: Customer
   labels:
-    ## Tell grafana to load this configmap as a dashboard
+    ## Tell Grafana to load this configmap as a dashboard
     app.giantswarm.io/kind: dashboard
   name: my-grafana-dashboard
   namespace: my-namespace
@@ -40,5 +40,5 @@ metadata:
 
 ### Limitations
 
-* the dashboard's json must contain an `uid` otherwise it won't be provisioned.
-* the dashboard name and uid must be unique in each grafana organization.
+* the dashboard's JSON must contain an `uid` otherwise it won't be provisioned.
+* the dashboard name and UID must be unique in each Grafana organization.

--- a/src/content/tutorials/observability/data-exploration/creating-custom-dashboards/_index.md
+++ b/src/content/tutorials/observability/data-exploration/creating-custom-dashboards/_index.md
@@ -29,8 +29,8 @@ data:
 kind: ConfigMap
 metadata:
   annotations:
-    ## Define the directory in grafana where the dashboard will be added to the grafana container
-    k8s-sidecar-target-directory: /var/lib/grafana/dashboards/customer
+    ## Define the organization in grafana where the dashboard will be added
+    observability.giantswarm.io/organization: Customer
   labels:
     ## Tell grafana to load this configmap as a dashboard
     app.giantswarm.io/kind: dashboard


### PR DESCRIPTION
### What this PR does / why we need it

Towards https://github.com/giantswarm/roadmap/issues/3696

In order to support multi-tenancy, the "vintage" provisionning method is deprecated.
So the `k8s-sidecar-target-directory` annotation is soon to be deprecated, in favor of the new `observability.giantswarm.io/organization` annotation.

Note: I completely got rid of mentions of the old annotation, to keep the doc clean. If it's a problem I can add it back with a "deprecated" warning.

### Things to check/remember before submitting

- If it's one of your first contributions, make sure you've read the [Contributing Guidelines](https://handbook.giantswarm.io/docs/content/docs-guide).
- Bump `last_review_date` in the front matter header of the pages you've touched.
