### PR TITLE
Add cluster.giantswarm.io/description

### DIFF
--- a/src/content/reference/platform-api/annotations/_index.md
+++ b/src/content/reference/platform-api/annotations/_index.md
@@ -10,7 +10,7 @@ menu:
 weight: 500
 owner:
   - https://github.com/orgs/giantswarm/teams/team-honeybadger
-last_review_date: 2025-01-20
+last_review_date: 2025-02-20
 ---
 
 **Notice:** Annotations on Kubernetes resources are set by many different parties, and for various reasons. In this overview we explain our reasons for using a relevant set of annotations, and which values or value format is expected. If you are missing information, please consult upstream documentation from Kubernetes etc., or ask a Giant Swarm contact for more information. Also check our corresponding [labels]({{< relref "/reference/platform-api/labels" >}}) reference page.

--- a/src/content/reference/platform-api/annotations/_index.md
+++ b/src/content/reference/platform-api/annotations/_index.md
@@ -15,7 +15,6 @@ last_review_date: 2025-01-20
 
 **Notice:** Annotations on Kubernetes resources are set by many different parties, and for various reasons. In this overview we explain our reasons for using a relevant set of annotations, and which values or value format is expected. If you are missing information, please consult upstream documentation from Kubernetes etc., or ask a Giant Swarm contact for more information. Also check our corresponding [labels]({{< relref "/reference/platform-api/labels" >}}) reference page.
 
-
 ### cluster.giantswarm.io/description
 
 Used on the Cluster resource to provide a human-readable description of the cluster. This description is shown in Giant Swarm web interfaces.

--- a/src/content/reference/platform-api/annotations/_index.md
+++ b/src/content/reference/platform-api/annotations/_index.md
@@ -15,6 +15,11 @@ last_review_date: 2025-01-20
 
 **Notice:** Annotations on Kubernetes resources are set by many different parties, and for various reasons. In this overview we explain our reasons for using a relevant set of annotations, and which values or value format is expected. If you are missing information, please consult upstream documentation from Kubernetes etc., or ask a Giant Swarm contact for more information. Also check our corresponding [labels]({{< relref "/reference/platform-api/labels" >}}) reference page.
 
+
+### cluster.giantswarm.io/description
+
+Used on the Cluster resource to provide a human-readable description of the cluster. This description is shown in Giant Swarm web interfaces.
+
 ### network-topology.giantswarm.io/mode
 
 Found on the AWSCluster resource for Cluster API provider AWS (CAPA) clusters. Specifies how transit gateways for the cluster will get set up in AWS. Possible values are: `None`, `GiantSwarmManaged`, `UserManaged`.


### PR DESCRIPTION
### What this PR does / why we need it

Adds information on the cluster description annotation `cluster.giantswarm.io/description`

### Things to check/remember before submitting

- If it's one of your first contributions, make sure you've read the [Contributing Guidelines](https://handbook.giantswarm.io/docs/content/docs-guide).
- Bump `last_review_date` in the front matter header of the pages you've touched.
