### PR TITLE
Fix: Update vale image digest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ COMPANY=giantswarm
 REGISTRY=gsoci.azurecr.io
 SHELL=bash
 MARKDOWNLINT_IMAGE=ghcr.io/igorshubovych/markdownlint-cli:v0.35.0@sha256:22cf4699a448a7bbc311a940e0600019423d7671cbedae9c35cd32b51f560350
-VALE_IMAGE=gsoci.azurecr.io/giantswarm/vale:v3.4.0@sha256:fe9c173ef6dcd782cefa53cad69d1684bc317b12188b03299b0d29aecf265a59
+VALE_IMAGE=gsoci.azurecr.io/giantswarm/vale:v3.4.0@sha256:6374c8a4c6c61b5d73987ff707208da73042cd5985851bd8a63037f956247d7b
 APPLICATION=docs-app
 RUNNING_IN_CI ?= false
 


### PR DESCRIPTION
The digest we use here is no longer associated with tag `v3.4.0`, so the pull fails.

This PR fixes the digest.