### PR TITLE
Fix: Set layout to single for overview introduction page

### DIFF
--- a/src/content/overview/introduction/_index.md
+++ b/src/content/overview/introduction/_index.md
@@ -2,6 +2,7 @@
 title: Introduction to Giant Swarm and the Giant Swarm platform
 linkTitle: Introduction
 description: Giant Swarm gives platform engineering teams the ability to build cloud-native developer platforms and operate them without much hassle.
+layout: single
 weight: 10
 menu:
   principal:


### PR DESCRIPTION
The page has file name `_index.md`, so Hugo assumes that it's a list page and applies the list template.

The PR adds the explicit layout setting.

Before

![image](https://github.com/user-attachments/assets/0b52b1fe-8248-417e-be40-0a9619ce8c69)


After

![image](https://github.com/user-attachments/assets/f0ba5957-3d10-4485-8a71-0af0ed818ab4)
