### PR TITLE
Fix duplicate H1 headline

### DIFF
--- a/src/content/tutorials/fleet-management/cluster-management/gpu/index.md
+++ b/src/content/tutorials/fleet-management/cluster-management/gpu/index.md
@@ -16,9 +16,7 @@ user_questions:
 last_review_date: 2025-03-12
 ---
 
-# Running NVIDIA `GPU` workloads in Cluster API workload clusters
-
-This guide explains how to configure and use GPU-enabled nodes in Cluster API (CAPI) workload clusters to run GPU-accelerated workloads.
+This guide explains how to configure and use GPU-enabled nodes in Cluster API (CAPI) workload clusters to run GPU-accelerated workloads, focusing on NVIDIA GPUs.
 GPU support is available starting with release v30.1.0.
 
 ## Overview

--- a/src/content/tutorials/fleet-management/cluster-management/gpu/index.md
+++ b/src/content/tutorials/fleet-management/cluster-management/gpu/index.md
@@ -1,6 +1,6 @@
 ---
 linkTitle: GPU
-title: GPU workloads in Cluster API (CAPI) workload clusters
+title: GPU workloads in Cluster API workload clusters
 description: Guides explaining how to configure and use GPU nodes in Cluster API (CAPI) workload clusters for running GPU-accelerated workloads.
 weight: 70
 menu:


### PR DESCRIPTION
This PR removes the double headline.

Before:

![image](https://github.com/user-attachments/assets/6eb2ef34-0d4f-4f10-b062-1e98a4cd4370)
