### PR TITLE
Lastpass to 1password

### DIFF
--- a/src/content/tutorials/continuous-deployment/apps/update-appcr.md
+++ b/src/content/tutorials/continuous-deployment/apps/update-appcr.md
@@ -11,7 +11,7 @@ user_questions:
   - How can I update an existent app deployed with GitOps?
 owner:
   - https://github.com/orgs/giantswarm/teams/team-honeybadger
-last_review_date: 2024-11-19
+last_review_date: 2025-03-25
 ---
 
 This document is part of the documentation to use GitOps with Giant Swarm app platform. You can find more information about the [app platform in our docs]({{< relref "/overview/fleet-management/app-management/" >}}).
@@ -53,11 +53,12 @@ In case you just want to update the configuration of the app, you need to edit t
 
 In this case, you need to decrypt the `secret.enc.yaml` file before editing it. Then you perform the changes and encrypt the file again.
 
-Import the workload cluster private `GPG` key from your key chain tool. In our example, you see `LastPass` for this purpose:
+Import the workload cluster private `GPG` key from your keychain tool. In our example, you see `1Password` for this purpose:
 
 ```sh
+eval $(op signin)
 gpg --import \
-<(lpass show --notes "Shared-Dev Common/GPG private key (${MC_NAME}, ${WC_NAME}, Flux)")
+<(op item get --vault 'Dev Common' "Shared-Dev Common/GPG private key (${MC_NAME}, ${WC_NAME}, Flux)" --reveal --fields notesPlain)
 ```
 
 Then you can decrypt the `secret.enc.yaml` file and decode the `values` field:

--- a/src/content/tutorials/continuous-deployment/apps/update-appcr.md
+++ b/src/content/tutorials/continuous-deployment/apps/update-appcr.md
@@ -58,7 +58,7 @@ Import the workload cluster private `GPG` key from your keychain tool. In our ex
 ```sh
 eval $(op signin)
 gpg --import \
-<(op item get --vault 'Dev Common' "Shared-Dev Common/GPG private key (${MC_NAME}, ${WC_NAME}, Flux)" --reveal --fields notesPlain)
+<(op item get --vault 'Dev Common' "GPG private key (${MC_NAME}, ${WC_NAME}, Flux)" --reveal --fields notesPlain)
 ```
 
 Then you can decrypt the `secret.enc.yaml` file and decode the `values` field:

--- a/src/content/vintage/advanced/gitops/apps/update-appcr.md
+++ b/src/content/vintage/advanced/gitops/apps/update-appcr.md
@@ -68,7 +68,7 @@ export APP_NAME=APP_NAME
     ```sh
     eval $(op signin)
     gpg --import \
-    <(op item get --vault 'Dev Common' "Shared-Dev Common/GPG private key (${MC_NAME}, ${WC_NAME}, Flux)" --reveal --fields notesPlain)
+    <(op item get --vault 'Dev Common' "GPG private key (${MC_NAME}, ${WC_NAME}, Flux)" --reveal --fields notesPlain)
     ```
 
 3. Decrypt the `secret.enc.yaml` file with SOPS:

--- a/src/content/vintage/advanced/gitops/apps/update-appcr.md
+++ b/src/content/vintage/advanced/gitops/apps/update-appcr.md
@@ -7,7 +7,7 @@ menu:
   main:
     identifier: advanced-gitops-apps-app-update
     parent: advanced-gitops-apps
-last_review_date: 2024-02-16
+last_review_date: 2025-03-25
 user_questions:
   - How can I update an existent app deployed with GitOps?
 owner:
@@ -63,11 +63,12 @@ export APP_NAME=APP_NAME
     cd management-clusters/${MC_NAME}/organizations/${ORG_NAME}/workload-clusters/${WC_NAME}/mapi/apps/${APP_NAME}
     ```
 
-2. Import the WC's regular GPG private key from your safe storage into your keychain. In our example, we're gonna use `LastPass` for that:
+2. Import the WC's regular GPG private key from your safe storage into your keychain. In our example, we use 1Password's `op` CLI for that:
 
     ```sh
+    eval $(op signin)
     gpg --import \
-    <(lpass show --notes "Shared-Dev Common/GPG private key (${MC_NAME}, ${WC_NAME}, Flux)")
+    <(op item get --vault 'Dev Common' "Shared-Dev Common/GPG private key (${MC_NAME}, ${WC_NAME}, Flux)" --reveal --fields notesPlain)
     ```
 
 3. Decrypt the `secret.enc.yaml` file with SOPS:


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/32651

### Summary

Fix the 1Password CLI (`op`) commands used to access cluster's SOPS keys.

@ssyno As outlined [here](https://github.com/giantswarm/gitops-template/pull/109#issuecomment-2752063691), I saw the keys were stored with the wrong title. **Could you please make sure mc-bootstrap etc. is also matching this title? Or did we already release with "Shared-Dev Common" in the key's secret note title?**
