### PR TITLE
Exclude vale rule Microsoft.GeneralURL

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -12,6 +12,10 @@ BasedOnStyles = Vale, Microsoft
 # Microsoft.We disallows the use of "we" or "us". At Giant Swarm we are using this in many places for now.
 Microsoft.We = NO
 
+# Microsoft.GeneralURL suggests to use "address" instead of "URL". At Giant Swarm we assume a technical audience
+# that is familiar with the term "URL".
+Microsoft.GeneralURL = NO
+
 # No linting at all for the /changes section
 [src/content/changes/*.md]
 BasedOnStyles = Vale


### PR DESCRIPTION
This PR excludes the vale rule `Microsoft.GeneralURL`.

Microsoft.GeneralURL suggests to use "address" instead of "URL". At Giant Swarm we assume a technical audience that is familiar with the term "URL".