### PR TITLE
Update links in crds

### DIFF
--- a/scripts/update-crd-reference/config.yaml
+++ b/scripts/update-crd-reference/config.yaml
@@ -86,7 +86,7 @@ source_repositories:
   - url: https://github.com/giantswarm/release-operator
     organization: giantswarm
     short_name: release-operator
-    commit_reference: v4.2.0
+    commit_reference: v4.2.1
     crd_paths:
       - config/crd
     cr_paths:

--- a/src/content/reference/platform-api/crd/releases.release.giantswarm.io.md
+++ b/src/content/reference/platform-api/crd/releases.release.giantswarm.io.md
@@ -25,7 +25,7 @@ aliases:
   - /use-the-api/management-api/crd/releases.release.giantswarm.io/
 technical_name: releases.release.giantswarm.io
 source_repository: https://github.com/giantswarm/release-operator
-source_repository_ref: v4.2.0
+source_repository_ref: v4.2.1
 ---
 
 # Release


### PR DESCRIPTION
Related to https://github.com/giantswarm/release-operator/pull/673

### Summary

Update `release-operator` reference for CR example with working documentation link in metadata.

Depends on https://github.com/giantswarm/release-operator/pull/674