### PR TITLE
Remove front page link to vintage section

### DIFF
--- a/src/layouts/index.html
+++ b/src/layouts/index.html
@@ -58,14 +58,6 @@
     </div>
   </div>
 
-
-  <hr>
-  <div class="row">
-    <div class="col-xs-12">
-      <p class="">To view the documentation for our vintage product, follow this <a href="/vintage">link</a>.</p>
-    </div>
-  </div>
-
 </div>
 
 {{ partialCached "footer" . }}


### PR DESCRIPTION
Removing this link:

![image](https://github.com/user-attachments/assets/f35395f9-17db-418f-b619-a220d96f5b93)
