### PR TITLE
Add a bottom bar in main menu

### DIFF
--- a/src/layouts/index.html
+++ b/src/layouts/index.html
@@ -56,6 +56,9 @@
       <h3><a href="/changes/">Changes and releases</a></h3>
       <p class="intro">Stay up-to-date on changes and releases in apps, workload cluster components, UIs and even the documentation itself.</p>
     </div>
+    <div class="col-xs-12">
+      <hr />
+    </div>
   </div>
 
 </div>


### PR DESCRIPTION
After removing the vintage link, the bottom HR bar disappeared. I put it back.

<img width="1252" alt="Screenshot 2025-07-03 at 12 29 46" src="https://github.com/user-attachments/assets/841ed646-9905-41cf-bf6f-c171c81a4ec1" />


