### PR TITLE
Make relref shortcodes absolute

### DIFF
--- a/src/content/getting-started/provision-your-first-workload-cluster/_index.md
+++ b/src/content/getting-started/provision-your-first-workload-cluster/_index.md
@@ -51,7 +51,7 @@ kubectl gs template cluster \
 
 You can select the AWS account by specifying the `aws-cluster-role-identity-name` argument when templating the cluster.
 
-The name passed to `aws-cluster-role-identity-name` must match the name of [an existing `AWSClusterRoleIdentity`]({{< relref "getting-started/prepare-your-provider-infrastructure/aws/#configure-cluster-role-identity" >}}).
+The name passed to `aws-cluster-role-identity-name` must match the name of [an existing `AWSClusterRoleIdentity`]({{< relref "/getting-started/prepare-your-provider-infrastructure/aws/#configure-cluster-role-identity" >}}).
 
 ```sh
 kubectl gs template cluster \
@@ -80,7 +80,7 @@ kubectl gs template cluster \
 
 You can select the AWS account by specifying the `aws-cluster-role-identity-name` argument when templating the cluster.
 
-The name passed to `aws-cluster-role-identity-name` must match the name of [an existing `AWSClusterRoleIdentity`]({{< relref "getting-started/prepare-your-provider-infrastructure/aws/#configure-cluster-role-identity" >}}).
+The name passed to `aws-cluster-role-identity-name` must match the name of [an existing `AWSClusterRoleIdentity`]({{< relref "/getting-started/prepare-your-provider-infrastructure/aws/#configure-cluster-role-identity" >}}).
 
 ```sh
 kubectl gs template cluster \

--- a/src/content/overview/connectivity/_index.md
+++ b/src/content/overview/connectivity/_index.md
@@ -42,4 +42,4 @@ Our platform leverages various projects under the cloud-native initiative that h
 - **Node Local DNS**: an extension to CoreDNS that provides a scalable DNS solution regardless of the cluster's size. It improves the speed and reliability of DNS resolution for your workloads while reducing the load on CoreDNS.
 - **External DNS**: extends Kubernetes resources, adding the option to manage DNS records for external services.
 
-Learn how to expose your workloads on Giant Swarm by visiting our [getting started page]({{< relref "getting-started/understand-connectivity/" >}}).
+Learn how to expose your workloads on Giant Swarm by visiting our [getting started page]({{< relref "/getting-started/understand-connectivity/" >}}).

--- a/src/content/overview/continuous-deployment/_index.md
+++ b/src/content/overview/continuous-deployment/_index.md
@@ -29,4 +29,4 @@ Continuous Deployment (CD) is a crucial practice in modern software development,
 
 - **Crossplane**: It enables the management of infrastructure and services using Kubernetes-native APIs. It supports the declarative management of cloud resources, facilitating the implementation of Infrastructure as Code (IaC) practices. Crossplane allows seamless integration with existing Kubernetes workflows, providing a unified approach to managing applications and infrastructure.
 
-Learn how to start with continuous deployment on Giant Swarm by visiting our [getting started continuous deployment page]({{< relref "getting-started/install-an-application/" >}}).
+Learn how to start with continuous deployment on Giant Swarm by visiting our [getting started continuous deployment page]({{< relref "/getting-started/install-an-application/" >}}).

--- a/src/content/overview/observability/_index.md
+++ b/src/content/overview/observability/_index.md
@@ -50,4 +50,4 @@ Here are the most important tools we rely on:
 
 The observability platform provides comprehensive [data management capabilities]({{< relref "/overview/observability/data-management" >}}) that handle the complete lifecycle of your observability data - from collection and storage to analysis and export. Our integrated approach ensures efficient data flow while maintaining security, performance, and multi-tenancy across all data types.
 
-Learn how to start with observability on Giant Swarm by visiting our [getting started observability page]({{< relref "getting-started/observe-your-clusters-and-apps/" >}}).
+Learn how to start with observability on Giant Swarm by visiting our [getting started observability page]({{< relref "/getting-started/observe-your-clusters-and-apps/" >}}).

--- a/src/content/tutorials/observability/multi-tenancy/_index.md
+++ b/src/content/tutorials/observability/multi-tenancy/_index.md
@@ -174,7 +174,7 @@ The platform automatically enforces tenant governance to control data ingestion:
 
 **Creating tenants:**
 
-1. Define the tenant in `GrafanaOrganization` resource (see [documentation]({{< relref "creating-grafana-organization" >}}))
+1. Define the tenant in `GrafanaOrganization` resource (see [documentation]({{< relref "/tutorials/observability/multi-tenancy/creating-grafana-organization" >}}))
 2. Configure data collection to use tenant label (see [Data Ingestion documentation]({{< relref "/tutorials/observability/data-ingestion" >}}))
 3. Verify data appears in organization dashboards (see [Data Exploration documentation]({{< relref "/tutorials/observability/data-exploration" >}}))
 
@@ -185,7 +185,7 @@ The platform automatically enforces tenant governance to control data ingestion:
 
 ## Next steps
 
-- [Create a Grafana organization]({{< relref "creating-grafana-organization" >}}) to implement your tenant strategy
+- [Create a Grafana organization]({{< relref "/tutorials/observability/multi-tenancy/creating-grafana-organization" >}}) to implement your tenant strategy
 - [Configure alerting]({{< relref "/tutorials/observability/alerting" >}}) with tenant-specific rules
 - [Set up data ingestion]({{< relref "/tutorials/observability/data-ingestion" >}}) to send data to your tenants
 - [Explore your data]({{< relref "/tutorials/observability/data-exploration" >}}) using Grafana dashboards and queries


### PR DESCRIPTION
All relref values are supposed to be absolute, to facilitate search & replace operations. This PR aligns the ones I have found not starting with `/`.