### PR TITLE
Remove reference to old label

### DIFF
--- a/src/content/reference/platform-api/labels/index.md
+++ b/src/content/reference/platform-api/labels/index.md
@@ -10,6 +10,7 @@ weight: 500
 owner:
   - https://github.com/orgs/giantswarm/teams/team-honeybadger
 last_review_date: 2024-11-27
+user_questions: []
 ---
 
 **Notice:** Labels on Kubernetes resources are set by many different parties, and for various reasons. In this overview we explain our reasons for using a relevant set of labels, and which values or value format is expected. If you are missing information, please consult upstream documentation  from Kubernetes etc., or ask a Giant Swarm contact for more information. Also check our corresponding [annotations]({{< relref "/reference/platform-api/annotations" >}}) reference page.


### PR DESCRIPTION
### What this PR does / why we need it

This label is not used anymore.