### PR TITLE
Use frontmatter-validator 0.2.0 with configuration system

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -21,7 +21,7 @@ jobs:
         uses: giantswarm/install-binary-action@0797deb878056114fa54ee30c519f617716e8c69 # v3.1.1
         with:
           binary: frontmatter-validator
-          version: "0.1.1"
+          version: "0.2.0"
           smoke_test: frontmatter-validator --help
 
       - name: Validate front matter for changed files
@@ -32,7 +32,7 @@ jobs:
           if [ -s files.txt ]; then
             # Validate the changed files
             echo "Validating front matter for changed files:"
-            cat files.txt | frontmatter-validator
+            cat files.txt | frontmatter-validator --config ./scripts/frontmatter-validator/config-default.yaml
 
             # Print for debugging
             printf "\nAnnotations JSON:\n"

--- a/Makefile
+++ b/Makefile
@@ -106,16 +106,19 @@ validate-front-matter:
 	docker run --rm \
 		--volume=${PWD}:/workdir:ro \
 		-w /workdir \
-		$(REGISTRY)/$(COMPANY)/frontmatter-validator:0.1.1 \
-			--path ./src/content
+		$(REGISTRY)/$(COMPANY)/frontmatter-validator:0.2.0 \
+			--path ./src/content \
+			--config ./scripts/frontmatter-validator/config-default.yaml
 
 # Validate front matter for last-reviewed date.
 validate-last-reviewed-json:
 	docker run --rm \
 		--volume=${PWD}:/workdir:ro \
 		-w /workdir \
-		$(REGISTRY)/$(COMPANY)/frontmatter-validator:0.1.1 \
-			--validation last-reviewed --output json
+		$(REGISTRY)/$(COMPANY)/frontmatter-validator:0.2.0 \
+		    --path ./src/content \
+			--config ./scripts/frontmatter-validator/config-last-reviewed.yaml \
+			--output json
 
 # Print a report of pages with a last_review_date that's
 # too long ago.
@@ -123,8 +126,9 @@ validate-last-reviewed:
 	docker run --rm \
 		--volume=${PWD}:/workdir:ro \
 		-w /workdir \
-		$(REGISTRY)/$(COMPANY)/frontmatter-validator:0.1.1 \
-			--validation last-reviewed
+		$(REGISTRY)/$(COMPANY)/frontmatter-validator:0.2.0 \
+		    --path ./src/content \
+			--config ./scripts/frontmatter-validator/config-last-reviewed.yaml
 
 docker-build:
 	docker build -t $(REGISTRY)/$(COMPANY)/$(PROJECT):latest .

--- a/scripts/frontmatter-validator/config-default.yaml
+++ b/scripts/frontmatter-validator/config-default.yaml
@@ -1,0 +1,86 @@
+# Frontmatter Validator configuration
+# This file defines which validation checks are enabled and how they apply to different directories.
+
+# Default rules applied to all files unless overridden
+default_rules:
+  enabled_checks:
+    - NO_FRONT_MATTER
+    - NO_TRAILING_NEWLINE
+    - UNKNOWN_ATTRIBUTE
+    - NO_TITLE
+    - LONG_TITLE
+    - SHORT_TITLE
+    - NO_DESCRIPTION
+    - LONG_DESCRIPTION
+    - SHORT_DESCRIPTION
+    - NO_FULL_STOP_DESCRIPTION
+    - INVALID_DESCRIPTION
+    - NO_LINK_TITLE
+    - LONG_LINK_TITLE
+    - NO_WEIGHT
+    - NO_OWNER
+    - INVALID_OWNER
+    - NO_LAST_REVIEW_DATE
+    - REVIEW_TOO_LONG_AGO
+    - INVALID_LAST_REVIEW_DATE
+    - NO_USER_QUESTIONS
+    - LONG_USER_QUESTION
+    - NO_QUESTION_MARK
+
+# Directory-specific overrides
+# Rules are applied in order, with later matches taking precedence
+directory_overrides:
+  # CRD documentation has relaxed requirements
+  - path: "src/content/reference/platform-api/crd/**"
+    disabled_checks:
+      - INVALID_DESCRIPTION
+      - LONG_DESCRIPTION
+      - NO_DESCRIPTION
+      - NO_FULL_STOP_DESCRIPTION
+      - NO_LINK_TITLE
+      - NO_OWNER
+      - NO_USER_QUESTIONS
+      - SHORT_DESCRIPTION
+      - NO_LAST_REVIEW_DATE
+      - REVIEW_TOO_LONG_AGO
+
+  # Vintage CRD documentation
+  - path: "src/content/vintage/use-the-api/management-api/crd/**"
+    disabled_checks:
+      - NO_DESCRIPTION
+      - LONG_DESCRIPTION
+      - SHORT_DESCRIPTION
+      - NO_FULL_STOP_DESCRIPTION
+      - INVALID_DESCRIPTION
+      - NO_LINK_TITLE
+      - NO_OWNER
+      - NO_USER_QUESTIONS
+
+  # Changes/changelog entries have different requirements
+  - path: "src/content/changes/**"
+    disabled_checks:
+      - LONG_LINK_TITLE
+      - NO_DESCRIPTION
+      - NO_FULL_STOP_DESCRIPTION
+      - NO_LAST_REVIEW_DATE
+      - NO_LINK_TITLE
+      - NO_OWNER
+      - NO_USER_QUESTIONS
+      - SHORT_DESCRIPTION
+
+  # Vintage documentation doesn't require review dates
+  - path: "src/content/vintage/**"
+    disabled_checks:
+      - NO_LAST_REVIEW_DATE
+      - REVIEW_TOO_LONG_AGO
+
+  # Cluster apps documentation
+  - path: "src/content/reference/platform-api/cluster-apps/**"
+    disabled_checks:
+      - NO_LAST_REVIEW_DATE
+      - REVIEW_TOO_LONG_AGO
+
+  # Meta documentation
+  - path: "src/content/meta/**"
+    disabled_checks:
+      - NO_LAST_REVIEW_DATE

--- a/scripts/frontmatter-validator/config-last-reviewed.yaml
+++ b/scripts/frontmatter-validator/config-last-reviewed.yaml
@@ -1,0 +1,42 @@
+# Frontmatter Validator configuration - Last review date only
+# This configuration only validates last review date related checks.
+
+# Only enable last review date checks by default
+default_rules:
+  enabled_checks:
+    - NO_FRONT_MATTER           # Need frontmatter to check review dates
+    - NO_TRAILING_NEWLINE       # Basic file format requirement
+    - NO_LAST_REVIEW_DATE
+    - REVIEW_TOO_LONG_AGO
+    - INVALID_LAST_REVIEW_DATE
+
+# Directory-specific overrides for last review date validation
+directory_overrides:
+  # Vintage documentation doesn't require review dates
+  - path: "src/content/vintage/**"
+    disabled_checks:
+      - NO_LAST_REVIEW_DATE
+      - REVIEW_TOO_LONG_AGO
+
+  # Changes/changelog entries don't need review dates
+  - path: "src/content/changes/**"
+    disabled_checks:
+      - NO_LAST_REVIEW_DATE
+      - REVIEW_TOO_LONG_AGO
+
+  # Cluster apps documentation
+  - path: "src/content/reference/platform-api/cluster-apps/**"
+    disabled_checks:
+      - NO_LAST_REVIEW_DATE
+      - REVIEW_TOO_LONG_AGO
+
+  # CRD documentation doesn't require review dates
+  - path: "src/content/reference/platform-api/crd/**"
+    disabled_checks:
+      - NO_LAST_REVIEW_DATE
+      - REVIEW_TOO_LONG_AGO
+
+  # Meta documentation
+  - path: "src/content/meta/**"
+    disabled_checks:
+      - NO_LAST_REVIEW_DATE


### PR DESCRIPTION
frontmatter-validator 0.2.0 is more flexible, to be usable in docs and intranet.

This PR upgrades and adds the configuration for the two validation modes we need.