### PR TITLE
Reassign AI agent setup guide to team-bumblebee

### DIFF
--- a/src/content/getting-started/ai-agent-setup/index.md
+++ b/src/content/getting-started/ai-agent-setup/index.md
@@ -9,7 +9,7 @@ menu:
     identifier: getting-started-ai-agent-setup
 last_review_date: 2026-02-27
 owner:
-  - https://github.com/orgs/giantswarm/teams/sig-docs
+  - https://github.com/orgs/giantswarm/teams/team-bumblebee
 user_questions:
   - How do I use AI assistants with my Kubernetes clusters?
   - How do I set up Muster with VS Code or Cursor?


### PR DESCRIPTION
## Summary
- Move ownership of `getting-started/ai-agent-setup/` from `sig-docs` to `team-bumblebee`. This page covers Muster + mcp-kubernetes, which Bumblebee owns alongside Klaus and the wider MCP toolchain.

## Test plan
- [ ] Frontmatter `owner` field renders/links to the correct GitHub team
- [ ] No other pages referenced `sig-docs` ownership for this guide (CODEOWNERS only has a repo-wide wildcard, so no further changes needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)