### PR TITLE
Deprecate ingress-nginx docs, promote Gateway API

### DIFF
--- a/src/content/tutorials/connectivity/gateway-api/_index.md
+++ b/src/content/tutorials/connectivity/gateway-api/_index.md
@@ -14,7 +14,7 @@ user_questions:
   - What is the difference between Gateway API and Ingress?
   - How do I configure Envoy Gateway for my workloads?
   - What are the Gateway API components and how do they work together?
-last_review_date: 2025-10-17
+last_review_date: 2026-05-18
 ---
 
 The Kubernetes Gateway API is the next-generation standard for managing ingress traffic in Kubernetes clusters. It provides a more expressive, extensible, and role-oriented approach to traffic management compared to traditional Ingress resources. Giant Swarm supports Gateway API through Envoy Gateway, providing advanced load balancing, traffic routing, and API gateway capabilities.

--- a/src/content/tutorials/connectivity/gateway-api/_index.md
+++ b/src/content/tutorials/connectivity/gateway-api/_index.md
@@ -2,7 +2,7 @@
 linkTitle: Gateway API
 title: Gateway API
 description: Learn how to use the Kubernetes Gateway API with Envoy Gateway in Giant Swarm workload clusters for advanced traffic management, load balancing, and API gateway functionality.
-weight: 25
+weight: 15
 menu:
   principal:
     parent: tutorials-connectivity

--- a/src/content/tutorials/connectivity/ingress/_index.md
+++ b/src/content/tutorials/connectivity/ingress/_index.md
@@ -1,19 +1,28 @@
 ---
-title: Ingress connectivity
-linkTitle: Ingress
-description: List of articles explaining how to manage with the different ingress features available in the platform.
-weight: 20
-menu:
-  principal:
-    parent: tutorials-connectivity
-    identifier: tutorials-connectivity-ingress
+title: Ingress connectivity (deprecated)
+linkTitle: Ingress (deprecated)
+description: Ingress NGINX is deprecated. Use Gateway API with Envoy Gateway instead.
+weight: 40
 aliases:
   - /getting-started/connectivity/ingress-controller
   - /vintage/getting-started/connectivity/ingress-controller
   - /advanced/connectivity/ingress
-last_review_date: 2025-09-22
+last_review_date: 2026-05-12
 owner:
   - https://github.com/orgs/giantswarm/teams/team-cabbage
 user_questions:
   - How do I expose my workloads to the internet using an ingress?
 ---
+
+{{% notice warning %}}
+**Deprecated:** Giant Swarm no longer offers Ingress NGINX as a managed solution. It has been replaced by [Gateway API with Envoy Gateway]({{< relref "/tutorials/connectivity/gateway-api/" >}}). If you're still running ingress-nginx, follow the [migration guide]({{< relref "/tutorials/connectivity/gateway-api/ingress-nginx-migration/" >}}) to transition your workloads.
+{{% /notice %}}
+
+The pages in this section are kept for reference while you migrate existing workloads. They describe ingress-nginx features and configuration that are no longer actively supported.
+
+## Archived pages
+
+- [Exposing workloads]({{< relref "/tutorials/connectivity/ingress/exposing-workloads/" >}}) — basic ingress setup and port forwarding
+- [Advanced ingress configuration]({{< relref "/tutorials/connectivity/ingress/configuration/" >}}) — annotations, TLS, auth, rate limiting, ModSecurity
+- [Running multiple ingress-nginx controllers]({{< relref "/tutorials/connectivity/ingress/multi-nginx-ic/" >}}) — separating internal and external traffic
+- [Services of type LoadBalancer]({{< relref "/tutorials/connectivity/ingress/service-type-loadbalancer/" >}}) — direct cloud load balancer exposure on AWS and Azure

--- a/src/content/tutorials/connectivity/ingress/_index.md
+++ b/src/content/tutorials/connectivity/ingress/_index.md
@@ -7,7 +7,7 @@ aliases:
   - /getting-started/connectivity/ingress-controller
   - /vintage/getting-started/connectivity/ingress-controller
   - /advanced/connectivity/ingress
-last_review_date: 2026-05-12
+last_review_date: 2026-05-18
 owner:
   - https://github.com/orgs/giantswarm/teams/team-cabbage
 user_questions:

--- a/src/content/tutorials/connectivity/ingress/_index.md
+++ b/src/content/tutorials/connectivity/ingress/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Ingress connectivity (deprecated)
 linkTitle: Ingress (deprecated)
-description: Ingress NGINX is deprecated. Use Gateway API with Envoy Gateway instead.
+description: Ingress Nginx is deprecated. Use Gateway API with Envoy Gateway instead.
 weight: 40
 aliases:
   - /getting-started/connectivity/ingress-controller
@@ -15,14 +15,14 @@ user_questions:
 ---
 
 {{% notice warning %}}
-**Deprecated:** Giant Swarm no longer offers Ingress NGINX as a managed solution. It has been replaced by [Gateway API with Envoy Gateway]({{< relref "/tutorials/connectivity/gateway-api/" >}}). If you're still running ingress-nginx, follow the [migration guide]({{< relref "/tutorials/connectivity/gateway-api/ingress-nginx-migration/" >}}) to transition your workloads.
+**Deprecated:** Giant Swarm no longer offers Ingress Nginx as a managed solution. It has been replaced by [Gateway API with Envoy Gateway]({{< relref "/tutorials/connectivity/gateway-api/" >}}). If you're still running ingress-nginx, follow the [migration guide]({{< relref "/tutorials/connectivity/gateway-api/ingress-nginx-migration/" >}}) to transition your workloads.
 {{% /notice %}}
 
 The pages in this section are kept for reference while you migrate existing workloads. They describe ingress-nginx features and configuration that are no longer actively supported.
 
 ## Archived pages
 
-- [Exposing workloads]({{< relref "/tutorials/connectivity/ingress/exposing-workloads/" >}}) — basic ingress setup and port forwarding
-- [Advanced ingress configuration]({{< relref "/tutorials/connectivity/ingress/configuration/" >}}) — annotations, TLS, auth, rate limiting, ModSecurity
-- [Running multiple ingress-nginx controllers]({{< relref "/tutorials/connectivity/ingress/multi-nginx-ic/" >}}) — separating internal and external traffic
-- [Services of type LoadBalancer]({{< relref "/tutorials/connectivity/ingress/service-type-loadbalancer/" >}}) — direct cloud load balancer exposure on AWS and Azure
+- [Exposing workloads]({{< relref "/tutorials/connectivity/ingress/exposing-workloads/" >}}): basic ingress setup and port forwarding
+- [Advanced ingress configuration]({{< relref "/tutorials/connectivity/ingress/configuration/" >}}): annotations, TLS, auth, rate limiting, ModSecurity
+- [Running multiple ingress-nginx controllers]({{< relref "/tutorials/connectivity/ingress/multi-nginx-ic/" >}}): separating internal and external traffic
+- [Services of type LoadBalancer]({{< relref "/tutorials/connectivity/ingress/service-type-loadbalancer/" >}}): direct cloud load balancer exposure on AWS and Azure

--- a/src/content/tutorials/connectivity/ingress/configuration/index.md
+++ b/src/content/tutorials/connectivity/ingress/configuration/index.md
@@ -2,10 +2,6 @@
 title: Advanced ingress configuration
 description: Here we describe how you can customize and enable specific features for the ingress-nginx controller.
 weight: 20
-menu:
-  principal:
-    parent: tutorials-connectivity-ingress
-    identifier: tutorials-connectivity-ingress-configuration
 user_questions:
   - How can I allow only certain IPs for ingress access?
   - How can I assign requests to different services, based on the address path?
@@ -35,6 +31,10 @@ aliases:
 owner:
   - https://github.com/orgs/giantswarm/teams/team-cabbage
 ---
+
+{{% notice warning %}}
+**Deprecated:** Ingress NGINX is no longer offered by Giant Swarm. This page is kept for reference. Migrate to [Gateway API with Envoy Gateway]({{< relref "/tutorials/connectivity/gateway-api/" >}}) — see the [migration guide]({{< relref "/tutorials/connectivity/gateway-api/ingress-nginx-migration/" >}}).
+{{% /notice %}}
 
 The [ingress-nginx controller](https://github.com/kubernetes/ingress-nginx) has additional configuration options and features that can be customized. The functionality is split into two categories:
 

--- a/src/content/tutorials/connectivity/ingress/configuration/index.md
+++ b/src/content/tutorials/connectivity/ingress/configuration/index.md
@@ -22,7 +22,7 @@ user_questions:
   - How can I use ingress-nginx controller as a Web Application Firewall?
   - How can I protect my workload from malicious requests?
   - How can I enable & configure ModSecurity inside of the ingress-nginx controller?
-last_review_date: 2025-09-22
+last_review_date: 2026-05-18
 aliases:
   - /vintage/advanced/connectivity/ingress/configuration
   - /advanced/connectivity/ingress/configuration

--- a/src/content/tutorials/connectivity/ingress/configuration/index.md
+++ b/src/content/tutorials/connectivity/ingress/configuration/index.md
@@ -33,7 +33,7 @@ owner:
 ---
 
 {{% notice warning %}}
-**Deprecated:** Ingress NGINX is no longer offered by Giant Swarm. This page is kept for reference. Migrate to [Gateway API with Envoy Gateway]({{< relref "/tutorials/connectivity/gateway-api/" >}}) — see the [migration guide]({{< relref "/tutorials/connectivity/gateway-api/ingress-nginx-migration/" >}}).
+**Deprecated:** Ingress Nginx is no longer offered by Giant Swarm. This page is kept for reference. Migrate to [Gateway API with Envoy Gateway]({{< relref "/tutorials/connectivity/gateway-api/" >}}) — see the [migration guide]({{< relref "/tutorials/connectivity/gateway-api/ingress-nginx-migration/" >}}).
 {{% /notice %}}
 
 The [ingress-nginx controller](https://github.com/kubernetes/ingress-nginx) has additional configuration options and features that can be customized. The functionality is split into two categories:

--- a/src/content/tutorials/connectivity/ingress/configuration/index.md
+++ b/src/content/tutorials/connectivity/ingress/configuration/index.md
@@ -41,7 +41,7 @@ The [ingress-nginx controller](https://github.com/kubernetes/ingress-nginx) has 
 - [Per-service options](#yaml) in each ingress' YAML definition either directly or via [Annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/) ([Complete list of supported Annotations](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/)).
 - [Global options](#configmap) that influence all ingresses of a cluster via a ConfigMap ([Complete list of ConfigMap options](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/)).
 
-__Note__: Giant Swarm clusters don't come with an ingress controller pre-installed. See our [guide on how to install an ingress controller from the Giant Swarm catalog]({{< relref "/getting-started/install-an-application#install-ingress-controller" >}}).
+**Note**: Giant Swarm clusters don't come with an ingress controller pre-installed. See our [guide on how to install an ingress controller from the Giant Swarm catalog]({{< relref "/getting-started/install-an-application#install-ingress-controller" >}}).
 
 ## Per-Service options {#yaml}
 
@@ -79,7 +79,7 @@ spec:
               number: SERVICE_2_PORT
 ```
 
-__Note__: If you are using TLS you also need each of the hosts in the `tls` section (see below) of the YAML.
+**Note**: If you are using TLS you also need each of the hosts in the `tls` section (see below) of the YAML.
 
 ### Path Based Fan-out
 
@@ -112,7 +112,7 @@ spec:
               number: SERVICE_2_PORT
 ```
 
-__Note__: Your applications need to be capable of running on a non-root path either by default or by setting the base path in their configuration.
+**Note**: Your applications need to be capable of running on a non-root path either by default or by setting the base path in their configuration.
 
 ### Encryption
 
@@ -120,7 +120,7 @@ It's possible to configure TLS encryption in your ingress objects. You can eithe
 
 #### SSL passthrough
 
-__Warning__: This feature was disabled by default in the ingress-nginx controller managed by Giant Swarm. Reason is a potential [crash](https://github.com/kubernetes/ingress-nginx/issues/2354) of internal TCP proxy. We recommend to [terminate TLS in ingress controller](#terminating-tls-in-ingress-controller) instead.
+**Warning**: This feature was disabled by default in the ingress-nginx controller managed by Giant Swarm. Reason is a potential [crash](https://github.com/kubernetes/ingress-nginx/issues/2354) of internal TCP proxy. We recommend to [terminate TLS in ingress controller](#terminating-tls-in-ingress-controller) instead.
 
 For SSL passthrough you need to set an annotation and enable TLS for the host:
 
@@ -149,7 +149,7 @@ spec:
               number: SERVICE_PORT
 ```
 
-__Note__: SSL passthrough can't work with path based routing based on the nature of SSL.
+**Note**: SSL passthrough can't work with path based routing based on the nature of SSL.
 
 #### Terminating TLS in the ingress controller
 
@@ -166,7 +166,7 @@ data:
   tls.key: BASE64_ENCODED_KEY
 ```
 
-__Note__: The data keys must be named `tls.crt` and `tls.key`!
+**Note**: The data keys must be named `tls.crt` and `tls.key`!
 
 Referencing this secret in an ingress will tell the ingress controller to secure the channel from the client to the ingress controller using TLS:
 
@@ -194,7 +194,7 @@ spec:
               number: SERVICE_PORT
 ```
 
-__Note__: If you want to use [Let's Encrypt](https://letsencrypt.org/) certificates with your domains you can automate their creation and renewal with the help of [cert-manager](https://cert-manager.io/docs/). After configuring cert-manager there is only an annotation inside your ingresses needed and your web application will be secured by a valid TLS certificate. You can learn more about this behavior [here]({{< relref "/tutorials/security/tls-certificates" >}}).
+**Note**: If you want to use [Let's Encrypt](https://letsencrypt.org/) certificates with your domains you can automate their creation and renewal with the help of [cert-manager](https://cert-manager.io/docs/). After configuring cert-manager there is only an annotation inside your ingresses needed and your web application will be secured by a valid TLS certificate. You can learn more about this behavior [here]({{< relref "/tutorials/security/tls-certificates" >}}).
 
 ### Authentication
 
@@ -321,7 +321,7 @@ By default the ingress-nginx controller redirects (301) to `HTTPS` if TLS is ena
 
 You can specify the allowed client IP source ranges through the `nginx.ingress.kubernetes.io/allowlist-source-range` annotation. The value is a comma separated list of [CIDRs](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing), for example `10.0.0.0/24,172.10.0.1`.
 
-__Note__: Adding an annotation to an ingress rule overrides any global restrictions set in the ingress-nginx controller.
+**Note**: Adding an annotation to an ingress rule overrides any global restrictions set in the ingress-nginx controller.
 
 ### Custom max body size
 
@@ -341,7 +341,7 @@ Ingress nginx controller allows you to define the timeout that waits to close a 
 
 Many other timeouts can be customized when configuring an ingress. Take a look at the [official docs](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#custom-timeouts).
 
-__Warning__: When running in cloud provider environments, you may often rely on integrated services like AWS NLBs or Azure LBs. Those intermediate Load Balancers could have their own settings which can be in the request path conflicting with values defined in ingress Resources. Read [how to configure ingress-nginx controller in cloud environments]({{< relref "/tutorials/connectivity/ingress/service-type-loadbalancer" >}}) to avoid unexpected results.
+**Warning**: When running in cloud provider environments, you may often rely on integrated services like AWS NLBs or Azure LBs. Those intermediate Load Balancers could have their own settings which can be in the request path conflicting with values defined in ingress Resources. Read [how to configure ingress-nginx controller in cloud environments]({{< relref "/tutorials/connectivity/ingress/service-type-loadbalancer" >}}) to avoid unexpected results.
 
 ### Session affinity
 
@@ -359,7 +359,7 @@ The ingress-nginx controller creates an nginx configuration file. You can direct
 
 The _configuration snippets_ through ingress annotations is disabled by default. To enable parsing of _configuration snippets_, you must set `controller.allowSnippetAnnotations: true` and the `controller.config.annotations-risk-level: Critical`, both in the [App configuration]({{< relref "/tutorials/fleet-management/app-platform/app-configuration" >}}).
 
-__Warning__: We recommend enabling this option only if you TRUST users with permission to create ingress objects. Doing so may allow a user to add restricted configurations to the final `nginx.conf` file.
+**Warning**: We recommend enabling this option only if you TRUST users with permission to create ingress objects. Doing so may allow a user to add restricted configurations to the final `nginx.conf` file.
 
 Here is an example of adding an `Expires` header to every response:
 
@@ -410,7 +410,7 @@ NAME                        DATA      AGE
 ingress-nginx-user-values   0         11m
 ```
 
-__Warning__:
+**Warning**:
 
 Please don't edit any of the other ingress-nginx controller related ConfigMaps.
 
@@ -457,7 +457,7 @@ Please make sure you look at the right tag in that repository. When reading this
 
 ### Configure proxy protocol
 
-__Warning__:
+**Warning**:
 
 We also allow setting `use-proxy-protocol: "true"/"false"`. This setting always applies globally for the ingress-nginx controller.
 

--- a/src/content/tutorials/connectivity/ingress/exposing-workloads/index.md
+++ b/src/content/tutorials/connectivity/ingress/exposing-workloads/index.md
@@ -13,7 +13,7 @@ user_questions:
 ---
 
 {{% notice warning %}}
-**Deprecated:** Ingress NGINX is no longer offered by Giant Swarm. This page is kept for reference. Migrate to [Gateway API with Envoy Gateway]({{< relref "/tutorials/connectivity/gateway-api/" >}}) — see the [migration guide]({{< relref "/tutorials/connectivity/gateway-api/ingress-nginx-migration/" >}}).
+**Deprecated:** Ingress Nginx is no longer offered by Giant Swarm. This page is kept for reference. Migrate to [Gateway API with Envoy Gateway]({{< relref "/tutorials/connectivity/gateway-api/" >}}) — see the [migration guide]({{< relref "/tutorials/connectivity/gateway-api/ingress-nginx-migration/" >}}).
 {{% /notice %}}
 
 Once you have some workload running on your cluster, you might want to access it from outside your cluster. Creating an Ingress resource is the canonical way to do that:

--- a/src/content/tutorials/connectivity/ingress/exposing-workloads/index.md
+++ b/src/content/tutorials/connectivity/ingress/exposing-workloads/index.md
@@ -26,7 +26,7 @@ Before we explain how to set up ingress for a service, please read the next sect
 
 Setting up ingress means to make services publicly available via DNS names. For an application facing the public, you will eventually want to set up names ending in your own domain.
 
-However, for development or test purposes, you can use the fact that every Giant Swarm installation maps to a DNS zone. We call this the __ingress base domain__.
+However, for development or test purposes, you can use the fact that every Giant Swarm installation maps to a DNS zone. We call this the **ingress base domain**.
 
 In our cloud installation, for example, the ingress base domain is
 

--- a/src/content/tutorials/connectivity/ingress/exposing-workloads/index.md
+++ b/src/content/tutorials/connectivity/ingress/exposing-workloads/index.md
@@ -5,16 +5,16 @@ weight: 10
 aliases:
   - /getting-started/connectivity/exposing-workloads
   - /vintage/getting-started/connectivity/exposing-workloads
-menu:
-  principal:
-    parent: tutorials-connectivity-ingress
-    identifier: tutorials-connectivity-ingress-ic
 last_review_date: 2025-09-22
 owner:
   - https://github.com/orgs/giantswarm/teams/team-cabbage
 user_questions:
   - How can I connect my applications to the internet using an ingress controller?
 ---
+
+{{% notice warning %}}
+**Deprecated:** Ingress NGINX is no longer offered by Giant Swarm. This page is kept for reference. Migrate to [Gateway API with Envoy Gateway]({{< relref "/tutorials/connectivity/gateway-api/" >}}) — see the [migration guide]({{< relref "/tutorials/connectivity/gateway-api/ingress-nginx-migration/" >}}).
+{{% /notice %}}
 
 Once you have some workload running on your cluster, you might want to access it from outside your cluster. Creating an Ingress resource is the canonical way to do that:
 

--- a/src/content/tutorials/connectivity/ingress/exposing-workloads/index.md
+++ b/src/content/tutorials/connectivity/ingress/exposing-workloads/index.md
@@ -5,7 +5,7 @@ weight: 10
 aliases:
   - /getting-started/connectivity/exposing-workloads
   - /vintage/getting-started/connectivity/exposing-workloads
-last_review_date: 2025-09-22
+last_review_date: 2026-05-18
 owner:
   - https://github.com/orgs/giantswarm/teams/team-cabbage
 user_questions:

--- a/src/content/tutorials/connectivity/ingress/multi-nginx-ic/index.md
+++ b/src/content/tutorials/connectivity/ingress/multi-nginx-ic/index.md
@@ -20,7 +20,7 @@ owner:
 ---
 
 {{% notice warning %}}
-**Deprecated:** Ingress NGINX is no longer offered by Giant Swarm. This page is kept for reference. Migrate to [Gateway API with Envoy Gateway]({{< relref "/tutorials/connectivity/gateway-api/" >}}) — see the [migration guide]({{< relref "/tutorials/connectivity/gateway-api/ingress-nginx-migration/" >}}).
+**Deprecated:** Ingress Nginx is no longer offered by Giant Swarm. This page is kept for reference. Migrate to [Gateway API with Envoy Gateway]({{< relref "/tutorials/connectivity/gateway-api/" >}}) — see the [migration guide]({{< relref "/tutorials/connectivity/gateway-api/ingress-nginx-migration/" >}}).
 {{% /notice %}}
 
 ingress-nginx controller handles [ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) resources, routing traffic from outside the Kubernetes cluster to services within the cluster.
@@ -140,5 +140,5 @@ For the second ingress-nginx controller installation, ingress class name and hos
 - [Services of type LoadBalancer]({{< relref "/tutorials/connectivity/ingress/service-type-loadbalancer" >}})
 - [Installing an ingress controller]({{< relref "/getting-started/install-an-application#install-ingress-controller" >}})
 - [Ingress nginx controller configuration options](https://github.com/giantswarm/ingress-nginx-app/blob/main/helm/ingress-nginx/values.yaml)
-- [Upstream ingress-nginx controller configuration documentation](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/)
-- [Upstream ingress-nginx controller multi-nginx documentation](https://kubernetes.github.io/ingress-nginx/user-guide/multiple-ingress/)
+- [upstream ingress-nginx controller configuration documentation](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/)
+- [upstream ingress-nginx controller multi-nginx documentation](https://kubernetes.github.io/ingress-nginx/user-guide/multiple-ingress/)

--- a/src/content/tutorials/connectivity/ingress/multi-nginx-ic/index.md
+++ b/src/content/tutorials/connectivity/ingress/multi-nginx-ic/index.md
@@ -9,7 +9,7 @@ user_questions:
   - How do I configure ingress-nginx controller for internal traffic?
   - How do I override the NodePorts on KVM ingresses?
   - How do I configure ingress-nginx controller to allow weak ciphers?
-last_review_date: 2025-09-22
+last_review_date: 2026-05-18
 aliases:
   - /vintage/advanced/connectivity/ingress/multi-nginx-ic
   - /advanced/connectivity/ingress/multi-nginx-ic

--- a/src/content/tutorials/connectivity/ingress/multi-nginx-ic/index.md
+++ b/src/content/tutorials/connectivity/ingress/multi-nginx-ic/index.md
@@ -46,7 +46,7 @@ Further information on configuring ingress-nginx controller can be found on the 
 
 ## Set the ingress class name of each ingress
 
-__Note__: if you are running multiple ingress controllers, you need to use the appropriate `ingressClassName` in your ingress resources, for example.
+**Note**: if you are running multiple ingress controllers, you need to use the appropriate `ingressClassName` in your ingress resources, for example.
 
 ```yaml
 ...

--- a/src/content/tutorials/connectivity/ingress/multi-nginx-ic/index.md
+++ b/src/content/tutorials/connectivity/ingress/multi-nginx-ic/index.md
@@ -3,10 +3,6 @@ linkTitle: Multiple ingress-nginx controllers
 title: Running multiple ingress-nginx controllers
 description: Deploy multiple ingress-nginx controllers in a Kubernetes cluster to separate different ingress traffic classes.
 weight: 20
-menu:
-  principal:
-    parent: tutorials-connectivity-ingress
-    identifier: tutorials-connectivity-ingress-multi-ic
 user_questions:
   - How do I install multiple ingress-nginx controllers?
   - How do I separate internal and external Services?
@@ -22,6 +18,10 @@ aliases:
 owner:
   - https://github.com/orgs/giantswarm/teams/team-cabbage
 ---
+
+{{% notice warning %}}
+**Deprecated:** Ingress NGINX is no longer offered by Giant Swarm. This page is kept for reference. Migrate to [Gateway API with Envoy Gateway]({{< relref "/tutorials/connectivity/gateway-api/" >}}) — see the [migration guide]({{< relref "/tutorials/connectivity/gateway-api/ingress-nginx-migration/" >}}).
+{{% /notice %}}
 
 ingress-nginx controller handles [ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) resources, routing traffic from outside the Kubernetes cluster to services within the cluster.
 

--- a/src/content/tutorials/connectivity/ingress/service-type-loadbalancer/index.md
+++ b/src/content/tutorials/connectivity/ingress/service-type-loadbalancer/index.md
@@ -9,7 +9,7 @@ user_questions:
   - How do I configure an ingress controller behind an ELB that terminates SSL?
   - How do I configure an internal Load Balancer on AWS?
   - How do I configure an internal Load Balancer on Azure?
-last_review_date: 2025-09-22
+last_review_date: 2026-05-18
 aliases:
   - /advanced/connectivity/ingress/service-type-loadbalancer
   - /guides/services-of-type-loadbalancer-and-multiple-ingress-controllers/

--- a/src/content/tutorials/connectivity/ingress/service-type-loadbalancer/index.md
+++ b/src/content/tutorials/connectivity/ingress/service-type-loadbalancer/index.md
@@ -19,7 +19,7 @@ owner:
 ---
 
 {{% notice warning %}}
-**Deprecated:** Ingress NGINX is no longer offered by Giant Swarm. This page is kept for reference. Migrate to [Gateway API with Envoy Gateway]({{< relref "/tutorials/connectivity/gateway-api/" >}}) — see the [migration guide]({{< relref "/tutorials/connectivity/gateway-api/ingress-nginx-migration/" >}}).
+**Deprecated:** Ingress Nginx is no longer offered by Giant Swarm. This page is kept for reference. Migrate to [Gateway API with Envoy Gateway]({{< relref "/tutorials/connectivity/gateway-api/" >}}) — see the [migration guide]({{< relref "/tutorials/connectivity/gateway-api/ingress-nginx-migration/" >}}).
 {{% /notice %}}
 
 Next to using the default ingress-nginx controller, on cloud providers (currently AWS and Azure), you can expose services directly outside your cluster by using services of type `LoadBalancer`.

--- a/src/content/tutorials/connectivity/ingress/service-type-loadbalancer/index.md
+++ b/src/content/tutorials/connectivity/ingress/service-type-loadbalancer/index.md
@@ -26,7 +26,7 @@ Next to using the default ingress-nginx controller, on cloud providers (currentl
 
 You can use this to [expose single services](#service-of-type-lb) to the internet. It's also possible, to [install additional ingress-nginx controllers]({{< relref "/tutorials/connectivity/ingress/multi-nginx-ic" >}}) to expose a subset of your services with a different ingress controller configuration.
 
-__Note__: that this functionality can't be used on premises in most of the occasions.
+**Note**: that this functionality can't be used on premises in most of the occasions.
 
 ## Exposing a single service {#service-of-type-lb}
 

--- a/src/content/tutorials/connectivity/ingress/service-type-loadbalancer/index.md
+++ b/src/content/tutorials/connectivity/ingress/service-type-loadbalancer/index.md
@@ -3,10 +3,6 @@ linkTitle: Load balancer services
 title: Services of type LoadBalancer
 description: Learn how to expose services directly on cloud providers through services of type LoadBalancer.
 weight: 30
-menu:
-  principal:
-    parent: tutorials-connectivity-ingress
-    identifier: tutorials-connectivity-ingress-lb
 user_questions:
   - How can I expose services to the internet?
   - How do I configure an ingress controller behind an ELB for traffic between services within the VPC?
@@ -21,6 +17,10 @@ aliases:
 owner:
   - https://github.com/orgs/giantswarm/teams/team-cabbage
 ---
+
+{{% notice warning %}}
+**Deprecated:** Ingress NGINX is no longer offered by Giant Swarm. This page is kept for reference. Migrate to [Gateway API with Envoy Gateway]({{< relref "/tutorials/connectivity/gateway-api/" >}}) — see the [migration guide]({{< relref "/tutorials/connectivity/gateway-api/ingress-nginx-migration/" >}}).
+{{% /notice %}}
 
 Next to using the default ingress-nginx controller, on cloud providers (currently AWS and Azure), you can expose services directly outside your cluster by using services of type `LoadBalancer`.
 

--- a/src/layouts/shortcodes/notice.html
+++ b/src/layouts/shortcodes/notice.html
@@ -1,0 +1,5 @@
+{{ $type := .Get 0 | default "warning" }}
+<div class="well disclaimer notice--{{ $type }}">
+  <i class="fa fa-warning"></i>
+  {{ .Inner }}
+</div>


### PR DESCRIPTION
Ingress NGINX is no longer offered by Giant Swarm. Archive the ingress
section by removing it from the navigation and adding deprecation notices
to each page pointing users to Gateway API with Envoy Gateway.

- Add reusable `notice` shortcode for styled warning banners
- Rewrite ingress/_index.md as a deprecation landing page (hidden from nav)
- Remove menu entries from all four ingress sub-pages (hidden from nav)
- Add deprecation notice to each sub-page body
- Lower gateway-api section weight (25 → 15) to promote it in the nav

### What this PR does / why we need it

<!-- Reference a GitHub issue, set a descriptive PR title, and use this space for additional explanations. -->

### Things to check/remember before submitting

- If it's one of your first contributions, make sure you've read the [Contributing Guidelines](https://handbook.giantswarm.io/docs/content/docs-guide).
- Bump `last_review_date` in the front matter header of the pages you've touched.
