### PR TITLE
feat(ci): add workflow to audit dependencies

### DIFF
--- a/.github/workflows/js-dependency-audit.yaml
+++ b/.github/workflows/js-dependency-audit.yaml
@@ -1,0 +1,23 @@
+name: JS Dependency Audit
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - '**/package.json'
+      - '**/package-lock.json'
+      - '**/npm-shrinkwrap.json'
+      - '**/yarn.lock'
+      - '**/.yarnrc'
+      - '**/.yarnrc.yml'
+      - '**/pnpm-lock.yaml'
+      - '**/pnpm-workspace.yaml'
+
+permissions: {}
+
+jobs:
+  audit:
+    uses: giantswarm/github-workflows/.github/workflows/js-dependency-audit.yaml@main
+    permissions:
+      contents: read
+      pull-requests: write


### PR DESCRIPTION
Adds the workflow created in https://github.com/giantswarm/github-workflows/pull/168 for auditing dependency changes in PRs.

Pilots: giantswarm/happa#4749 and giantswarm/backstage#1663.

Tracking: giantswarm/giantswarm#36606.