### PR TITLE
Refresh Kueue tutorial for chart 0.2.0 / upstream v0.17.3

### DIFF
--- a/src/content/tutorials/fleet-management/job-management/kueue/index.md
+++ b/src/content/tutorials/fleet-management/job-management/kueue/index.md
@@ -16,7 +16,7 @@ user_questions:
   - How do I set up gang scheduling for distributed workloads?
   - How do I configure all-or-nothing scheduling for coordinated jobs?
   - How do I install and configure Kueue in Giant Swarm?
-last_review_date: 2025-10-16
+last_review_date: 2026-05-18
 ---
 
 Kueue is a Kubernetes-native system that manages quotas and how jobs consume them. It provides advanced job queueing, resource management, and fair sharing capabilities for batch workloads, machine learning training jobs, and other compute-intensive tasks. Giant Swarm supports Kueue through a managed app that simplifies installation and configuration.
@@ -69,7 +69,7 @@ kubectl gs template app \
   --organization=ORGANIZATION \
   --name=kueue \
   --target-namespace=kueue-system \
-  --version=0.1.0 > kueue.yaml
+  --version=0.2.0 > kueue.yaml
 
 kubectl apply -f kueue.yaml
 ```
@@ -88,7 +88,7 @@ Expected output:
 
 ```text
 NAME                                        READY   STATUS    RESTARTS   AGE
-kueue-controller-manager-74c8f8c7c4-x7jwz   2/2     Running   0          2m
+kueue-controller-manager-74c8f8c7c4-x7jwz   1/1     Running   0          2m
 ```
 
 Verify that Kueue CRDs are installed:


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/4258

Updates the Kueue tutorial to match the chart bump in [giantswarm/kueue-app#20](https://github.com/giantswarm/kueue-app/pull/20), which moves the chart from upstream v0.14.1 to v0.17.3 and ships as chart version \`0.2.0\`.

- Install snippet: \`--version=0.1.0\` → \`--version=0.2.0\`.
- Verify-installation pod output: \`2/2 Running\` → \`1/1 Running\` (the manager runs as a single container in v0.17.x).
- New short paragraph in the Install section pointing readers at \`enableCertManager: true\` through a \`userConfig\` configmap, with the chart-version requirement that came out of testing the bump on a workload cluster (the cert-manager path on v0.17.x crashed before our chart fix shipped in \`0.2.0\`).
