### PR TITLE
fix: make commit message and PR-title conventional

### DIFF
--- a/.github/workflows/update-changes.yml
+++ b/.github/workflows/update-changes.yml
@@ -43,9 +43,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.TOKEN }}
         with:
-          title: "Semi-automatic update of generated content"
+          title: "chore: update generated content"
           branch: "automatic-update-of-generated-content"
-          commit-message: "Update self-generated content"
+          commit-message: "chore: update generated content"
           assignees: taylorbot
           reviewers: pipo02mix
           body: |


### PR DESCRIPTION
This updates our cronjob to generate a PR title and commit message that complies with conventional commits.

Before: "Semi-automated update of generated content"

After: "chore: update generated content"