### PR TITLE
chore: assign some pages from honeybadger to bumblebee

### DIFF
--- a/src/content/overview/developer-portal/_index.md
+++ b/src/content/overview/developer-portal/_index.md
@@ -8,7 +8,7 @@ menu:
     identifier: overview-developer-portal
 last_review_date: 2025-10-29
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-honeybadger
+  - https://github.com/orgs/giantswarm/teams/team-bumblebee
 user_questions:
   - What is the developer portal?
   - What is Backstage?

--- a/src/content/overview/developer-portal/access/index.md
+++ b/src/content/overview/developer-portal/access/index.md
@@ -9,7 +9,7 @@ menu:
     identifier: overview-developer-portal-access
 last_review_date: 2025-04-01
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-honeybadger
+  - https://github.com/orgs/giantswarm/teams/team-bumblebee
 user_questions:
   - How can I find the Giant Swarm developer portal?
   - How can I log in to the Giant Swarm developer portal?

--- a/src/content/overview/developer-portal/clusters/_index.md
+++ b/src/content/overview/developer-portal/clusters/_index.md
@@ -9,7 +9,7 @@ menu:
     identifier: overview-developer-portal-clusters
 last_review_date: 2025-04-01
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-honeybadger
+  - https://github.com/orgs/giantswarm/teams/team-bumblebee
 user_questions:
   - What information is there with regard to clusters in the developer portal?
 ---

--- a/src/content/overview/developer-portal/clusters/details/index.md
+++ b/src/content/overview/developer-portal/clusters/details/index.md
@@ -9,7 +9,7 @@ menu:
     identifier: overview-developer-portal-clusters-details
 last_review_date: 2025-04-01
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-honeybadger
+  - https://github.com/orgs/giantswarm/teams/team-bumblebee
 user_questions:
   - How can I access cluster details in the developer portal?
 ---

--- a/src/content/overview/developer-portal/clusters/list/index.md
+++ b/src/content/overview/developer-portal/clusters/list/index.md
@@ -9,7 +9,7 @@ menu:
     identifier: overview-developer-portal-clusters-list
 last_review_date: 2025-04-01
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-honeybadger
+  - https://github.com/orgs/giantswarm/teams/team-bumblebee
 user_questions:
   - How can I access clusters in the developer portal?
   - How can I navigate to details for a particular cluster in the developer portal?

--- a/src/content/overview/developer-portal/customizing/_index.md
+++ b/src/content/overview/developer-portal/customizing/_index.md
@@ -9,7 +9,7 @@ menu:
     identifier: overview-developer-portal-customizing
 last_review_date: 2025-04-01
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-honeybadger
+  - https://github.com/orgs/giantswarm/teams/team-bumblebee
 user_questions:
   - How can I configure and customize the developer portal?
 ---

--- a/src/content/overview/developer-portal/customizing/annotations/index.md
+++ b/src/content/overview/developer-portal/customizing/annotations/index.md
@@ -9,7 +9,7 @@ menu:
     identifier: overview-developer-portal-customizing-annotations
 last_review_date: 2025-06-24
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-honeybadger
+  - https://github.com/orgs/giantswarm/teams/team-bumblebee
 user_questions:
   - How can I configure and customize the display of annotations in the developer portal?
 ---

--- a/src/content/overview/developer-portal/customizing/catalog/index.md
+++ b/src/content/overview/developer-portal/customizing/catalog/index.md
@@ -9,7 +9,7 @@ menu:
     identifier: overview-developer-portal-customizing-catalog
 last_review_date: 2025-04-01
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-honeybadger
+  - https://github.com/orgs/giantswarm/teams/team-bumblebee
 user_questions:
   - How can I have my own catalog entities in the developer portal?
 ---

--- a/src/content/overview/developer-portal/customizing/gitops-links/index.md
+++ b/src/content/overview/developer-portal/customizing/gitops-links/index.md
@@ -9,7 +9,7 @@ menu:
     identifier: overview-developer-portal-customizing-gitopslinks
 last_review_date: 2025-04-01
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-honeybadger
+  - https://github.com/orgs/giantswarm/teams/team-bumblebee
 user_questions:
   - How can I have links to GitOps sources in the developer portal?
 ---

--- a/src/content/overview/developer-portal/customizing/labels/index.md
+++ b/src/content/overview/developer-portal/customizing/labels/index.md
@@ -9,7 +9,7 @@ menu:
     identifier: overview-developer-portal-customizing-labels
 last_review_date: 2025-06-24
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-honeybadger
+  - https://github.com/orgs/giantswarm/teams/team-bumblebee
 user_questions:
   - How can I configure and customize the display of labels in the developer portal?
 ---

--- a/src/content/overview/developer-portal/customizing/url/index.md
+++ b/src/content/overview/developer-portal/customizing/url/index.md
@@ -9,7 +9,7 @@ menu:
     identifier: overview-developer-portal-customizing-url
 last_review_date: 2025-04-01
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-honeybadger
+  - https://github.com/orgs/giantswarm/teams/team-bumblebee
 user_questions:
   - How can I configure and customize the developer portal?
 ---

--- a/src/content/overview/developer-portal/deployments/index.md
+++ b/src/content/overview/developer-portal/deployments/index.md
@@ -9,7 +9,7 @@ menu:
     identifier: overview-developer-portal-deployments
 last_review_date: 2025-04-01
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-honeybadger
+  - https://github.com/orgs/giantswarm/teams/team-bumblebee
 user_questions:
   - How can I access app details in the developer portal?
 ---

--- a/src/content/overview/developer-portal/deployments/metrics-matching/index.md
+++ b/src/content/overview/developer-portal/deployments/metrics-matching/index.md
@@ -9,7 +9,7 @@ menu:
     identifier: overview-developer-portal-deployments-metricsmatching
 last_review_date: 2026-03-13
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-honeybadger
+  - https://github.com/orgs/giantswarm/teams/team-bumblebee
 user_questions:
   - How do I need to label workloads so that I see metrics in the developer portal?
 ---

--- a/src/content/overview/developer-portal/introduction/index.md
+++ b/src/content/overview/developer-portal/introduction/index.md
@@ -9,7 +9,7 @@ menu:
     identifier: overview-developer-portal-introduction
 last_review_date: 2025-04-01
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-honeybadger
+  - https://github.com/orgs/giantswarm/teams/team-bumblebee
 user_questions:
   - What is the Giant Swarm developer portal?
   - What is Backstage?

--- a/src/content/reference/kubectl-gs/_index.md
+++ b/src/content/reference/kubectl-gs/_index.md
@@ -14,7 +14,7 @@ last_review_date: 2026-03-25
 user_questions:
   - Which commands does kubectl-gs offer?
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-honeybadger
+  - https://github.com/orgs/giantswarm/teams/team-bumblebee
 aliases:
   - /vintage/use-the-api/kubectl-gs/
 ---

--- a/src/content/reference/kubectl-gs/deploy-chart.md
+++ b/src/content/reference/kubectl-gs/deploy-chart.md
@@ -8,7 +8,7 @@ menu:
     parent: reference-kubectlgs
 last_review_date: 2026-03-25
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-honeybadger
+  - https://github.com/orgs/giantswarm/teams/team-bumblebee
 user_questions:
   - How can I deploy a Helm chart using kubectl gs?
 ---

--- a/src/content/reference/kubectl-gs/faq.md
+++ b/src/content/reference/kubectl-gs/faq.md
@@ -8,7 +8,7 @@ menu:
     parent: reference-kubectlgs
 last_review_date: 2024-11-25
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-honeybadger
+  - https://github.com/orgs/giantswarm/teams/team-bumblebee
 user_questions:
   - How can I create a cluster or node pool with kubectl-gs?
   - How can I install an app in a workload cluster with kubectl-gs?

--- a/src/content/reference/kubectl-gs/get-apps.md
+++ b/src/content/reference/kubectl-gs/get-apps.md
@@ -7,7 +7,7 @@ menu:
   principal:
     parent: reference-kubectlgs
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-honeybadger
+  - https://github.com/orgs/giantswarm/teams/team-bumblebee
 user_questions:
   - How can I list apps using kubectl?
   - How can I inspect apps using kubectl?

--- a/src/content/reference/kubectl-gs/get-catalogs.md
+++ b/src/content/reference/kubectl-gs/get-catalogs.md
@@ -8,7 +8,7 @@ menu:
     parent: reference-kubectlgs
 last_review_date: 2024-11-25
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-honeybadger
+  - https://github.com/orgs/giantswarm/teams/team-bumblebee
 user_questions:
   - How can I list catalogs using kubectl?
   - How can I inspect catalogs using kubectl?

--- a/src/content/reference/kubectl-gs/get-clusters.md
+++ b/src/content/reference/kubectl-gs/get-clusters.md
@@ -11,7 +11,7 @@ user_questions:
   - How can I inspect clusters using kubectl?
 last_review_date: 2024-11-25
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-honeybadger
+  - https://github.com/orgs/giantswarm/teams/team-bumblebee
 aliases:
   - /vintage/use-the-api/kubectl-gs/get-clusters/
 ---

--- a/src/content/reference/kubectl-gs/get-nodepools.md
+++ b/src/content/reference/kubectl-gs/get-nodepools.md
@@ -7,7 +7,7 @@ menu:
   principal:
     parent: reference-kubectlgs
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-honeybadger
+  - https://github.com/orgs/giantswarm/teams/team-bumblebee
 user_questions:
   - How can I list node pools in a cluster using kubectl?
   - How can I inspect node pools using kubectl?

--- a/src/content/reference/kubectl-gs/get-organizations.md
+++ b/src/content/reference/kubectl-gs/get-organizations.md
@@ -7,7 +7,7 @@ menu:
   principal:
     parent: reference-kubectlgs
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-honeybadger
+  - https://github.com/orgs/giantswarm/teams/team-bumblebee
 user_questions:
   - How can I list organizations in the management API using kubectl?
   - How can I inspect organizations using kubectl?

--- a/src/content/reference/kubectl-gs/get-releases.md
+++ b/src/content/reference/kubectl-gs/get-releases.md
@@ -7,7 +7,7 @@ menu:
   principal:
     parent: reference-kubectlgs
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-honeybadger
+  - https://github.com/orgs/giantswarm/teams/team-bumblebee
 user_questions:
   - How can I list releases in a cluster using kubectl?
   - How can I inspect releases using kubectl?

--- a/src/content/reference/kubectl-gs/installation.md
+++ b/src/content/reference/kubectl-gs/installation.md
@@ -7,7 +7,7 @@ menu:
   principal:
     parent: reference-kubectlgs
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-honeybadger
+  - https://github.com/orgs/giantswarm/teams/team-bumblebee
 last_review_date: 2024-11-25
 user_questions:
   - Where can I find the Giant Swarm plugin for kubectl?

--- a/src/content/reference/kubectl-gs/login.md
+++ b/src/content/reference/kubectl-gs/login.md
@@ -8,7 +8,7 @@ menu:
     identifier: reference-kubectlgs-login
     parent: reference-kubectlgs
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-honeybadger
+  - https://github.com/orgs/giantswarm/teams/team-bumblebee
 user_questions:
   - How can I log in with kubectl for the platform API?
   - How can I create a workload cluster client certificate?

--- a/src/content/reference/kubectl-gs/telemetry.md
+++ b/src/content/reference/kubectl-gs/telemetry.md
@@ -8,7 +8,7 @@ menu:
     identifier: reference-kubectlgs-telemetry
     parent: reference-kubectlgs
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-honeybadger
+  - https://github.com/orgs/giantswarm/teams/team-bumblebee
 user_questions:
   - What usage data does kubectl-gs collect?
   - How does Giant Swarm use the usage data collected from kubectl-gs?

--- a/src/content/reference/kubectl-gs/template-app.md
+++ b/src/content/reference/kubectl-gs/template-app.md
@@ -8,7 +8,7 @@ menu:
     parent: reference-kubectlgs
 last_review_date: 2026-03-25
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-honeybadger
+  - https://github.com/orgs/giantswarm/teams/team-bumblebee
 user_questions:
   - How can I create an app manifest for the platform API?
   - How can I add labels and annotations to the target namespace of an app?

--- a/src/content/reference/kubectl-gs/template-catalog.md
+++ b/src/content/reference/kubectl-gs/template-catalog.md
@@ -8,7 +8,7 @@ menu:
     parent: reference-kubectlgs
 last_review_date: 2024-11-25
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-honeybadger
+  - https://github.com/orgs/giantswarm/teams/team-bumblebee
 user_questions:
   - How can I create an catalog manifest for the platform API?
   - How can I add catalog level values or secrets for the apps deployed from this catalog?

--- a/src/content/reference/kubectl-gs/template-cluster.md
+++ b/src/content/reference/kubectl-gs/template-cluster.md
@@ -7,7 +7,7 @@ menu:
   principal:
     parent: reference-kubectlgs
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-honeybadger
+  - https://github.com/orgs/giantswarm/teams/team-bumblebee
 user_questions:
   - How can I create a cluster manifest for the platform API?
 last_review_date: 2025-09-03

--- a/src/content/reference/kubectl-gs/template-nodepool.md
+++ b/src/content/reference/kubectl-gs/template-nodepool.md
@@ -13,7 +13,7 @@ user_questions:
   - How can I create a node pool manifest for the platform API?
 last_review_date: 2024-11-25
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-honeybadger
+  - https://github.com/orgs/giantswarm/teams/team-bumblebee
 aliases:
   - /vintage/use-the-api/kubectl-gs/template-nodepool/
 ---

--- a/src/content/reference/kubectl-gs/template-organization.md
+++ b/src/content/reference/kubectl-gs/template-organization.md
@@ -8,7 +8,7 @@ menu:
     parent: reference-kubectlgs
 last_review_date: 2024-11-25
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-honeybadger
+  - https://github.com/orgs/giantswarm/teams/team-bumblebee
 user_questions:
   - How can I create an organization manifest for the platform API?
 aliases:

--- a/src/content/reference/kubectl-gs/update-app.md
+++ b/src/content/reference/kubectl-gs/update-app.md
@@ -8,7 +8,7 @@ menu:
     parent: reference-kubectlgs
 last_review_date: 2024-11-25
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-honeybadger
+  - https://github.com/orgs/giantswarm/teams/team-bumblebee
 user_questions:
   - How can I update an app version from the command line?
 aliases:


### PR DESCRIPTION
This touches:

- developer portal
- kubectl-gs (minus the gitops command family)