### PR TITLE
docs(kubectl-gs): update get releases command reference

### DIFF
--- a/src/content/reference/kubectl-gs/get-releases.md
+++ b/src/content/reference/kubectl-gs/get-releases.md
@@ -11,13 +11,10 @@ owner:
 user_questions:
   - How can I list releases in a cluster using kubectl?
   - How can I inspect releases using kubectl?
-last_review_date: 2024-11-25
+last_review_date: 2026-06-08
 aliases:
   - /vintage/use-the-api/kubectl-gs/get-releases/
 ---
-
-**Note** This command relates to our vintage product and is not relevant for
-Clusters based on Cluster API.
 
 Like with all `get` commands in `kubectl`, this command can be used to get details on one item, a release in this case, or list several of them.
 
@@ -36,14 +33,11 @@ to list some information on all releases available to you in the current install
 Here is some example output:
 
 ```nohighlight
-VERSION          STATUS       AGE   KUBERNETES  CONTAINER LINUX   COREDNS   CALICO
-v14.2.1          ACTIVE       2d    1.19.9      2765.2.3          1.6.5     3.15.3
-v14.2.2          ACTIVE       2d    1.19.9      2605.12.0         1.6.5     3.15.3
-v15.0.0          DEPRECATED   3d    1.20.8      2765.2.6          1.6.5     3.15.3
-v15.1.0          DEPRECATED   4d    1.20.9      2765.2.6          1.8.3     3.15.5
-v15.1.1          DEPRECATED   4d    1.20.9      2765.2.6          1.8.3     3.15.5
-v15.2.0          ACTIVE       20d   1.20.9      2765.2.6          1.8.3     3.15.5
-v15.2.1          ACTIVE       21d   1.20.9      2765.2.6          1.8.3     3.15.5
+VERSION      STATUS       AGE   KUBERNETES   FLATCAR    CILIUM   COREDNS   OBSERVABILITY BUNDLE   SECURITY BUNDLE
+aws-34.3.0   ACTIVE       24d   1.34.7       4593.2.1   1.4.3    1.30.0    2.8.0                  1.17.1
+aws-34.4.0   ACTIVE       3d    1.34.7       4593.2.2   1.4.3    1.30.0    2.8.0                  1.17.1
+eks-34.0.0   DEPRECATED   103d  1.34.4       4459.2.3   1.3.4    1.29.1    2.5.0                  1.16.1
+eks-34.0.1   ACTIVE       48d   1.34.4       4459.2.3   1.3.4    1.30.0    2.5.0                  1.16.1
 ```
 
 ### Get specific release
@@ -51,7 +45,7 @@ v15.2.1          ACTIVE       21d   1.20.9      2765.2.6          1.8.3     3.15
 When used with a release version as additional argument, the command will show details for a single release. Example:
 
 ```nohighlight
-kubectl gs get releases v15.2.1
+kubectl gs get releases aws-34.4.0
 ```
 
 Note: As an alternative to `get releases`, `get release` will also work.
@@ -67,10 +61,12 @@ The standard tabular output format features these columns:
     - `WIP`: Work in progress, a release in development.
     - `DEPRECATED`: Has been replaced by a successor release. No longer recommended.
 - `AGE`: How long ago was the release created.
-- `KUBERNETES`: The version of Kubernetes provided by this release
-- `CONTAINER LINUX`: The version of container linux provided by this release
-- `COREDNS`: The version of CoreDNS provided by this release
-- `CALICO`: The version of Calico provided by this release
+- `KUBERNETES`: The version of Kubernetes provided by this release.
+- `FLATCAR`: The version of Flatcar Container Linux provided by this release.
+- `CILIUM`: The version of Cilium provided by this release.
+- `COREDNS`: The version of CoreDNS provided by this release.
+- `OBSERVABILITY BUNDLE`: The version of the observability bundle provided by this release.
+- `SECURITY BUNDLE`: The version of the security bundle provided by this release.
 
 ## Flags {#flags}
 
@@ -89,10 +85,10 @@ Similar to other `get` subcommands, you can specify the output format of `kubect
 
 To inspect a release's main custom resource in YAML notation, add the `--output yaml` flag (or `-o yaml` in short) to the command.
 
-The following example command would print the main resource for release `v15.2.1`.
+The following example command would print the main resource for release `aws-34.4.0`.
 
 ```nohighlight
-kubectl gs get releases v15.2.1 --output yaml
+kubectl gs get releases aws-34.4.0 --output yaml
 ```
 
 When applied without a release version argument, the output will be a list of resources. Example:


### PR DESCRIPTION
## Summary

- Removes outdated note claiming `get releases` is vintage-only — the command works with CAPI-based releases too
- Updates example output columns: `CONTAINER LINUX` → `FLATCAR`, `CALICO` → `CILIUM`, adds `OBSERVABILITY BUNDLE` and `SECURITY BUNDLE`
- Updates example release versions from old `v15.x` to current `aws-34.x` / `eks-34.x`
- Updates `last_review_date` to 2026-06-08

Spotted during a review of kubectl-gs commands per giantswarm/giantswarm#36810.

## Test plan

- [x] Verified actual `kubectl gs get releases` output against gazelle management cluster