### PR TITLE
docs(kubectl-gs): remove deprecated --namespace flag from template catalog

### DIFF
--- a/src/content/reference/kubectl-gs/template-catalog.md
+++ b/src/content/reference/kubectl-gs/template-catalog.md
@@ -6,7 +6,7 @@ weight: 80
 menu:
   principal:
     parent: reference-kubectlgs
-last_review_date: 2024-11-25
+last_review_date: 2026-06-08
 owner:
   - https://github.com/orgs/giantswarm/teams/team-honeybadger
 user_questions:
@@ -38,12 +38,6 @@ It supports the following required flags:
 - `--type` - Label containing a type of the helm repository. Defaults to `helm`. Can be defined multiple times.
 - `--logo` - URL of the catalog logo image.
 - `--visibility` - Defaults to `public` in which case the catalog appears in the web UI. Any other value will hide the catalog.
-
-It also supports an older flag variation to maintain backward compatibility:
-
-- `--namespace` - replaced by `--target-namespace`.
-
-This older flag variation is marked as deprecated and will be removed in the next major version of `kubectl gs`.
 
 Example command:
 


### PR DESCRIPTION
## Summary

- Removes the mention of `--namespace` as a deprecated flag — it is no longer present in the CLI at all, so documenting it causes confusion
- Updates `last_review_date` to 2026-06-08

Part of giantswarm/giantswarm#36810.

## Test plan

- [x] Verified `kubectl gs template catalog --help` — `--namespace` does not appear in the flag list