### PR TITLE
docs(kubectl-gs): update gitops command family reference

### DIFF
--- a/src/content/reference/kubectl-gs/gitops/add-base.md
+++ b/src/content/reference/kubectl-gs/gitops/add-base.md
@@ -6,7 +6,7 @@ weight: 20
 menu:
   principal:
     parent: kubectlgs-gitops
-last_review_date: 2026-05-21
+last_review_date: 2026-06-08
 owner:
   - https://github.com/orgs/giantswarm/teams/team-honeybadger
 user_questions:
@@ -30,12 +30,10 @@ The structure created by this command is presented below.
 ```nohighlight
 bases
 └── clusters
-    └── capa
+    └── PROVIDER
         └── template
             ├── cluster.yaml
             ├── cluster_config.yaml
-            ├── default_apps.yaml
-            ├── default_apps_config.yaml
             └── kustomization.yaml
 ```
 
@@ -45,26 +43,27 @@ Basic command syntax: `kubectl gs gitops add base FLAGS`.
 
 ### Flags
 
-- `--provider` -- Installation infrastructure provider, supported values: capa, gcp, openstack
+- `--provider` -- Installation infrastructure provider, supported values: `capa`, `capz`, `vsphere` (required)
+- `--region` -- AWS or Azure region where the cluster will be created (required for `capz`)
+- `--azure-subscription-id` -- Azure subscription ID (required for `capz`)
 
 {{% kubectl_gs_gitops_common_flags %}}
 
 ### Examples
 
 ```nohighlight
-kubectl gs gitops add base --provider gcp --dry-run
+kubectl gs gitops add base --provider capa --dry-run
 ```
 
 Output:
 
 ```nohighlight
-
 ## CREATE ##
 ./bases
 ./bases/clusters
-./bases/clusters/gcp
-./bases/clusters/gcp/template
-./bases/clusters/gcp/template/kustomization.yaml
+./bases/clusters/capa
+./bases/clusters/capa/template
+./bases/clusters/capa/template/kustomization.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
 buildMetadata: [originAnnotations]
 configMapGenerator:
@@ -72,18 +71,13 @@ configMapGenerator:
     - values=cluster_config.yaml
     name:  ${cluster_name}-config
     namespace: org-${organization}
-  - files:
-    - values=default_apps_config.yaml
-    name:  ${cluster_name}-default-apps-config
-    namespace: org-${organization}
 generatorOptions:
   disableNameSuffixHash: true
 kind: Kustomization
 resources:
   - cluster.yaml
-  - default_apps.yaml
 
-./bases/clusters/gcp/template/cluster.yaml
+./bases/clusters/capa/template/cluster.yaml
 apiVersion: application.giantswarm.io/v1alpha1
 kind: App
 metadata:
@@ -107,70 +101,29 @@ spec:
     secret:
       name: ""
       namespace: ""
-  name: cluster-gcp
+  name: cluster-aws
   namespace: org-${organization}
   userConfig:
     configMap:
       name: ${cluster_name}-config
       namespace: org-${organization}
-  version: ${cluster_release}
+  version: ""
 
-./bases/clusters/gcp/template/cluster_config.yaml
-clusterName: ${cluster_name}
-controlPlane:
-  containerdVolume: {}
-  etcdVolume: {}
-  kubeletVolume: {}
-  replicas: 3
-  rootVolume: {}
-  serviceAccount: {}
-gcp: {}
-machineDeployments:
-- containerdVolume: {}
-  kubeletVolume: {}
-  name: machine-pool0
-  rootVolume: {}
-  serviceAccount: {}
-organization: ${organization}
-
-./bases/clusters/gcp/template/default_apps.yaml
-apiVersion: application.giantswarm.io/v1alpha1
-kind: App
-metadata:
-  labels:
-    app-operator.giantswarm.io/version: 0.0.0
-    giantswarm.io/cluster: ${cluster_name}
-    giantswarm.io/managed-by: cluster
-  name: ${cluster_name}-default-apps
-  namespace: org-${organization}
-spec:
-  catalog: cluster
-  config:
-    configMap:
-      name: ${cluster_name}-cluster-values
-      namespace: org-${organization}
-    secret:
-      name: ""
-      namespace: ""
-  kubeConfig:
-    context:
-      name: ""
-    inCluster: true
-    secret:
-      name: ""
-      namespace: ""
-  name: default-apps-gcp
-  namespace: org-${organization}
-  userConfig:
-    configMap:
-      name: ${cluster_name}-default-apps-config
-      namespace: org-${organization}
-  version: ${default_apps_release}
-
-./bases/clusters/gcp/template/default_apps_config.yaml
-clusterName: ${cluster_name}
-organization: ${organization}
-
+./bases/clusters/capa/template/cluster_config.yaml
+global:
+  connectivity:
+    network: {}
+    topology: {}
+  controlPlane: {}
+  metadata:
+    name: ${cluster_name}
+    organization: ${organization}
+    preventDeletion: false
+  nodePools:
+    nodepool0: {}
+  providerSpecific: {}
+  release:
+    version: ${release}
 ```
 
 Remove the `--dry-run` flag and re-run it to apply the changes.

--- a/src/content/reference/kubectl-gs/gitops/add-enc.md
+++ b/src/content/reference/kubectl-gs/gitops/add-enc.md
@@ -6,7 +6,7 @@ weight: 40
 menu:
   principal:
     parent: kubectlgs-gitops
-last_review_date: 2026-05-21
+last_review_date: 2026-06-08
 owner:
   - https://github.com/orgs/giantswarm/teams/team-honeybadger
 user_questions:

--- a/src/content/reference/kubectl-gs/gitops/add-update.md
+++ b/src/content/reference/kubectl-gs/gitops/add-update.md
@@ -6,7 +6,7 @@ weight: 35
 menu:
   principal:
     parent: kubectlgs-gitops
-last_review_date: 2026-05-21
+last_review_date: 2026-06-08
 owner:
   - https://github.com/orgs/giantswarm/teams/team-honeybadger
 user_questions:
@@ -55,7 +55,8 @@ Basic command syntax: `kubectl gs gitops add automatic-update FLAGS`.
 - `--app` -- name of the App in the repository to configure automatic update for (required)
 - `--management-cluster` -- name of the management cluster the workload cluster belongs to (required)
 - `--organization` -- name of the organization the workload cluster belongs to (required)
-- `--version-repository` -- the container image repository to update the version from. (required)
+- `--repository` -- name of the GitOps repository (required)
+- `--version-repository` -- the OCI image repository to watch for new versions (required)
 - `--workload-cluster` -- name of the workload cluster to configure the app for (required)
 - `--skip-mapi` -- skip mapi directory when adding the app
 

--- a/src/content/reference/kubectl-gs/gitops/add-wc.md
+++ b/src/content/reference/kubectl-gs/gitops/add-wc.md
@@ -6,7 +6,7 @@ weight: 25
 menu:
   principal:
     parent: kubectlgs-gitops
-last_review_date: 2026-05-21
+last_review_date: 2026-06-08
 owner:
   - https://github.com/orgs/giantswarm/teams/team-honeybadger
 user_questions:
@@ -47,16 +47,14 @@ management-clusters/MC_NAME
                     └── cluster
                         ├── [kustomization.yaml]
                         ├── [cluster_userconfig.yaml]
-                        ├── [patch_cluster_userconfig.yaml]
-                        ├── [default_apps_userconfig.yaml]
-                        └── [patch_default_apps_userconfig.yaml]
+                        └── [patch_cluster_userconfig.yaml]
 ```
 
 The content of the `cluster` directory is optional because in its most basic form, the GitOps repository does not require you to
 put the cluster definition in there. It can be added later by re-running the command with additional flags. Re-running works
 in such case, because `cluster` directory is initially empty. Note however, in order to populate it, you must have a
 working base and reference it by the `--base` flag when running the command. You may customize the referenced base with
-the `--cluster-user-config` and `--default-apps-user-config` flags when needed.
+the `--cluster-user-config` flag when needed.
 
 **Note:** the latest recommendation mandates creation of the `mapi` directory. However, users who have not yet migrated to it,
 but still want to use automation for their repositories, may skip the `mapi` layer by using the `--skip-mapi` flag. Migration is
@@ -68,12 +66,12 @@ Basic command syntax: `kubectl gs gitops add workload-cluster <FLAGS>`
 
 ### Flags
 
-- `--release` -- [workload cluster release](https://github.com/giantswarm/releases) version (required)
 - `--management-cluster` -- name of the management cluster the workload cluster belongs to (required)
 - `--name` -- name of the workload cluster (required)
 - `--organization` -- name of the organization the workload cluster belongs to (required)
 - `--repository-name` -- name of the GitOps repository (required)
 - `--base` -- path to the base directory; must be relative to the repository root
+- `--release` -- [workload cluster release](https://github.com/giantswarm/releases) version; required when `--base` is set
 - `--cluster-user-config` -- cluster app user configuration to patch the base with
 - `--skip-mapi` -- skip mapi directory when adding the app
 
@@ -106,6 +104,7 @@ apiVersion: v1
 kind: Secret
 metadata:
     name: sops-gpg-demowc
+    namespace: default
 
 /tmp/gitops-demo/management-clusters/demomc/organizations/demoorg/workload-clusters
 /tmp/gitops-demo/management-clusters/demomc/organizations/demoorg/workload-clusters/demowc.yaml
@@ -195,6 +194,7 @@ apiVersion: v1
 kind: Secret
 metadata:
     name: sops-gpg-demowc
+    namespace: default
 
 /tmp/gitops-demo/management-clusters/demomc/organizations/demoorg/workload-clusters
 /tmp/gitops-demo/management-clusters/demomc/organizations/demoorg/workload-clusters/demowc.yaml
@@ -326,6 +326,7 @@ apiVersion: v1
 kind: Secret
 metadata:
     name: sops-gpg-demowc
+    namespace: default
 
 /tmp/gitops-demo/management-clusters/demomc/organizations/demoorg/workload-clusters
 /tmp/gitops-demo/management-clusters/demomc/organizations/demoorg/workload-clusters/demowc.yaml


### PR DESCRIPTION
### What this PR does / why we need it

Updates the kubectl-gs `gitops` command family reference docs as part of the systematic review in https://github.com/giantswarm/giantswarm/issues/36810. Each page was checked against the current CLI output and tested against a live cluster.

Changes per page:

**`gitops add base`**
- Corrected provider list: `capa`, `capz`, `vsphere` (was `gcp`, `openstack`)
- Added `--region` and `--azure-subscription-id` flags
- Updated example output to match current real output

**`gitops add encryption`**
- Updated `last_review_date` (command verified working; existing docs accurate)

**`gitops add automatic-update`**
- Added missing `--repository` flag to the flags list
- Fixed `--version-repository` description: "container image repository" (was "OCR repository")

**`gitops add workload-cluster`**
- Removed `--default-apps-user-config` references (flag no longer exists)
- Removed `[default_apps_userconfig.yaml]` / `[patch_default_apps_userconfig.yaml]` from structure diagram
- Fixed `--release`: was marked required, is only required when `--base` is set
- Added missing `namespace: default` to Secret metadata in all three example outputs

### Things to check/remember before submitting

- `last_review_date` bumped on all touched pages ✓