### PR TITLE
docs(kubectl-gs): bump last_review_date for reviewed-unchanged command pages

### DIFF
--- a/src/content/reference/kubectl-gs/get-apps.md
+++ b/src/content/reference/kubectl-gs/get-apps.md
@@ -11,7 +11,7 @@ owner:
 user_questions:
   - How can I list apps using kubectl?
   - How can I inspect apps using kubectl?
-last_review_date: 2024-11-25
+last_review_date: 2026-06-08
 aliases:
   - /vintage/use-the-api/kubectl-gs/get-apps/
 ---

--- a/src/content/reference/kubectl-gs/get-catalogs.md
+++ b/src/content/reference/kubectl-gs/get-catalogs.md
@@ -6,7 +6,7 @@ weight: 20
 menu:
   principal:
     parent: reference-kubectlgs
-last_review_date: 2024-11-25
+last_review_date: 2026-06-08
 owner:
   - https://github.com/orgs/giantswarm/teams/team-honeybadger
 user_questions:

--- a/src/content/reference/kubectl-gs/get-organizations.md
+++ b/src/content/reference/kubectl-gs/get-organizations.md
@@ -11,7 +11,7 @@ owner:
 user_questions:
   - How can I list organizations in the management API using kubectl?
   - How can I inspect organizations using kubectl?
-last_review_date: 2024-11-25
+last_review_date: 2026-06-08
 aliases:
   - /vintage/use-the-api/kubectl-gs/get-organizations/
 ---

--- a/src/content/reference/kubectl-gs/gitops/add-app.md
+++ b/src/content/reference/kubectl-gs/gitops/add-app.md
@@ -6,7 +6,7 @@ weight: 30
 menu:
   principal:
     parent: kubectlgs-gitops
-last_review_date: 2026-05-21
+last_review_date: 2026-06-08
 owner:
   - https://github.com/orgs/giantswarm/teams/team-honeybadger
 user_questions:

--- a/src/content/reference/kubectl-gs/gitops/add-mc.md
+++ b/src/content/reference/kubectl-gs/gitops/add-mc.md
@@ -6,7 +6,7 @@ weight: 15
 menu:
   principal:
     parent: kubectlgs-gitops
-last_review_date: 2026-05-21
+last_review_date: 2026-06-08
 owner:
   - https://github.com/orgs/giantswarm/teams/team-honeybadger
 user_questions:

--- a/src/content/reference/kubectl-gs/gitops/add-org.md
+++ b/src/content/reference/kubectl-gs/gitops/add-org.md
@@ -6,7 +6,7 @@ weight: 20
 menu:
   principal:
     parent: kubectlgs-gitops
-last_review_date: 2026-05-21
+last_review_date: 2026-06-08
 owner:
   - https://github.com/orgs/giantswarm/teams/team-honeybadger
 user_questions:

--- a/src/content/reference/kubectl-gs/gitops/init.md
+++ b/src/content/reference/kubectl-gs/gitops/init.md
@@ -6,7 +6,7 @@ weight: 10
 menu:
   principal:
     parent: kubectlgs-gitops
-last_review_date: 2026-05-21
+last_review_date: 2026-06-08
 owner:
   - https://github.com/orgs/giantswarm/teams/team-honeybadger
 user_questions:

--- a/src/content/reference/kubectl-gs/template-app.md
+++ b/src/content/reference/kubectl-gs/template-app.md
@@ -6,7 +6,7 @@ weight: 70
 menu:
   principal:
     parent: reference-kubectlgs
-last_review_date: 2026-03-25
+last_review_date: 2026-06-08
 owner:
   - https://github.com/orgs/giantswarm/teams/team-honeybadger
 user_questions:

--- a/src/content/reference/kubectl-gs/template-organization.md
+++ b/src/content/reference/kubectl-gs/template-organization.md
@@ -6,7 +6,7 @@ weight: 110
 menu:
   principal:
     parent: reference-kubectlgs
-last_review_date: 2024-11-25
+last_review_date: 2026-06-08
 owner:
   - https://github.com/orgs/giantswarm/teams/team-honeybadger
 user_questions:

--- a/src/content/reference/kubectl-gs/update-app.md
+++ b/src/content/reference/kubectl-gs/update-app.md
@@ -6,7 +6,7 @@ weight: 120
 menu:
   principal:
     parent: reference-kubectlgs
-last_review_date: 2024-11-25
+last_review_date: 2026-06-08
 owner:
   - https://github.com/orgs/giantswarm/teams/team-honeybadger
 user_questions:

--- a/src/content/reference/kubectl-gs/update-cluster.md
+++ b/src/content/reference/kubectl-gs/update-cluster.md
@@ -7,7 +7,7 @@ menu:
   principal:
     parent: reference-kubectlgs
     identifier: reference-kubectlgs-updatecluster
-last_review_date: 2024-11-28
+last_review_date: 2026-06-08
 owner:
   - https://github.com/orgs/giantswarm/teams/team-phoenix
 user_questions:


### PR DESCRIPTION
### What this PR does / why we need it

As part of the systematic kubectl-gs command review in https://github.com/giantswarm/giantswarm/issues/36810, these reference pages were reviewed against the current CLI and found to be **accurate as-is** — no content changes were needed. This PR bumps their `last_review_date` to record the review.

Pages bumped:

- `get apps` (deprecated; verified working)
- `get catalogs`
- `get organizations`
- `template organization`
- `template app`
- `update app` (deprecated)
- `update cluster`
- `gitops init`
- `gitops add app` (deprecated)
- `gitops add management-cluster`
- `gitops add organization`

Pages that *did* require content changes are handled in separate PRs (#3146–#3152).

### Things to check/remember before submitting

- `last_review_date` bumped to 2026-06-08 (date-only changes) ✓