### PR TITLE
feat(HRs): Rewrite app management overview

### DIFF
--- a/src/content/overview/fleet-management/app-management/index.md
+++ b/src/content/overview/fleet-management/app-management/index.md
@@ -1,7 +1,7 @@
 ---
 linkTitle: App management
 title: App management
-description: The app platform allows to manage app catalogs and apps, for simple and standardized deployment across the platform.
+description: The app platform helps you browse, deploy, and manage applications across your clusters. New deployments use Flux HelmRelease; the legacy App custom resource is still supported.
 weight: 40
 menu:
   principal:
@@ -10,124 +10,151 @@ menu:
 owner:
   - https://github.com/orgs/giantswarm/teams/team-honeybadger
 user_questions:
-  - What does App Platform do?
-  - What is an App Catalog?
-  - What is a Managed App?
+  - What does the App Platform do?
+  - How do I deploy apps on Giant Swarm?
+  - What's the recommended way to deploy applications?
+  - What is a managed app?
   - Does Giant Swarm provide app catalogs out of the box?
-  - How is App Platform implemented?
-  - How does the App Platform relate to helm?
-  - What are the components of App Platform?
-  - What are the app catalogs that Giant Swarm provides out of the box?
+  - How is the App Platform implemented?
+  - How does the App Platform relate to Helm?
+  - What is the App custom resource and is it still supported?
   - How can I create an organizational app catalog?
-  - How can I interact with the Giant Swarm App Platform?
-  - Can I create an app catalog?
-last_review_date: 2026-04-20
+  - Can I host my own catalog?
+last_review_date: 2026-06-17
 ---
 
-The _Giant Swarm App Platform_ refers to a set of features and concepts that allow you to browse, install and manage the configurations of apps (such as `prometheus`) from a single place; the [platform API]({{< relref "/overview/architecture#platform-api" >}}).
+The _Giant Swarm App Platform_ is the set of features that help you browse, install, and manage applications across your clusters — from curated Giant Swarm-managed apps such as `prometheus`, `ingress-nginx`, or `cert-manager`, to your own internal services.
 
-Giant Swarm fully supports [`helm`](https://helm.sh/) as a general tool to deploy your applications as well as for our `App Catalog`. Apps are packaged as `helm` charts and can be configured with _values_. A recommended [app configuration]({{< relref "/tutorials/fleet-management/app-platform/app-configuration" >}}) is provided which you can override to meet your needs.
+Applications are packaged as [Helm](https://helm.sh/) charts. You deploy them by creating Flux [HelmRelease](https://fluxcd.io/flux/components/helm/helmreleases/) resources on the management cluster, which Flux reconciles into the target workload cluster. Every Giant Swarm management cluster runs Flux out of the box, so there's nothing extra to install.
 
-The app platform installs these `helm` charts whenever an app installation is requested by you. The `helm` execution is mostly not configurable, with the exception to the options presented in
-[installation configuration]({{< relref "/tutorials/fleet-management/app-platform/installation-configuration" >}}).
+**Note**: The proprietary `App` custom resource (`application.giantswarm.io/v1alpha1`) is still fully supported, but is being phased out in favor of Flux HelmRelease. See [App CR deprecation]({{< relref "/overview/fleet-management/app-management/app-cr-deprecation" >}}) for the timeline and migration path.
 
-This feature of the platform provides a collection of curated managed apps. These managed apps are grouped into app catalogs, which can be browsed through our web interface. They may also install their own catalogs using the platform API. Finally, it's worth noting that Giant Swarm uses the app platform to pre-install apps such as `coredns` or `cluster-autoscaler` into your clusters.
+## How you deploy apps
 
-In short: the _Giant Swarm App Platform_ refers to the whole feature, and an app catalog is a collection of apps.
+A typical deployment uses two Flux resources:
 
-Giant Swarm provides an app catalog with our offered set of cloud-native applications which are operated and pre-configured by us. You are able to set up your own [additional catalog(s)]({{< relref "/tutorials/fleet-management/app-platform/create-catalog" >}}) to provide for any needs you have at the enterprise level.
+- An **[OCIRepository](https://fluxcd.io/flux/components/source/ocirepositories/)** points Flux at a Helm chart in an OCI registry (for example, Giant Swarm's public registry at `gsoci.azurecr.io`). It pins a version or a SemVer range and controls how often Flux checks for updates.
+- A **[HelmRelease](https://fluxcd.io/flux/components/helm/helmreleases/)** references the OCIRepository, declares the target namespace and configuration values, and points at the workload cluster's kubeconfig Secret so Flux can install the chart in the right place.
 
-### What makes up the Giant Swarm app platform {#what-makes-up-the-app-platform}
+Here's what a minimal pair looks like for deploying `ingress-nginx` to a workload cluster called `dev01` from the `acmedev` organization:
 
-Technically the app platform is implemented as a set of operators running on your management cluster and workload clusters. These operators watch various custom resources, some created by us, and others created by you. Together, they make up the desired state of the app platform.
+```yaml
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: dev01-ingress-nginx
+  namespace: org-acmedev
+spec:
+  url: oci://gsoci.azurecr.io/charts/giantswarm/ingress-nginx
+  ref:
+    tag: "3.9.2"
+  interval: 60m
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: dev01-ingress-nginx
+  namespace: org-acmedev
+  labels:
+    giantswarm.io/cluster: dev01
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: dev01-ingress-nginx
+  kubeConfig:
+    secretRef:
+      name: dev01-kubeconfig
+  targetNamespace: kube-system
+  releaseName: dev01-ingress-nginx
+  interval: 60m
+```
 
-For example, this `App` custom resource indicates that you want `kong` installed on a specific workload cluster. Some values are [defaulted]({{< relref "/tutorials/fleet-management/app-platform/defaulting-validation" >}}) for the workload cluster you select.
+For a step-by-step walkthrough, see [Deploying an application via a Flux HelmRelease]({{< relref "/tutorials/fleet-management/app-platform/deploy-app-helmrelease" >}}).
+
+### Why Flux HelmRelease
+
+A few features customers tell us matter most:
+
+- **Standard upstream API.** The same resources Giant Swarm uses internally and the same controllers thousands of teams already run elsewhere. No proprietary CRD to learn.
+- **Automatic version updates.** Pin a SemVer range on the OCIRepository and Flux rolls out new patches or minors as they ship.
+- **Layered configuration.** `valuesFrom` references ConfigMaps and Secrets with explicit merge order, so there's no surprise about which value wins.
+- **Dependency ordering.** Use `dependsOn` to install resources in a specific sequence (for example, install `cert-manager` before anything that needs a certificate).
+- **Drift detection.** If something or someone edits the deployed resources manually, Flux brings them back in line.
+- **Post-renderers.** Apply a Kustomize patch over a chart's rendered output without forking the chart.
+- **Operational controls.** Suspend a release for a maintenance window with `flux suspend`, then `flux resume` when you're ready. Force an immediate reconciliation with `flux reconcile`.
+
+## The Giant Swarm app catalog
+
+Giant Swarm publishes a catalog of cloud-native applications that we operate and pre-configure. The charts live in our public OCI registry at `gsoci.azurecr.io/charts/giantswarm/`. You can browse the catalog through the [developer portal]({{< relref "/overview/developer-portal/" >}}) or pull charts directly with any OCI-aware tool.
+
+The maturity levels of apps in this catalog are expressed through semantic versioning:
+
+- **`-alpha` or `-beta` suffix** — basic maturity. No stable release. Best-effort support.
+- **`-rc*` suffix** — preview maturity. Lets you preview a new release and evaluate new features. Best-effort support.
+- **Version `>= v1.0.0`, no suffix** — stable maturity. Available as a managed offering with support and SLA.
+
+### Managed app definition
+
+A _managed app_ is an app in our Giant Swarm catalog that comes with:
+
+- **Safe and tested deployment.** The Helm chart is ready to use and tested. We [build apps a common way](https://github.com/giantswarm/app-build-suite) and validate them through a [testing framework](https://github.com/giantswarm/app-test-suite) that checks deployability, basic functionality, security, and upgrade viability.
+- **Monitoring.** Giant Swarm makes sure the main components of the app run and that the app behaves as expected. Our automation sets up monitoring and alerting on the metrics needed to honor our SLAs. When an alert fires, the operations team performs root cause analysis to determine whether the issue is on Giant Swarm's side or originates from customer configuration.
+- **Configurations and plugins.** You can configure and extend the app freely. Configurations that deviate from the defaults are your responsibility to test and maintain — we're always happy to help validate them against best practices, but rolling them out is your call. Giant Swarm tests upgrades only against default values; if you've customized configuration, validate the upgrade in a lower environment first.
+- **Upgrades.** We follow semantic versioning:
+
+  1. Patch releases (for example, `2.1.1 → 2.1.2`) roll automatically; we log them and communicate the changes.
+  2. Minor releases ship the same way, with changelogs and customer communication.
+  3. Major releases are customer-triggered. As with our managed Kubernetes, we support one major version back.
+
+  All changes land in the changelogs and we communicate them weekly. You decide when to upgrade, so changes happen inside your maintenance windows. If you'd like Flux to roll new versions on a schedule, see [automatic chart updates with Flux](https://fluxcd.io/flux/guides/image-update/).
+
+- **Dependencies.** When a managed app needs secondary apps to function, we adapt the chart to run a standard deployment of the secondary app. Those secondary apps aren't managed under the same terms as primary apps.
+
+## Hosting your own catalog
+
+You don't need a Giant Swarm-specific catalog mechanism to host your own charts — you can publish them to any OCI registry your management cluster and workload clusters can reach. Once they're there, point an OCIRepository at the registry and reference it from a HelmRelease. The same applies to HTTP-based Helm repositories: Flux supports those via the [HelmRepository](https://fluxcd.io/flux/components/source/helmrepositories/) source.
+
+If you'd like Giant Swarm to host your charts alongside ours, ask your account engineer.
+
+## How to interact with the app platform
+
+Manage HelmRelease and OCIRepository resources with whatever tool fits your workflow:
+
+- **`kubectl`** — apply manifests directly to the management cluster's [platform API]({{< relref "/overview/architecture#platform-api" >}}).
+- **The [Flux CLI](https://fluxcd.io/flux/cmd/)** — `flux create source oci`, `flux create helmrelease`, `flux get helmreleases`, `flux suspend`, `flux reconcile`, and so on.
+- **GitOps** — store your HelmRelease YAML in a Git repository and let Flux apply changes when you commit. See [FluxCD]({{< relref "/tutorials/continuous-deployment/flux" >}}) for an introduction and [continuous deployment tutorials]({{< relref "/tutorials/continuous-deployment/" >}}) for end-to-end workflows.
+- **The [developer portal]({{< relref "/overview/developer-portal/" >}})** — browse catalogs, inspect deployed releases, and view their status from a web UI.
+
+## Legacy: the App custom resource
+
+Deployments managed via the Giant Swarm `App` CR continue to work without changes. The conceptual model is similar to the Flux-based one — an App CR points at a chart in a `Catalog` and Helm installs it — but the underlying API is Giant Swarm-specific. For example:
 
 ```yaml
 apiVersion: application.giantswarm.io/v1alpha1
 kind: App
 metadata:
-  name: "my-kong"
-  namespace: "x7jwz"
+  name: my-kong
+  namespace: x7jwz
 spec:
-  catalog: "giantswarm"
+  catalog: giantswarm
   config:
     configMap:
-      name: "x7jwz-cluster-values"
-      namespace: "x7jwz"
-  name: "kong-app"
-  namespace: "kong"
-  version: "0.7.2"
+      name: x7jwz-cluster-values
+      namespace: x7jwz
+  name: kong-app
+  namespace: kong
+  version: 0.7.2
   kubeConfig:
-     inCluster: false
+    inCluster: false
   userConfig:
     configMap:
-      name: "kong-user-values"
-      namespace: "x7jwz"
+      name: kong-user-values
+      namespace: x7jwz
 ```
 
-Below you can see a high level overview of the components and resources that work together to enable the features of the Giant Swarm app platform:
+The diagram below shows the components and resources that make up the Giant Swarm app platform when using App CRs:
 
 ![A diagram showing an overview of various components and concepts that make up the Giant Swarm App Platform](app-platform-overview.png)
 <!-- Original version: https://docs.google.com/drawings/d/1V3KcUImxRdrrb2v_nIQnkapHiRkRM6t8PoYGCqWebYY/edit -->
 
-#### The Giant Swarm app catalog
-
-This catalog contains our stable, fully managed apps, with service-level agreement (SLA).
-
-The maturity levels of apps in this catalog are expressed through semantic versioning as follows:
-
-- Version with `-alpha` or `-beta` suffix - the application is only at a basic maturity level. There is no stable release. It's supported on a best effort basis,
-- Version with `-rc*` suffix - the application is at a preview maturity level. This allows customers to preview a new release of an application and evaluate new features. It's supported on a best effort basis.
-- Version >= `v1.0.0` with no suffix - the specified version of the application is at a stable maturity level. It's available to our customers as a managed offering with support and SLA.
-
-### Managed app definition
-
-A `managed app` is an app in our Giant Swarm catalog that provides:
-
-- Safe and tested deployment
-
-The `helm` chart is ready to use and tested, either sanitizing the upstream forked applications or creating good defaults for our maintained ones. [It's offered a common way of building apps](https://github.com/giantswarm/app-build-suite) and a [testing framework](https://github.com/giantswarm/app-test-suite) which ensure the application is deployable and works as expected. Security and upgrade viability are checked too during the integration process.
-
-- Monitoring
-
-Giant Swarm makes sure all the main components of the app are running and that the app is working as expected. At the same time, our automation set up monitoring and alerting on necessary metrics to ensure our service level agreements.
-
-In case of an alert, operations team perform an root cause analysis (RCA) to understand if it's a Giant Swarm or customer-inflicted issue that broke the application.
-
-- Configurations and plugins
-
-The customer can do unlimited configurations to the app. The customer can also install unlimited plugins to the app. The application configuration is the customer's responsibility. In other words, configurations that derail from the default ones have to be tested and maintained by the customer. Giant Swarm is always happy to help in validating whether those configurations adhere to best-practices and test them together with the customer, but it's the latter's responsibility to actually deploy those configurations in their environments according to their deployment processes and maintenance windows.
-
-__Note__: Giant Swarm only perform tests for upgrades with the default values, so in case you have customized configuration you need to ensure that the upgrade procedure works as expected in a lower environment and reach out to our support in case of problems.
-
-- Upgrades
-
-Our team following the common semantic versioning (`semver`) use in cloud-native projects to release our apps:
-
-1. Patch releases (for example, 2.1.1 -> 2.1.2 -> 2.1.3): those are rolled automatically, add them to the change logs, and communicate the changes to the customer.
-2. Minor versions: upgrade to minor versions, add them to the change logs, and communicate the changes to the customer.
-3. Major versions: the customer decides when to do a major upgrade. Similar to our managed Kubernetes, it only supports one major version back.
-
-All changes are in the change logs and communicated them to customers weekly.
-
-It's the responsibility of the customer to upgrade the applications they run. Whereas Giant Swarm provides updated charts and the relative changelogs and is always willing to help customers understand the impact of upgrades, the responsibility of actually triggering upgrades resides on the customer. This ensures that no changes happen outside of customer-defined maintenance windows and gives customers all the time they need to validate upgrades in low environments before applying them to production ones. That said, Giant Swarm provides tooling to automate upgrades for the apps and customers can adopt it to automate changes on the platform.
-
-- Dependencies
-
-If a managed app requires secondary apps to run, charts are adapted to run a "standard" deployment of the secondary app. However, these aren't managed and maintained in the same terms as a primary app.
-
-__Note__: Overall, it adapts the chart to make sure the app works with the customer’s custom configurations and plugins.
-
-### Installing your own app catalog
-
-It’s possible to create your own `App Catalog`. This is useful if you want to create a set of apps available to your company. Currently, this functionality is only available through direct access to the Giant Swarm platform API. You can request access from your account engineer. Prerequisite for this is a standard `helm` chart repository. It should be served through HTTP and accessible to the management cluster and your workload clusters.
-
-### How interact with the Giant Swarm app platform
-
-You can interact with the Giant Swarm app platform through creating `App` custom resources using the platform API or the developer portal.
-
-- [App CRD reference]({{< relref "/reference/platform-api/crd/apps.application.giantswarm.io.md" >}})
-- [The Giant Swarm developer portal]({{< relref "/overview/developer-portal/" >}})
-
-As you have direct access to the platform API you can also interact with the above mentioned resources using `kubectl`, and automate them just as you have been automating other parts of your stack. And as Kubernetes resources and especially some custom resource definitions require lots of boilerplate and conventions, our team built a [kubectl plugin]({{< relref "/reference/kubectl-gs" >}}) to help you with that.
+We're building a migration CLI that converts an App CR — together with its associated ConfigMaps and Secrets — into an equivalent HelmRelease and OCIRepository bundle. For the timeline and reasoning, see [App CR deprecation]({{< relref "/overview/fleet-management/app-management/app-cr-deprecation" >}}). For the legacy walkthrough, see [Getting started deploying an app with the App Platform]({{< relref "/tutorials/fleet-management/app-platform/deploy-app" >}}) and [the App CRD reference]({{< relref "/reference/platform-api/crd/apps.application.giantswarm.io.md" >}}).

--- a/src/content/overview/fleet-management/app-management/index.md
+++ b/src/content/overview/fleet-management/app-management/index.md
@@ -23,7 +23,7 @@ user_questions:
 last_review_date: 2026-06-17
 ---
 
-The _Giant Swarm App Platform_ is the set of features that help you browse, install, and manage applications across your clusters — from curated Giant Swarm-managed apps such as `prometheus`, `ingress-nginx`, or `cert-manager`, to your own internal services.
+The _Giant Swarm App Platform_ is the set of features that help you browse, install, and manage applications across your clusters. It covers both curated Giant Swarm-managed apps (such as `prometheus`, `ingress-nginx`, or `cert-manager`) and your own internal services.
 
 Applications are packaged as [Helm](https://helm.sh/) charts. You deploy them by creating Flux [HelmRelease](https://fluxcd.io/flux/components/helm/helmreleases/) resources on the management cluster, which Flux reconciles into the target workload cluster. Every Giant Swarm management cluster runs Flux out of the box, so there's nothing extra to install.
 
@@ -89,9 +89,9 @@ Giant Swarm publishes a catalog of cloud-native applications that we operate and
 
 The maturity levels of apps in this catalog are expressed through semantic versioning:
 
-- **`-alpha` or `-beta` suffix** — basic maturity. No stable release. Best-effort support.
-- **`-rc*` suffix** — preview maturity. Lets you preview a new release and evaluate new features. Best-effort support.
-- **Version `>= v1.0.0`, no suffix** — stable maturity. Available as a managed offering with support and SLA.
+- **`-alpha` or `-beta` suffix.** Basic maturity. No stable release. Best-effort support.
+- **`-rc*` suffix.** Preview maturity. Lets you preview a new release and evaluate new features. Best-effort support.
+- **Version `>= v1.0.0`, no suffix.** Stable maturity. Available as a managed offering with support and SLA.
 
 ### Managed app definition
 
@@ -99,7 +99,7 @@ A _managed app_ is an app in our Giant Swarm catalog that comes with:
 
 - **Safe and tested deployment.** The Helm chart is ready to use and tested. We [build apps a common way](https://github.com/giantswarm/app-build-suite) and validate them through a [testing framework](https://github.com/giantswarm/app-test-suite) that checks deployability, basic functionality, security, and upgrade viability.
 - **Monitoring.** Giant Swarm makes sure the main components of the app run and that the app behaves as expected. Our automation sets up monitoring and alerting on the metrics needed to honor our SLAs. When an alert fires, the operations team performs root cause analysis to determine whether the issue is on Giant Swarm's side or originates from customer configuration.
-- **Configurations and plugins.** You can configure and extend the app freely. Configurations that deviate from the defaults are your responsibility to test and maintain — we're always happy to help validate them against best practices, but rolling them out is your call. Giant Swarm tests upgrades only against default values; if you've customized configuration, validate the upgrade in a lower environment first.
+- **Configurations and plugins.** You can configure and extend the app freely. Configurations that deviate from the defaults are your responsibility to test and maintain. We're always happy to help validate them against best practices, but rolling them out is your call. Giant Swarm tests upgrades only against default values; if you've customized configuration, validate the upgrade in a lower environment first.
 - **Upgrades.** We follow semantic versioning:
 
   1. Patch releases (for example, `2.1.1 → 2.1.2`) roll automatically; we log them and communicate the changes.
@@ -112,7 +112,7 @@ A _managed app_ is an app in our Giant Swarm catalog that comes with:
 
 ## Hosting your own catalog
 
-You don't need a Giant Swarm-specific catalog mechanism to host your own charts — you can publish them to any OCI registry your management cluster and workload clusters can reach. Once they're there, point an OCIRepository at the registry and reference it from a HelmRelease. The same applies to HTTP-based Helm repositories: Flux supports those via the [HelmRepository](https://fluxcd.io/flux/components/source/helmrepositories/) source.
+You don't need a Giant Swarm-specific catalog mechanism to host your own charts. Publish them to any OCI registry your management cluster and workload clusters can reach. Once they're there, point an OCIRepository at the registry and reference it from a HelmRelease. The same applies to HTTP-based Helm repositories: Flux supports those via the [HelmRepository](https://fluxcd.io/flux/components/source/helmrepositories/) source.
 
 If you'd like Giant Swarm to host your charts alongside ours, ask your account engineer.
 
@@ -120,14 +120,14 @@ If you'd like Giant Swarm to host your charts alongside ours, ask your account e
 
 Manage HelmRelease and OCIRepository resources with whatever tool fits your workflow:
 
-- **`kubectl`** — apply manifests directly to the management cluster's [platform API]({{< relref "/overview/architecture#platform-api" >}}).
-- **The [Flux CLI](https://fluxcd.io/flux/cmd/)** — `flux create source oci`, `flux create helmrelease`, `flux get helmreleases`, `flux suspend`, `flux reconcile`, and so on.
-- **GitOps** — store your HelmRelease YAML in a Git repository and let Flux apply changes when you commit. See [FluxCD]({{< relref "/tutorials/continuous-deployment/flux" >}}) for an introduction and [continuous deployment tutorials]({{< relref "/tutorials/continuous-deployment/" >}}) for end-to-end workflows.
-- **The [developer portal]({{< relref "/overview/developer-portal/" >}})** — browse catalogs, inspect deployed releases, and view their status from a web UI.
+- **`kubectl`**: apply manifests directly to the management cluster's [platform API]({{< relref "/overview/architecture#platform-api" >}}).
+- **The [Flux CLI](https://fluxcd.io/flux/cmd/)**: `flux create source oci`, `flux create helmrelease`, `flux get helmreleases`, `flux suspend`, `flux reconcile`.
+- **GitOps**: store your HelmRelease YAML in a Git repository and let Flux apply changes when you commit. See [FluxCD]({{< relref "/tutorials/continuous-deployment/flux" >}}) for an introduction and [continuous deployment tutorials]({{< relref "/tutorials/continuous-deployment/" >}}) for end-to-end workflows.
+- **The [developer portal]({{< relref "/overview/developer-portal/" >}})**: browse catalogs, inspect deployed releases, and view their status from a web UI.
 
 ## Legacy: the App custom resource
 
-Deployments managed via the Giant Swarm `App` CR continue to work without changes. The conceptual model is similar to the Flux-based one — an App CR points at a chart in a `Catalog` and Helm installs it — but the underlying API is Giant Swarm-specific. For example:
+Deployments managed via the Giant Swarm `App` CR continue to work without changes. The conceptual model is similar to the Flux-based one (an App CR points at a chart in a `Catalog` and Helm installs it), but the underlying API is Giant Swarm-specific. For example:
 
 ```yaml
 apiVersion: application.giantswarm.io/v1alpha1
@@ -157,4 +157,4 @@ The diagram below shows the components and resources that make up the Giant Swar
 ![A diagram showing an overview of various components and concepts that make up the Giant Swarm App Platform](app-platform-overview.png)
 <!-- Original version: https://docs.google.com/drawings/d/1V3KcUImxRdrrb2v_nIQnkapHiRkRM6t8PoYGCqWebYY/edit -->
 
-We're building a migration CLI that converts an App CR — together with its associated ConfigMaps and Secrets — into an equivalent HelmRelease and OCIRepository bundle. For the timeline and reasoning, see [App CR deprecation]({{< relref "/overview/fleet-management/app-management/app-cr-deprecation" >}}). For the legacy walkthrough, see [Getting started deploying an app with the App Platform]({{< relref "/tutorials/fleet-management/app-platform/deploy-app" >}}) and [the App CRD reference]({{< relref "/reference/platform-api/crd/apps.application.giantswarm.io.md" >}}).
+We're building a migration CLI that converts an App CR (together with its associated ConfigMaps and Secrets) into an equivalent HelmRelease and OCIRepository bundle. For the timeline and reasoning, see [App CR deprecation]({{< relref "/overview/fleet-management/app-management/app-cr-deprecation" >}}). For the legacy walkthrough, see [Getting started deploying an app with the App Platform]({{< relref "/tutorials/fleet-management/app-platform/deploy-app" >}}) and [the App CRD reference]({{< relref "/reference/platform-api/crd/apps.application.giantswarm.io.md" >}}).


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/4316

Adds a new page under overview/fleet-management/app-management/ that will serve as the link target for deprecation banners across CRD references and App-CR-specific tutorials. Timeline is intentionally TBD; content explains the move to Flux HelmRelease, what's affected, and points at the existing HelmRelease tutorial as the recommended path for new deployments.


@mproffitt, happy to receive a contribution from you :) 