### PR TITLE
feat: add steps and step shortcodes for step-by-step content

### DIFF
--- a/src/assets/styles/_steps.sass
+++ b/src/assets/styles/_steps.sass
@@ -1,0 +1,68 @@
+// Styles for the `steps` / `step` shortcode (step-by-step processes).
+
+$step-number-size: 32px
+$step-line-color: #ccc
+$step-number-bg: #1c91d5
+
+// Rendered as an <ol>; reset the native list styling since the visible number
+// is drawn by `.step-number`.
+.steps
+  margin: 24px 0
+  padding: 0
+  list-style: none
+
+.step
+  position: relative
+  display: flex
+  align-items: flex-start
+  padding-bottom: 24px
+  // Override the global `li` margin so the connecting line reaches the next
+  // number without a gap; spacing between steps comes from padding-bottom.
+  margin-bottom: 0
+
+.step:last-child
+  padding-bottom: 0
+
+// Vertical line connecting the step numbers. Drawn behind the circle and
+// hidden on the last step so it stops at the final number.
+.step:not(:last-child)::before
+  content: ''
+  position: absolute
+  top: $step-number-size
+  bottom: 0
+  left: ($step-number-size / 2) - 1px
+  width: 2px
+  background: $step-line-color
+
+.step-number
+  flex: 0 0 $step-number-size
+  width: $step-number-size
+  height: $step-number-size
+  border-radius: 50%
+  background: $step-number-bg
+  color: #fff
+  font-weight: 700
+  display: flex
+  align-items: center
+  justify-content: center
+  position: relative
+  z-index: 1
+
+.step-body
+  flex: 1
+  min-width: 0
+  padding-left: 16px
+
+// The headline is a Markdown `### ` heading (so it lands in the table of
+// contents) rendered as the first child of the step body. It sits on the same
+// vertical level as the number circle.
+.step-body > h3
+  margin: 0 0 8px 0
+  min-height: $step-number-size
+  display: flex
+  align-items: center
+
+// Content is indented under the headline (the column padding already clears
+// the connecting line). Drop the trailing margin of the last block.
+.step-body > :last-child
+  margin-bottom: 0

--- a/src/assets/styles/base.sass
+++ b/src/assets/styles/base.sass
@@ -4,6 +4,7 @@
 @import home
 @import search
 @import mermaid
+@import steps
 
 @import chart.css
 @import crd.css

--- a/src/content/tutorials/observability/network-monitoring/index.md
+++ b/src/content/tutorials/observability/network-monitoring/index.md
@@ -97,7 +97,9 @@ In this scenario, your cloud bill shows high network costs. You suspect cross-AZ
 
 **The problem**: A `payments` service frequently queries a `database` service. Because pods are distributed across availability zones for high availability, many of these requests cross zone boundaries. At $0.01/GB, a service transferring 50 GB/day across zones costs approximately $15/month - and this adds up quickly across multiple services.
 
-#### Step 1: Identify high cross-AZ namespaces
+{{% steps %}}
+
+{{% step title="Identify high cross-AZ namespaces" %}}
 
 1. Open the **Network Traffic Analysis - Overview** dashboard in Grafana
 2. Look at the **Average Cross-AZ Network Traffic** panel
@@ -106,7 +108,9 @@ In this scenario, your cloud bill shows high network costs. You suspect cross-AZ
 
 ![network traffic analysis - overview](./network-monitoring-overview.png)
 
-#### Step 2: Investigate Traffic Source
+{{% /step %}}
+
+{{% step title="Investigate traffic source" %}}
 
 1. Open the **Network Traffic Analysis** dashboard (the detailed view)
 2. Use the namespace filter to select the `payments` namespace we identified
@@ -121,7 +125,9 @@ For advanced investigation, you can explore specific panel queries, for example 
 
 ![network traffic analysis - explore](./network-monitoring-explore.png)
 
-#### Step 3: Apply Optimizations
+{{% /step %}}
+
+{{% step title="Apply optimizations" %}}
 
 Based on your investigation, choose one or more of the following strategies to reduce cross-AZ traffic:
 
@@ -129,7 +135,9 @@ Based on your investigation, choose one or more of the following strategies to r
 - [Topology spread constraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/) to ensure your workload is which maximizes the chance of same-zone communication when combined with topology-aware routing
 - [Pod affinity for co-location](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity): for services that communicate frequently, use pod affinity to prefer scheduling them in the same zone.
 
-#### Step 4: Verify the optimization
+{{% /step %}}
+
+{{% step title="Verify the optimization" %}}
 
 After applying changes, allow some time for traffic patterns to stabilize, then verify the improvement:
 
@@ -138,6 +146,10 @@ After applying changes, allow some time for traffic patterns to stabilize, then 
 3. You should see a reduction in the **Average Cross-AZ Network Traffic** panel
 
 **Important**: Some cross-AZ traffic is expected and healthy - it ensures your application remains available if a zone fails. The goal is to reduce unnecessary cross-AZ traffic, not remove it entirely.
+
+{{% /step %}}
+
+{{% /steps %}}
 
 ## Understanding the Metrics
 

--- a/src/layouts/shortcodes/step.html
+++ b/src/layouts/shortcodes/step.html
@@ -1,0 +1,20 @@
+{{- /* Invoke with percent notation ({{% step %}}) so the headline below is a
+       real Markdown heading and gets picked up by the page table of contents.
+       The step counter is scoped to the parent `steps` instance, so each block
+       numbers from 1. The number circle is decorative ‒ the surrounding ordered
+       list already conveys the sequence to assistive technology ‒ so it is
+       hidden from the accessibility tree. */ -}}
+{{- .Parent.Scratch.Add "stepcount" 1 -}}
+{{- $number := .Parent.Scratch.Get "stepcount" -}}
+{{- $title := .Get "title" -}}
+{{- if not $title }}{{ errorf "Each `step` requires a `title` in %q" .Page.File.Path }}{{ end -}}
+<li class="step">
+<div class="step-number" aria-hidden="true">{{ $number }}</div>
+<div class="step-body">
+
+### {{ $title }}
+
+{{ .Inner }}
+
+</div>
+</li>

--- a/src/layouts/shortcodes/steps.html
+++ b/src/layouts/shortcodes/steps.html
@@ -1,0 +1,9 @@
+{{- /* Invoke with percent notation ({{% steps %}}) so step headlines become
+       real Markdown headings and appear in the page table of contents.
+       Rendered as an ordered list so assistive technology announces it as a
+       numbered, sequential set of steps. */ -}}
+<ol class="steps" aria-label="Step-by-step instructions">
+
+{{ .Inner }}
+
+</ol>


### PR DESCRIPTION
This PR introduces a new shortcodes pair for rendering step-by-step list content.

The new shortcode is also applied to the article `/tutorials/observability/network-monitoring/`.

## Preview

<img width="708" height="692" alt="image" src="https://github.com/user-attachments/assets/7fa0f522-709c-4fe3-ae9e-f4b034575686" />


## Code example

```text
{{% steps %}}
{{% step title="Install the CLI" %}}
Run `brew install ...` and verify the installation.
{{% /step %}}
{{% step title="Log in" %}}
Authenticate with the platform API.
{{% /step %}}
{{% /steps %}}
```