### PR TITLE
feat: add export skills for Miro and CSV

### DIFF
--- a/.claude/skills/export-csv/SKILL.md
+++ b/.claude/skills/export-csv/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: export-csv
+description: Export a CSV inventory of all documentation pages (title, navigation path levels, and public URL) from the frontmatter of every Markdown file under src/content
+user-invocable: true
+---
+
+# Export a CSV inventory of all documentation pages
+
+Generate a flat CSV listing every documentation page, so the content can be
+reviewed, filtered, or analyzed in a spreadsheet.
+
+A helper script does the work in code — don't assemble the inventory by hand.
+
+## What it produces
+
+A CSV file (`export.csv` by default) with one row per page and these columns:
+
+- `title` — from the page's frontmatter
+- `path_l1` through `path_l6` — the first six URL path segments, i.e. the
+  navigation hierarchy
+- `url` — the public docs URL (`https://docs.giantswarm.io/<relpath>`)
+
+The script walks all `.md` files under `src/content`, reads each file's YAML
+frontmatter, and derives the path levels and URL from the file location.
+
+By default it **excludes the `/changes/` section** (changelogs, `path_l1=changes`),
+which otherwise dominates the output. Adjust `EXCLUDED_SECTIONS` in the script to
+change which top-level sections are skipped.
+
+## Steps
+
+1. Run the script (pure Python plus PyYAML, no Docker needed):
+
+   ```bash
+   python3 .claude/skills/export-csv/export_csv.py
+   ```
+
+   It writes `export.csv` to the current working directory and covers all
+   pages under `src/content`.
+
+2. Report the result to the user — the output path and how many rows were
+   written. Offer to open or summarize the CSV if useful.
+
+## Notes
+
+- The same script also backs the `make export-csv` target, which runs it inside
+  the `docs-scriptrunner` Docker image (no local Python required).
+- Pages with empty content or missing frontmatter are skipped.

--- a/.claude/skills/export-csv/export_csv.py
+++ b/.claude/skills/export-csv/export_csv.py
@@ -12,14 +12,20 @@ from pprint import pprint
 
 PATH = 'src/content'
 
+# Top-level sections (path_l1) excluded from the export by default.
+EXCLUDED_SECTIONS = {'changes'}
+
 def main():
     fpaths = []
-    for root, _, files in os.walk(PATH):
+    for root, dirs, files in os.walk(PATH):
+            # Don't descend into excluded top-level sections.
+            if os.path.relpath(root, PATH) == '.':
+                dirs[:] = [d for d in dirs if d not in EXCLUDED_SECTIONS]
             for file in files:
                 if not file.endswith('.md'):
                     continue
                 fpaths.append(os.path.join(root, file))
-    
+
     export_paths(fpaths)
 
 
@@ -27,7 +33,11 @@ def export_paths(paths):
     """Export data on the list of paths provided"""
     with open('./export.csv', 'w') as csvfile:
         writer = csv.writer(csvfile, quoting=csv.QUOTE_MINIMAL)
-        writer.writerow(['title', 'path_l1', 'path_l2', 'path_l3', 'url'])
+        writer.writerow([
+            'title',
+            'path_l1', 'path_l2', 'path_l3', 'path_l4', 'path_l5', 'path_l6',
+            'url',
+        ])
 
         for p in paths:
             frontmatter = frontmatter_for_path(p)
@@ -41,6 +51,9 @@ def export_paths(paths):
                 path_level(relpath, 0),
                 path_level(relpath, 1),
                 path_level(relpath, 2),
+                path_level(relpath, 3),
+                path_level(relpath, 4),
+                path_level(relpath, 5),
                 f'https://docs.giantswarm.io/{relpath}',
             ])
 

--- a/.claude/skills/export-to-miro/SKILL.md
+++ b/.claude/skills/export-to-miro/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: export-to-miro
+description: Create a box on a Miro board for every row in a CSV inventory of pages (e.g. the output of the export-csv skill) — each box shows the page title as a clickable link to its URL, with the navigation path as a subline
+user-invocable: true
+---
+
+# Export a CSV of pages to boxes on a Miro board
+
+Given a CSV with one row per page (a `title` column, a `url` column, and
+`path_l1`…`path_lN` navigation columns — exactly what the `export-csv` skill
+produces), create one box per row on a Miro board.
+
+Each box is **three independent items**:
+
+1. a `SHAPE` — the bordered rectangle (the box; no text)
+2. a `TEXT` — the page **title**, larger font (size 16), as a link to the `url`
+3. a `TEXT` — the **navigation path** (`path_l*` joined by `/`), smaller (size 11), gray
+
+Two text items are needed because a single Miro item supports only **one** font
+size (see gotchas). A helper script generates the layout DSL deterministically —
+don't hand-write the boxes. You then feed that DSL to the Miro MCP `layout_create`
+tool.
+
+## Prerequisites
+
+- A CSV file to import (default assumption: `export.csv` in the working dir).
+- The Miro MCP server connected, and the **target board URL** from the user
+  (e.g. `https://miro.com/app/board/uXjVO2Dh15w=/`). Ask for it if not given.
+
+## Steps
+
+1. **Generate the DSL** from the CSV:
+
+   ```bash
+   python3 .claude/skills/export-to-miro/generate_miro_dsl.py export.csv
+   ```
+
+   This writes chunk files (`/tmp/miro_dsl_chunk_0.dsl`, `_1.dsl`, …) and prints
+   the grid size, item count (3 per box), and chunk list. It splits into chunks
+   because a single `layout_create` call has a ~50k-char DSL limit. Run with
+   `-h` for layout options (columns, spacing, box size, fonts, colors). The
+   defaults are the agreed design: box 420×120, title size 16, path size 11
+   gray (`#6B7280`), 8 columns.
+
+2. **Create the boxes — delegate to subagents.** Each chunk's `dsl` argument is
+   large (tens of KB), and `layout_create` returns an even larger response. To
+   keep that bulk out of the main agent's context, spawn **one subagent per
+   chunk** and have each subagent do the work. Pass the subagent only the
+   **chunk file path, the board URL, and the expected item count** — do NOT read
+   the chunk file in the main agent (that would pull the big text back into the
+   main context).
+
+   Each subagent should:
+   - `ToolSearch` for `mcp__claude_ai_Miro__layout_create`, then Read its chunk
+     file, then call `layout_create` with `miro_url` = the board URL and `dsl` =
+     the file's exact contents (the MCP tool takes a string, not a file path, so
+     it must inline the text verbatim).
+   - Treat a too-large/"saved to file" response as success; confirm
+     `created_count` equals the expected item count (jq the saved file if
+     needed). Report back only the count.
+
+   Model/chunk-size trade-off (the subagent must reproduce the `dsl` verbatim,
+   so fidelity drops as chunks grow):
+   - **Sonnet** with the default ~44k chunks (≈3 chunks) — good fidelity, few agents.
+   - **Haiku** with smaller chunks (`--max-chars 10000`, ≈9 chunks) — cheapest.
+
+   The generator is deterministic, so if a chunk's count is off, just re-run the
+   script and recreate that one chunk.
+
+3. **Verify.** List the board's shapes/texts and confirm every box's title links
+   correctly and nothing came through broken (see "Verifying"). Report the box
+   count and board URL to the user.
+
+## Critical gotchas (baked into the script — don't undo them)
+
+- **One font size per item.** A `SHAPE` or `TEXT` renders all its text at a
+  single size; inline `<p style='font-size:…'>` / `<span style='font-size:…'>`
+  are **silently stripped**. That's why the title and path are separate `TEXT`
+  items overlaid on a border `SHAPE`.
+
+- **Single-quoted hrefs are mandatory.** Title content uses
+  `<p><a href='https://…'>Title</a></p>`. With *double* quotes the anchor
+  collides with the DSL's double-quoted content string and Miro **silently
+  strips the link**, leaving plain text with a stray `>`. The generator always
+  emits single quotes.
+
+- **HTML-escape title and path.** The script escapes `&`, `<`, `>`, `'`, `"`.
+
+- **No grouping.** The Miro MCP has no group tool. The only container that moves
+  children together is a `FRAME`, but it adds a visible label and clicking a
+  child moves only that child — not worth it. The three items per box are left
+  ungrouped; group them manually in Miro if desired.
+
+- **Boxes auto-nest into overlapping frames.** A box created at coordinates
+  inside an existing frame becomes that frame's child. Usually fine. Use
+  `--x0/--y0` to place the grid in empty space, or set `miro_url` to a specific
+  frame (`…/?moveToWidget=<frame_id>`) to target it (children then use
+  frame-relative coordinates).
+
+- **The 200-item limit only affects frame-scoped *edits*, not creation.**
+  `layout_create` happily creates hundreds of items. But once a frame holds
+  more than 200 items, `layout_read`/`layout_update` *scoped to that frame* fail
+  with `too many items (maximum 200)`. To edit an item in a large frame, scope
+  the `layout_update` to the **individual item's** URL (`…/?moveToWidget=<id>`),
+  which parses just that one item.
+
+## Verifying
+
+`board_list_items` for `item_type: text` returns a large JSON saved to a file.
+Use `jq` on that file:
+
+```bash
+# count title items with a working docs link (expect = number of pages):
+jq '[.data[] | select((.data.content // "") | test("href=.https"))] | length' <FILE>
+# 0 means no link-stripped titles:
+jq '[.data[] | select((.data.content // "") | test("&gt;"))] | length' <FILE>
+```
+
+## Editing or deleting individual items (gotchas)
+
+`layout_update` does find/replace on an item's DSL. When matching content that
+contains a link, two surprises:
+
+- The canonical DSL **backslash-escapes** the link's inner quotes
+  (`href=\"https://…\"`). Your `old_string` must include those backslashes —
+  they are part of the DSL, not JSON artifacts.
+- `layout_read` displays the link **without** the `rel="noopener noreferrer"`
+  attribute, but the matcher includes it. To delete a whole item line, read it
+  first, then match the full canonical line (with `rel` and escaped quotes).
+
+To delete an item: item-scoped `layout_update` with `old_string` = the item's
+exact canonical line and `new_string` = empty.
+
+## Repairing (only if titles were created without working links)
+
+If title items exist with stripped links (content stored as `&gt;Title…`), fix
+each with an **item-scoped** `layout_update` (frame-scoped fails past 200 items):
+`miro_url` = the item's `…/?moveToWidget=<id>`, `old_string` = the broken
+content, `new_string` = `<p><a href='URL'>Title</a></p>`. There can be many, so
+fan the repairs out across parallel subagents (Haiku is sufficient).

--- a/.claude/skills/export-to-miro/generate_miro_dsl.py
+++ b/.claude/skills/export-to-miro/generate_miro_dsl.py
@@ -1,0 +1,150 @@
+"""Generate Miro layout DSL from a CSV inventory of pages.
+
+Reads a CSV with a title column, a url column, and any number of `path_l*`
+columns (e.g. the output of the `export-csv` skill) and emits Miro layout DSL
+laying out one "box" per row in a grid. Each box is composed of THREE
+independent items:
+
+  1. a SHAPE  — the bordered rectangle (the box itself; no text)
+  2. a TEXT   — the page title, larger font, as a clickable link to the URL
+  3. a TEXT   — the navigation path (path_l* joined by "/"), smaller, gray
+
+Two text items are used because a single Miro shape/text item supports only
+ONE font size — inline `font-size` styles are silently stripped. Overlaying a
+large title TEXT and a small path TEXT on a border SHAPE is the only way to get
+two sizes per box.
+
+The three items are NOT grouped: the Miro MCP exposes no grouping tool, and a
+FRAME (the only container that moves children together) adds a visible label
+and awkward click-to-move behavior. Group the items manually in Miro if needed.
+
+The DSL is meant to be fed to the Miro MCP `layout_create` tool, split into
+chunk files because a single call has a ~50k-char DSL limit.
+
+IMPORTANT detail this script encodes (learned the hard way):
+links MUST use SINGLE-quoted hrefs (`<a href='...'>`). Miro shape/text content
+silently strips anchors whose href uses double quotes, because they collide
+with the double-quoted DSL content string.
+
+Usage:
+    python3 generate_miro_dsl.py INPUT.csv [options]
+
+Run with -h for the full option list.
+"""
+
+import argparse
+import csv
+import html
+import math
+import sys
+
+
+def esc(s):
+    """HTML-escape a value for safe inclusion in item content."""
+    return html.escape((s or "").strip(), quote=True)
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Generate Miro layout DSL from a CSV.")
+    ap.add_argument("csv_path")
+    ap.add_argument("--out-prefix", default="/tmp/miro_dsl_chunk")
+    # Grid
+    ap.add_argument("--cols", type=int, default=8)
+    ap.add_argument("--gap-x", type=int, default=460, help="spacing between box centers, x")
+    ap.add_argument("--gap-y", type=int, default=170, help="spacing between box centers, y")
+    ap.add_argument("--x0", type=float, default=None, help="x center of first column (default: centered on 0)")
+    ap.add_argument("--y0", type=float, default=-2000.0, help="y center of first row")
+    # Box geometry (Option B)
+    ap.add_argument("--box-width", type=int, default=420)
+    ap.add_argument("--box-height", type=int, default=120)
+    ap.add_argument("--border", default="#4A6FF3")
+    ap.add_argument("--text-pad", type=int, default=40, help="box_width - text_width")
+    # Title text
+    ap.add_argument("--title-size", type=int, default=16)
+    ap.add_argument("--title-dy", type=int, default=-28, help="title center offset from box center, y")
+    # Path text
+    ap.add_argument("--path-size", type=int, default=11)
+    ap.add_argument("--path-dy", type=int, default=32, help="path center offset from box center, y")
+    ap.add_argument("--path-color", default="#6B7280")
+    # Plumbing
+    ap.add_argument("--max-chars", type=int, default=44000)
+    ap.add_argument("--title-col", default="title")
+    ap.add_argument("--url-col", default="url")
+    args = ap.parse_args()
+
+    with open(args.csv_path, newline="") as f:
+        reader = csv.DictReader(f)
+        fieldnames = reader.fieldnames or []
+        rows = list(reader)
+
+    for required in (args.title_col, args.url_col):
+        if required not in fieldnames:
+            sys.exit(f"error: column '{required}' not found in {args.csv_path}. "
+                     f"Columns present: {', '.join(fieldnames)}")
+
+    path_cols = sorted(
+        (c for c in fieldnames if c.startswith("path_l") and c[len("path_l"):].isdigit()),
+        key=lambda c: int(c[len("path_l"):]),
+    )
+
+    n = len(rows)
+    if n == 0:
+        sys.exit("error: CSV has no data rows.")
+
+    cols = max(1, args.cols)
+    x0 = args.x0 if args.x0 is not None else -(cols - 1) * args.gap_x / 2
+    text_w = args.box_width - args.text_pad
+
+    lines = []
+    for i, r in enumerate(rows):
+        cx = int(round(x0 + (i % cols) * args.gap_x))
+        cy = int(round(args.y0 + (i // cols) * args.gap_y))
+
+        title = esc(r.get(args.title_col, ""))
+        url = (r.get(args.url_col, "") or "").strip()
+        path = esc("/".join(p for p in (r.get(c, "") for c in path_cols) if p and p.strip()))
+
+        # Single-quoted href is REQUIRED — double quotes would clash with the
+        # double-quoted DSL content string and Miro would strip the link.
+        lines.append(
+            f"b{i}box SHAPE x={cx} y={cy} w={args.box_width} h={args.box_height} "
+            f"type=rectangle fill=#FFFFFF border_color={args.border} "
+            f'size=12 valign=middle align=left ""'
+        )
+        lines.append(
+            f"b{i}t TEXT x={cx} y={cy + args.title_dy} w={text_w} align=left "
+            f'size={args.title_size} "<p><a href=\'{url}\'>{title}</a></p>"'
+        )
+        lines.append(
+            f"b{i}p TEXT x={cx} y={cy + args.path_dy} w={text_w} align=left "
+            f'size={args.path_size} color={args.path_color} "<p>{path}</p>"'
+        )
+
+    # Pack lines into chunks under the size limit. Items are independent
+    # (no cross-line aliases), so chunk boundaries can fall anywhere.
+    chunks = []
+    cur, cur_len = [], 0
+    for ln in lines:
+        if cur and cur_len + len(ln) + 1 > args.max_chars:
+            chunks.append(cur)
+            cur, cur_len = [], 0
+        cur.append(ln)
+        cur_len += len(ln) + 1
+    if cur:
+        chunks.append(cur)
+
+    n_rows = math.ceil(n / cols)
+    out = []
+    for idx, c in enumerate(chunks):
+        path = f"{args.out_prefix}_{idx}.dsl"
+        with open(path, "w") as fh:
+            fh.write("\n".join(c))
+        out.append((path, len(c), sum(len(l) + 1 for l in c)))
+
+    print(f"rows={n} grid={cols}x{n_rows} items={len(lines)} (3/box) chunks={len(chunks)}")
+    for path, count, size in out:
+        print(f"  {path}  ({count} items, {size} chars)")
+
+
+if __name__ == "__main__":
+    main()

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ export-csv:
 	  --volume=${PWD}:/workdir \
 	  -w /workdir \
 	  $(REGISTRY)/$(COMPANY)/docs-scriptrunner:latest \
-	  /workdir/scripts/export-csv/script.py
+	  /workdir/.claude/skills/export-csv/export_csv.py
 
 # Aggregate changelog entries from various repositories into our Changes section.
 changes:


### PR DESCRIPTION
This PR adds two export skills:

- CSV export (one record per page)
- Miro export (one box per page with title, link, and breadcrumb)

## Miro preview

<img width="930" height="483" alt="image" src="https://github.com/user-attachments/assets/c50ce30b-aa8e-4581-99f4-520566d12a36" />

