### PR TITLE
feat(HRs): add deprecation banners to App-CR kubectl-gs command pages

### DIFF
--- a/src/content/reference/kubectl-gs/get-apps.md
+++ b/src/content/reference/kubectl-gs/get-apps.md
@@ -16,6 +16,8 @@ aliases:
   - /vintage/use-the-api/kubectl-gs/get-apps/
 ---
 
+**Deprecated:** This command lists the legacy `App` custom resource, which is being phased out in favor of Flux HelmRelease. For new deployments, use `flux get helmreleases` (or `kubectl get helmreleases`). See [App management]({{< relref "/overview/fleet-management/app-management" >}}) for the conceptual overview.
+
 Like with all `get` commands in `kubectl`, this command can be used to get details on one item, an [App]({{< relref "/reference/platform-api/crd/apps.application.giantswarm.io.md" >}})
 custom resource in this case, or list several of them.
 

--- a/src/content/reference/kubectl-gs/get-catalogs.md
+++ b/src/content/reference/kubectl-gs/get-catalogs.md
@@ -16,6 +16,8 @@ aliases:
   - /vintage/use-the-api/kubectl-gs/get-catalogs/
 ---
 
+**Deprecated:** This command lists the legacy `Catalog` resource, which is being phased out in favor of Flux sources. For new deployments, use `flux get sources oci` (or `flux get sources helm` for HTTP-based Helm repositories). See [App management]({{< relref "/overview/fleet-management/app-management" >}}) for the conceptual overview.
+
 Like with all `get` commands in `kubectl`, this command can be used to get details on one item, a [Catalog]({{< relref "/reference/platform-api/crd/catalogs.application.giantswarm.io.md" >}})
 custom resource in this case, or list several of them.
 

--- a/src/content/reference/kubectl-gs/gitops/add-app.md
+++ b/src/content/reference/kubectl-gs/gitops/add-app.md
@@ -15,6 +15,8 @@ aliases:
   - /vintage/use-the-api/kubectl-gs/gitops/add-app/
 ---
 
+**Deprecated:** This command scaffolds the legacy `App` custom resource into a GitOps repository. `App` is being phased out in favor of Flux HelmRelease. For new deployments, scaffold the HelmRelease + OCIRepository pair with `flux create source oci --export` and `flux create helmrelease --export`. See [Deploying an application via a Flux HelmRelease]({{< relref "/tutorials/fleet-management/app-platform/deploy-app-helmrelease" >}}) for a worked example and [App management]({{< relref "/overview/fleet-management/app-management" >}}) for the conceptual overview.
+
 This command adds a new App to the GitOps repository.
 
 ## Prerequisites

--- a/src/content/reference/kubectl-gs/template-app.md
+++ b/src/content/reference/kubectl-gs/template-app.md
@@ -16,7 +16,7 @@ aliases:
   - /vintage/use-the-api/kubectl-gs/template-app/
 ---
 
-**This command is deprecated and will be removed in a future version of kubectl-gs.**
+**Deprecated:** This command produces a manifest for the legacy `App` custom resource, which is being phased out in favor of Flux HelmRelease. For new deployments, use the [Flux CLI](https://fluxcd.io/flux/cmd/): `flux create source oci --export` and `flux create helmrelease --export`. See [App management]({{< relref "/overview/fleet-management/app-management" >}}) for the conceptual overview and [Deploying an application via a Flux HelmRelease]({{< relref "/tutorials/fleet-management/app-platform/deploy-app-helmrelease" >}}) for a worked example.
 
 The `template app` command allows to create a manifest for an app to be installed in a workload cluster. The resulting manifest is meant to be applied to the management cluster, for example via `kubectl apply`.
 

--- a/src/content/reference/kubectl-gs/template-catalog.md
+++ b/src/content/reference/kubectl-gs/template-catalog.md
@@ -16,6 +16,8 @@ aliases:
   - /vintage/use-the-api/kubectl-gs/template-catalog/
 ---
 
+**Deprecated:** This command produces a manifest for the legacy `Catalog` resource, which is being phased out in favor of Flux sources (`OCIRepository`, `HelmRepository`). For new deployments, publish charts to an OCI registry and reference them via `flux create source oci`. See [App management]({{< relref "/overview/fleet-management/app-management" >}}) for the conceptual overview.
+
 The `template catalog` command allows to create an [app catalog]({{< relref "/tutorials/fleet-management/app-platform" >}}) manifest. The resulting manifest is meant to be applied to the management cluster, for example via `kubectl apply`.
 
 The resulting manifest will define a [`Catalog`]({{< relref "/reference/platform-api/crd/catalogs.application.giantswarm.io.md" >}}) resource (API group/version `application.giantswarm.io/v1alpha1`).

--- a/src/content/reference/kubectl-gs/update-app.md
+++ b/src/content/reference/kubectl-gs/update-app.md
@@ -15,6 +15,8 @@ aliases:
   - /vintage/use-the-api/kubectl-gs/update-app/
 ---
 
+**Deprecated:** This command updates the legacy `App` custom resource, which is being phased out in favor of Flux HelmRelease. For HelmRelease, update the chart version by editing the `OCIRepository`'s `spec.ref.tag` field; values are updated by editing the referenced ConfigMap or Secret. See [App management]({{< relref "/overview/fleet-management/app-management" >}}) for the conceptual overview.
+
 This command helps with updating [App]({{< relref "/reference/platform-api/crd/apps.application.giantswarm.io.md" >}}) custom resources.
 
 ## Usage


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/4316

Banners on 6 App-CR-specific kubectl-gs command pages (template-app, get-apps, template-catalog, get-catalogs, update-app, gitops/add-app). Each banner points readers at the Flux CLI equivalent (flux create / flux get) and the existing App management overview. 