### PR TITLE
docs(ai-agents): add Muster / AI agents concept pages and how-to tutorials

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -25,6 +25,11 @@ Microsoft.GeneralURL = NO
 # are commonly used in headings in technical documentation and should not be avoided.
 Microsoft.HeadingAcronyms = NO
 
+# Microsoft.Acronyms expects every acronym to be expanded on first use per page. For a technical audience,
+# terms like "MCP", "SSO", "RBAC", "OAuth", "IDE", "API", "CRD", "YAML", and "URL" are common knowledge and
+# repeating their definitions across every page adds noise without value.
+Microsoft.Acronyms = NO
+
 # No linting at all for the /changes section
 [src/content/changes/*.md]
 BasedOnStyles = Vale

--- a/.vale/styles/config/vocabularies/docs/accept.txt
+++ b/.vale/styles/config/vocabularies/docs/accept.txt
@@ -183,6 +183,7 @@ TraceQL
 UDP
 unmanaged
 upstream[s]?
+Valkey
 vApp
 vCenter
 very

--- a/.vale/styles/config/vocabularies/docs/accept.txt
+++ b/.vale/styles/config/vocabularies/docs/accept.txt
@@ -126,6 +126,7 @@ Kueue
 liveness
 LogQL
 mcp-kubernetes
+mcp-prometheus
 mimirtool
 MIG
 [Mm]uster

--- a/.vale/styles/config/vocabularies/docs/accept.txt
+++ b/.vale/styles/config/vocabularies/docs/accept.txt
@@ -11,6 +11,7 @@ envoy-gateway-app
 ACL
 ACLs
 [Aa]lert
+Atlassian
 Autoscaling
 Autoscaler
 [Bb]ackend
@@ -33,6 +34,7 @@ API[s]?
 ARN[s]?
 ASGs?
 auditable
+authorizationServer
 autoscaler
 autoscaling
 aws-cli
@@ -68,6 +70,7 @@ CRs
 declaratively
 deduplication
 descheduler
+discoverability
 [Dd]ex
 [Dd][Nn][Ss]
 configmap[s]?
@@ -127,6 +130,7 @@ liveness
 LogQL
 mcp-kubernetes
 mcp-prometheus
+MCPServer
 mimirtool
 MIG
 [Mm]uster
@@ -169,6 +173,7 @@ SRE[s]?
 SSL
 SSO
 subnets?
+substring
 [T|t]eleport
 templated
 TLS

--- a/.vale/styles/config/vocabularies/docs/accept.txt
+++ b/.vale/styles/config/vocabularies/docs/accept.txt
@@ -57,7 +57,11 @@ CAPI
 CAPV
 CAPVCD
 CAPZ
+ChatGPT
 CIDR[s]?
+Claude Code
+Claude Desktop
+Claude.ai
 CLI
 CNAME
 cluster-aws
@@ -130,6 +134,7 @@ liveness
 LogQL
 mcp-kubernetes
 mcp-prometheus
+mcp-remote
 MCPServer
 mimirtool
 MIG

--- a/src/content/getting-started/ai-agent-setup/index.md
+++ b/src/content/getting-started/ai-agent-setup/index.md
@@ -1,7 +1,7 @@
 ---
 linkTitle: Set up your AI agent
 title: Set up your AI agent for Kubernetes operations
-description: Learn how to use Muster and mcp-kubernetes to interact with your Giant Swarm management clusters through AI assistants like GitHub Copilot or Cursor.
+description: Learn how to use Muster and mcp-kubernetes to interact with your Giant Swarm management clusters through AI assistants like Claude Code, Cursor, or GitHub Copilot.
 weight: 80
 mermaid: true
 menu:
@@ -13,7 +13,7 @@ owner:
   - https://github.com/orgs/giantswarm/teams/team-bumblebee
 user_questions:
   - How do I use AI assistants with my Kubernetes clusters?
-  - How do I set up Muster with VS Code or Cursor?
+  - How do I set up Muster with Claude Code, Cursor, or VS Code?
   - What is mcp-kubernetes?
   - How do I authenticate with Muster?
 ---
@@ -28,11 +28,11 @@ Two components work together to make this possible:
 
 - **Muster** is a central aggregator that connects all your mcp-kubernetes instances into a single endpoint. Instead of configuring your AI assistant to talk to a separate MCP server for each cluster, you point it at Muster and get unified access to all clusters at once.
 
-Modern AI assistants—VS Code with GitHub Copilot and Cursor—support remote, OAuth-protected MCP servers natively. You point your editor straight at the Muster endpoint over HTTPS, and it runs the SSO login flow itself, with nothing to install or keep running locally:
+Modern AI assistants—Claude Code, Cursor, and VS Code with GitHub Copilot—support remote, OAuth-protected MCP servers natively. You point your editor straight at the Muster endpoint over HTTPS, and it runs the SSO login flow itself, with nothing to install or keep running locally:
 
 {{< mermaid >}}
 flowchart TB
-  client["AI assistant<br/>(VS Code / Cursor)"]
+  client["AI assistant<br/>(Claude Code / Cursor / VS Code)"]
   muster["Muster aggregator<br/>(management cluster)"]
   k8sA["mcp-kubernetes (cluster A)"]
   k8sB["mcp-kubernetes (cluster B)"]
@@ -53,11 +53,32 @@ You'll need:
 
 - Access to a Giant Swarm installation with mcp-kubernetes and Muster deployed. Ask your Giant Swarm account engineer for your Muster endpoint URL—it looks like `https://muster.<management-cluster>.<base-domain>/mcp`.
 - Ensure `dex` is configured in your management clusters with a supported identity provider. Contact Giant Swarm support if not.
-- VS Code with the GitHub Copilot extension, or Cursor.
+- An MCP-capable client: Claude Code, Cursor, or VS Code with the GitHub Copilot extension.
 
 ## Connect your editor directly
 
 This is the recommended setup. Point your editor at the Muster endpoint your account engineer gave you—it looks like `https://muster.<management-cluster>.<base-domain>/mcp`. The first time the editor connects, it opens your browser for SSO login. After you authenticate, the full set of Kubernetes tools becomes available with no restart.
+
+### Claude Code
+
+Register the endpoint as an HTTP MCP server:
+
+```bash
+claude mcp add --transport http muster https://muster.<management-cluster>.<base-domain>/mcp
+```
+
+Then run `/mcp` in your session to complete the browser OAuth login. Alternatively, commit a project-level `.mcp.json` so your team shares the configuration:
+
+```json
+{
+  "mcpServers": {
+    "muster": {
+      "type": "http",
+      "url": "https://muster.<management-cluster>.<base-domain>/mcp"
+    }
+  }
+}
+```
 
 ### Cursor
 
@@ -135,6 +156,12 @@ MCP Servers
 
 For an editor that can't connect to a remote, OAuth-protected MCP server directly, bridge it with `muster agent`. This needs the CLI installed and a context set, as above. The bridge uses the active context, so no endpoint flag is needed in the editor config.
 
+### Claude Code through the bridge
+
+```bash
+claude mcp add muster -- muster agent --mcp-server
+```
+
 ### Cursor through the bridge
 
 ```json
@@ -166,6 +193,14 @@ Make sure MCP is enabled in Cursor's settings. After saving the configuration, y
 ```
 
 The first time your editor connects through the bridge, if you haven't authenticated yet, the agent exposes a single tool called `authenticate_muster`. Your assistant calls it automatically, which opens your browser for SSO login. After authentication succeeds, the full set of Kubernetes tools becomes available—no restart needed.
+
+## Connect from other MCP tools
+
+The Muster endpoint is a standard remote, OAuth-protected MCP server, so it works with any client that supports remote MCP and OAuth—not just code editors. Point the client at the same `https://muster.<management-cluster>.<base-domain>/mcp` URL and complete the browser SSO login.
+
+- **Claude.ai (web) and Claude Desktop**: open Settings -> Connectors, add a custom connector with the endpoint URL, and complete the browser OAuth login. Custom connectors are available on Pro, Max, Team, and Enterprise plans; on Team and Enterprise an organization owner has to add the connector before members can use it.
+- **ChatGPT**: in Connectors (developer mode, available on Business, Enterprise, and Pro), add the MCP server URL and authenticate. The tools then become available to the model.
+- **Any other MCP client**: use the same endpoint URL. For a client that only speaks stdio or has no built-in OAuth flow, bridge it with [`muster agent`](#connect-through-the-local-bridge-fallback) or a generic stdio bridge such as [`mcp-remote`](https://github.com/geelen/mcp-remote).
 
 ## What you can ask
 

--- a/src/content/getting-started/ai-agent-setup/index.md
+++ b/src/content/getting-started/ai-agent-setup/index.md
@@ -3,6 +3,7 @@ linkTitle: Set up your AI agent
 title: Set up your AI agent for Kubernetes operations
 description: Learn how to use Muster and mcp-kubernetes to interact with your Giant Swarm management clusters through AI assistants like GitHub Copilot or Cursor.
 weight: 80
+mermaid: true
 menu:
   principal:
     parent: getting-started
@@ -27,23 +28,22 @@ Two components work together to make this possible:
 
 - **Muster** is a central aggregator that connects all your mcp-kubernetes instances into a single endpoint. Instead of configuring your AI assistant to talk to a separate MCP server for each cluster, you point it at Muster and get unified access to all clusters at once.
 
-The `muster` CLI runs locally as a lightweight agent that bridges your AI assistant (via stdio) with the Muster aggregator (via HTTPS):
+Modern AI assistants—VS Code with GitHub Copilot and Cursor—support remote, OAuth-protected MCP servers natively. You point your editor straight at the Muster endpoint over HTTPS, and it runs the SSO login flow itself, with nothing to install or keep running locally:
 
-```text
-AI Assistant (VS Code / Cursor)
-      │ stdio (MCP protocol)
-      ▼
-muster agent (local CLI process)
-      │ HTTPS
-      ▼
-Muster aggregator (management cluster)
-      │
-      ├── mcp-kubernetes (cluster A)
-      ├── mcp-kubernetes (cluster B)
-      └── mcp-kubernetes (cluster C)
-```
+{{< mermaid >}}
+flowchart TB
+  client["AI assistant<br/>(VS Code / Cursor)"]
+  muster["Muster aggregator<br/>(management cluster)"]
+  k8sA["mcp-kubernetes (cluster A)"]
+  k8sB["mcp-kubernetes (cluster B)"]
+  k8sC["mcp-kubernetes (cluster C)"]
+  client -- "HTTPS (MCP, OAuth)" --> muster
+  muster --> k8sA
+  muster --> k8sB
+  muster --> k8sC
+{{< /mermaid >}}
 
-The agent handles authentication transparently, so your AI assistant never needs to manage tokens or cluster credentials directly.
+That direct connection is the recommended setup, and Muster handles authentication to each cluster on your behalf so your assistant never juggles tokens or credentials directly. For a client that can't reach a remote, OAuth-protected MCP server—one that only speaks stdio, or has no built-in OAuth flow—the `muster` CLI provides an optional local bridge (`muster agent`) that converts stdio to HTTPS and performs the login for you.
 
 For the bigger picture—what Muster is, how the aggregator works, and how it stays secure—see the [AI agents overview]({{< relref "/overview/ai-agents" >}}). If you'd rather ask questions in the browser instead of your IDE, the [developer portal AI chat]({{< relref "/overview/developer-portal/ai-chat" >}}) is powered by the same Muster aggregator.
 
@@ -55,40 +55,68 @@ You'll need:
 - Ensure `dex` is configured in your management clusters with a supported identity provider. Contact Giant Swarm support if not.
 - VS Code with the GitHub Copilot extension, or Cursor.
 
-## Step 1: Install Muster
+## Connect your editor directly
+
+This is the recommended setup. Point your editor at the Muster endpoint your account engineer gave you—it looks like `https://muster.<management-cluster>.<base-domain>/mcp`. The first time the editor connects, it opens your browser for SSO login. After you authenticate, the full set of Kubernetes tools becomes available with no restart.
+
+### Cursor
+
+Create or edit `~/.cursor/mcp.json` (for global settings) or `.cursor/mcp.json` in your project directory, and add:
+
+```json
+{
+  "mcpServers": {
+    "muster": {
+      "url": "https://muster.<management-cluster>.<base-domain>/mcp"
+    }
+  }
+}
+```
+
+Make sure MCP is enabled in Cursor's settings. Cursor opens your browser to authenticate on first connect.
+
+### VS Code (GitHub Copilot)
+
+Create or edit `.vscode/mcp.json` in your workspace (or your user-level MCP settings) and add:
+
+```json
+{
+  "servers": {
+    "muster": {
+      "type": "http",
+      "url": "https://muster.<management-cluster>.<base-domain>/mcp"
+    }
+  }
+}
+```
+
+VS Code opens your browser for SSO the first time Copilot connects. After authentication the Kubernetes tools become available—no restart needed.
+
+## Verify and manage with the muster CLI (optional)
+
+The direct connection above needs only your editor. Install the `muster` CLI when you want a terminal view of what you can reach, the `auth` and `context` commands, or the local bridge described below.
+
+### Install the CLI
 
 Download the `muster` binary from the [GitHub releases page](https://github.com/giantswarm/muster/releases). It's a single binary with no additional dependencies—just put it somewhere on your `PATH`.
 
-## Step 2: Configure your context
+### Point it at your endpoint
 
-A context tells Muster which aggregator endpoint to connect to. Add one with the endpoint URL your account engineer provided, then activate it:
+A context tells the CLI which aggregator endpoint to use. Add one with the endpoint URL your account engineer provided, then activate it:
 
 ```bash
 muster context add my-platform --endpoint https://muster.<management-cluster>.<base-domain>/mcp
 muster context use my-platform
 ```
 
-You can verify the context is set correctly:
-
-```bash
-muster context show my-platform
-```
-
-## Step 3: Authenticate
-
-Run the login command, which opens your browser for SSO authentication:
+### Check what you can reach
 
 ```bash
 muster auth login
-```
-
-After you authenticate, check that everything is connected:
-
-```bash
 muster auth status
 ```
 
-You should see all your MCP servers listed as `Connected`. The output looks something like this:
+`muster auth status` shows the aggregator and each downstream server's state:
 
 ```text
 Muster Aggregator
@@ -103,11 +131,26 @@ MCP Servers
   cluster-c-mcp-kubernetes   Connected [SSO: Exchanged]
 ```
 
-## Step 4: Configure your code editor
+## Connect through the local bridge (fallback)
 
-### VS Code (GitHub Copilot)
+For an editor that can't connect to a remote, OAuth-protected MCP server directly, bridge it with `muster agent`. This needs the CLI installed and a context set, as above. The bridge uses the active context, so no endpoint flag is needed in the editor config.
 
-Create or edit `.vscode/mcp.json` in your workspace (or your user-level MCP settings) and add:
+### Cursor through the bridge
+
+```json
+{
+  "mcpServers": {
+    "muster": {
+      "command": "muster",
+      "args": ["agent", "--mcp-server"]
+    }
+  }
+}
+```
+
+Make sure MCP is enabled in Cursor's settings. After saving the configuration, you can toggle the MCP server off and on from Cursor's MCP settings panel to pick up the changes.
+
+### VS Code through the bridge
 
 ```json
 {
@@ -122,24 +165,7 @@ Create or edit `.vscode/mcp.json` in your workspace (or your user-level MCP sett
 }
 ```
 
-The agent uses the active context you set in Step 2, so no endpoint flag is needed here. The first time Copilot connects, if you haven't authenticated yet, the agent exposes a single tool called `authenticate_muster`. Copilot calls this tool automatically, which opens your browser for SSO login. After authentication succeeds, the full set of Kubernetes tools becomes available—no restart needed.
-
-### Cursor
-
-Create or edit `~/.cursor/mcp.json` (for global settings) or `.cursor/mcp.json` in your project directory, and add:
-
-```json
-{
-  "mcpServers": {
-    "muster": {
-      "command": "muster",
-      "args": ["agent", "--mcp-server"]
-    }
-  }
-}
-```
-
-The agent uses the active context you set in Step 2. Make sure MCP is enabled in Cursor's settings. After saving the configuration, you can toggle the MCP server off and on from Cursor's MCP settings panel to pick up the changes.
+The first time your editor connects through the bridge, if you haven't authenticated yet, the agent exposes a single tool called `authenticate_muster`. Your assistant calls it automatically, which opens your browser for SSO login. After authentication succeeds, the full set of Kubernetes tools becomes available—no restart needed.
 
 ## What you can ask
 
@@ -167,9 +193,9 @@ Muster uses a meta-tool architecture. Instead of exposing hundreds of individual
 
 ## Session management
 
-- **Token expiry:** Access tokens expire every 30 minutes, but the agent refreshes them automatically in the background.
+- **Token expiry:** Access tokens expire every 30 minutes, but your editor (or the local bridge) refreshes them automatically in the background.
 - **Session duration:** Your overall session lasts approximately 30 days (the default) before you need to log in again. This can vary by installation.
-- **Re-authentication:** If your session expires, the agent automatically detects it and initiates re-authentication by opening your browser.
+- **Re-authentication:** If your session expires, your editor (or the bridge) detects it and re-authenticates by opening your browser.
 
 ## CLI quick reference
 
@@ -196,7 +222,7 @@ Your session has likely expired. Run `muster auth login` in a terminal to re-aut
 You may encounter a message like this in the agent output:
 
 ```text
-Failed to list resources: failed to list networkpolicies: networkpolicies.networking.k8s.io is forbidden: User "fernando@example.com" cannot list resource "networkpolicies" in API group "networking.k8s.io" in the namespace "kube-system"
+Failed to list resources: failed to list networkpolicies: networkpolicies.networking.k8s.io is forbidden: User "<user>" cannot list resource "networkpolicies" in API group "networking.k8s.io" in the namespace "kube-system"
 ```
 
 Make sure the user has the correct group attached in the identity provider (Azure AD, GitHub, and similar) which is bound to a role in the cluster to perform those actions.

--- a/src/content/getting-started/ai-agent-setup/index.md
+++ b/src/content/getting-started/ai-agent-setup/index.md
@@ -217,3 +217,4 @@ The mcp-kubernetes instance on that cluster may be temporarily unavailable. Othe
 - [Architecture]({{< relref "/overview/ai-agents/architecture" >}}): how the central aggregator gives you unified access to your whole fleet.
 - [Security]({{< relref "/overview/ai-agents/security" >}}): OAuth 2.1, per-user tool visibility, and how single sign-on works across clusters.
 - [Developer portal AI chat]({{< relref "/overview/developer-portal/ai-chat" >}}): ask the same questions in the browser instead of your IDE.
+- [Muster CLI reference]({{< relref "/reference/muster/cli" >}}): every `muster` command, including `context` and `auth`.

--- a/src/content/getting-started/ai-agent-setup/index.md
+++ b/src/content/getting-started/ai-agent-setup/index.md
@@ -45,6 +45,8 @@ Muster aggregator (management cluster)
 
 The agent handles authentication transparently, so your AI assistant never needs to manage tokens or cluster credentials directly.
 
+For the bigger picture—what Muster is, how the aggregator works, and how it stays secure—see the [AI agents overview]({{< relref "/overview/ai-agents" >}}). If you'd rather ask questions in the browser instead of your IDE, the [developer portal AI chat]({{< relref "/overview/developer-portal/ai-chat" >}}) is powered by the same Muster aggregator.
+
 ## Before you start
 
 You'll need:
@@ -64,6 +66,7 @@ A context tells Muster which aggregator endpoint to connect to. Add one with the
 ```bash
 muster context add my-platform --endpoint https://muster.<management-cluster>.<base-domain>/mcp
 muster context use my-platform
+```
 
 You can verify the context is set correctly:
 
@@ -160,7 +163,7 @@ Once everything's configured, your AI assistant has live access to Kubernetes re
 - "What are the resource requests and limits for pods in the default namespace?"
 - "What Helm releases are installed on cluster A?"
 
-Muster uses a meta-tool architecture—instead of exposing hundreds of individual tools (one per Kubernetes operation per cluster), it exposes a small set of meta-tools (including `list_tools`, `call_tool`, `filter_tools`, and `describe_tool`) that your AI assistant uses automatically. You don't need to know the tool names—just describe what you want in plain language.
+Muster uses a meta-tool architecture—instead of exposing hundreds of individual tools (one per Kubernetes operation per cluster), it exposes a small set of meta-tools (including `list_tools`, `call_tool`, `filter_tools`, and `describe_tool`) that your AI assistant uses automatically. You don't need to know the tool names—just describe what you want in plain language. See [Meta-tools]({{< relref "/overview/ai-agents/meta-tools" >}}) for how this keeps the assistant's context lean.
 
 ## Session management
 
@@ -207,3 +210,10 @@ The mcp-kubernetes instance on that cluster may be temporarily unavailable. Othe
 1. Verify authentication: `muster auth status`
 2. Check that the MCP server is enabled in your editor's MCP settings.
 3. Restart the MCP server from your editor's MCP panel.
+
+## Learn more
+
+- [AI agents overview]({{< relref "/overview/ai-agents" >}}): what AI agents on the platform are and the pieces involved.
+- [Architecture]({{< relref "/overview/ai-agents/architecture" >}}): how the central aggregator gives you unified access to your whole fleet.
+- [Security]({{< relref "/overview/ai-agents/security" >}}): OAuth 2.1, per-user tool visibility, and how single sign-on works across clusters.
+- [Developer portal AI chat]({{< relref "/overview/developer-portal/ai-chat" >}}): ask the same questions in the browser instead of your IDE.

--- a/src/content/getting-started/ai-agent-setup/index.md
+++ b/src/content/getting-started/ai-agent-setup/index.md
@@ -163,7 +163,7 @@ Once everything's configured, your AI assistant has live access to Kubernetes re
 - "What are the resource requests and limits for pods in the default namespace?"
 - "What Helm releases are installed on cluster A?"
 
-Muster uses a meta-tool architecture—instead of exposing hundreds of individual tools (one per Kubernetes operation per cluster), it exposes a small set of meta-tools (including `list_tools`, `call_tool`, `filter_tools`, and `describe_tool`) that your AI assistant uses automatically. You don't need to know the tool names—just describe what you want in plain language. See [Meta-tools]({{< relref "/overview/ai-agents/meta-tools" >}}) for how this keeps the assistant's context lean.
+Muster uses a meta-tool architecture. Instead of exposing hundreds of individual tools (one per Kubernetes operation per cluster), it exposes a small set of meta-tools that your AI assistant uses automatically. These include `list_tools`, `call_tool`, `filter_tools`, and `describe_tool`. You don't need to know the tool names—just describe what you want in plain language. See [Meta-tools]({{< relref "/overview/ai-agents/meta-tools" >}}) for how this keeps the assistant's context lean.
 
 ## Session management
 

--- a/src/content/overview/ai-agents/_index.md
+++ b/src/content/overview/ai-agents/_index.md
@@ -15,7 +15,7 @@ user_questions:
   - What is Muster?
 ---
 
-The Giant Swarm platform is built to be operated by AI agents as well as people. You can ask an AI assistant—in your IDE or in the developer portal—questions like "are there any pods in CrashLoopBackOff on any cluster?" and get answers grounded in live cluster state, without switching between terminals and dashboards.
+The Giant Swarm platform is built to be operated by AI agents and people. You can ask an AI assistant—in your IDE or in the developer portal—questions like "are there any pods in CrashLoopBackOff on any cluster?" and get answers grounded in live cluster state, without switching between terminals and dashboards.
 
 The piece that makes this possible is **Muster**, a universal control plane built on the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/). Muster aggregates many MCP servers—Kubernetes and Prometheus access on every management cluster, plus optionally Grafana, Teleport, and others—behind a single, OAuth-protected endpoint. Your AI assistant connects to Muster instead of juggling a separate connection and set of credentials for each server.
 

--- a/src/content/overview/ai-agents/_index.md
+++ b/src/content/overview/ai-agents/_index.md
@@ -24,7 +24,7 @@ The piece that makes this possible is **Muster**, a universal control plane buil
 - **Muster**: the MCP gateway. It aggregates downstream MCP servers, presents their combined capabilities through one connection, and handles authentication on your behalf.
 - **mcp-kubernetes**: runs on each management cluster and exposes Kubernetes resources (pods, deployments, services, logs, events, and more) through a secure MCP API.
 - **mcp-prometheus**: runs alongside it on each management cluster and exposes the cluster's metrics through MCP, so the assistant can correlate Kubernetes state with PromQL queries and alerts.
-- **Your AI assistant**: VS Code with GitHub Copilot, Cursor, or the developer portal's built-in chat. It talks MCP to Muster and turns your plain-language questions into tool calls.
+- **Your AI assistant**: Claude Code, Cursor, VS Code with GitHub Copilot, the developer portal's built-in chat, and other MCP-capable tools. It talks MCP to Muster and turns your plain-language questions into tool calls.
 
 ## In this section
 

--- a/src/content/overview/ai-agents/_index.md
+++ b/src/content/overview/ai-agents/_index.md
@@ -15,7 +15,7 @@ user_questions:
   - What is Muster?
 ---
 
-The Giant Swarm platform is built to be operated by AI agents and people. You can ask an AI assistant—in your IDE or in the developer portal—questions like "are there any pods in CrashLoopBackOff on any cluster?" and get answers grounded in live cluster state, without switching between terminals and dashboards.
+The Giant Swarm platform is built to be operated by AI agents and people. You can ask an AI assistant—in your IDE or in the developer portal—questions like "are there any pods in CrashLoopBackOff on any cluster?" You get answers grounded in live cluster state, without switching between terminals and dashboards.
 
 The piece that makes this possible is **Muster**, a universal control plane built on the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/). Muster aggregates many MCP servers—Kubernetes and Prometheus access on every management cluster, plus optionally Grafana, Teleport, and others—behind a single, OAuth-protected endpoint. Your AI assistant connects to Muster instead of juggling a separate connection and set of credentials for each server.
 

--- a/src/content/overview/ai-agents/_index.md
+++ b/src/content/overview/ai-agents/_index.md
@@ -1,0 +1,35 @@
+---
+title: AI agents
+description: How AI agents work on the Giant Swarm platform, powered by Muster as an MCP gateway that gives assistants unified, secure access to your fleet.
+weight: 35
+menu:
+  principal:
+    parent: overview
+    identifier: overview-ai-agents
+owner:
+  - https://github.com/orgs/giantswarm/teams/team-bumblebee
+last_review_date: 2026-06-20
+user_questions:
+  - What are AI agents on the Giant Swarm platform?
+  - How do AI assistants access my clusters?
+  - What is Muster?
+---
+
+The Giant Swarm platform is built to be operated by AI agents as well as people. You can ask an AI assistant—in your IDE or in the developer portal—questions like "are there any pods in CrashLoopBackOff on any cluster?" and get answers grounded in live cluster state, without switching between terminals and dashboards.
+
+The piece that makes this possible is **Muster**, a universal control plane built on the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/). Muster aggregates many MCP servers—Kubernetes access on every management cluster, and optionally Prometheus, Grafana, Teleport, and others—behind a single, OAuth-protected endpoint. Your AI assistant connects to Muster instead of juggling a separate connection and set of credentials for each server.
+
+## The pieces
+
+- **Muster**: the MCP gateway. It aggregates downstream MCP servers, presents their combined capabilities through one connection, and handles authentication on your behalf.
+- **mcp-kubernetes**: runs on each management cluster and exposes Kubernetes resources (pods, deployments, services, logs, events, and more) through a secure MCP API.
+- **Your AI assistant**: VS Code with GitHub Copilot, Cursor, or the developer portal's built-in chat. It talks MCP to Muster and turns your plain-language questions into tool calls.
+
+## In this section
+
+- [Introduction]({{< relref "/overview/ai-agents/introduction" >}}): what Muster is and the problem it solves.
+- [Architecture]({{< relref "/overview/ai-agents/architecture" >}}): the aggregator design and how fleet-wide aggregation works.
+- [Meta-tools]({{< relref "/overview/ai-agents/meta-tools" >}}): the small tool surface agents actually see, and how lazy discovery keeps context lean.
+- [Security]({{< relref "/overview/ai-agents/security" >}}): OAuth 2.1, per-user tool visibility, and single sign-on across clusters.
+
+To set up an assistant in your IDE today, follow [Set up your AI agent]({{< relref "/getting-started/ai-agent-setup" >}}).

--- a/src/content/overview/ai-agents/_index.md
+++ b/src/content/overview/ai-agents/_index.md
@@ -17,12 +17,13 @@ user_questions:
 
 The Giant Swarm platform is built to be operated by AI agents as well as people. You can ask an AI assistant—in your IDE or in the developer portal—questions like "are there any pods in CrashLoopBackOff on any cluster?" and get answers grounded in live cluster state, without switching between terminals and dashboards.
 
-The piece that makes this possible is **Muster**, a universal control plane built on the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/). Muster aggregates many MCP servers—Kubernetes access on every management cluster, and optionally Prometheus, Grafana, Teleport, and others—behind a single, OAuth-protected endpoint. Your AI assistant connects to Muster instead of juggling a separate connection and set of credentials for each server.
+The piece that makes this possible is **Muster**, a universal control plane built on the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/). Muster aggregates many MCP servers—Kubernetes and Prometheus access on every management cluster, plus optionally Grafana, Teleport, and others—behind a single, OAuth-protected endpoint. Your AI assistant connects to Muster instead of juggling a separate connection and set of credentials for each server.
 
 ## The pieces
 
 - **Muster**: the MCP gateway. It aggregates downstream MCP servers, presents their combined capabilities through one connection, and handles authentication on your behalf.
 - **mcp-kubernetes**: runs on each management cluster and exposes Kubernetes resources (pods, deployments, services, logs, events, and more) through a secure MCP API.
+- **mcp-prometheus**: runs alongside it on each management cluster and exposes the cluster's metrics through MCP, so the assistant can correlate Kubernetes state with PromQL queries and alerts.
 - **Your AI assistant**: VS Code with GitHub Copilot, Cursor, or the developer portal's built-in chat. It talks MCP to Muster and turns your plain-language questions into tool calls.
 
 ## In this section

--- a/src/content/overview/ai-agents/architecture/index.md
+++ b/src/content/overview/ai-agents/architecture/index.md
@@ -21,6 +21,7 @@ Muster runs as a central **aggregator**, the `muster serve` process, that holds 
 
 ## The aggregator
 
+<!-- vale off -->
 {{< mermaid >}}
 flowchart TB
   client["AI assistant<br/>(VS Code / Cursor / portal chat)"]
@@ -34,6 +35,7 @@ flowchart TB
   serve --> k8sB
   serve --> other
 {{< /mermaid >}}
+<!-- vale on -->
 
 `muster serve` is the central component, typically running on a management cluster. It hosts all business logic, manages the lifecycle of downstream MCP server processes, monitors their health, and exposes a [meta-tools]({{< relref "/overview/ai-agents/meta-tools" >}}) interface over HTTPS, using the MCP HTTP and SSE transports.
 
@@ -63,6 +65,7 @@ The aggregator resolves tool-name conflicts by prefixing external tools with the
 
 For a customer operating several management clusters, a **central** Muster instance aggregates the `mcp-kubernetes` and `mcp-prometheus` servers on each management cluster, giving SREs a single MCP endpoint for the entire fleet:
 
+<!-- vale off -->
 {{< mermaid >}}
 flowchart LR
   user["SRE / developer"]
@@ -76,8 +79,9 @@ flowchart LR
   central --> mcpB
   central --> mcpC
 {{< /mermaid >}}
+<!-- vale on -->
 
-The user authenticates once through their enterprise identity provider. Muster bridges that identity to each remote cluster—reusing the same token where the issuer is trusted, or exchanging it for one valid on the remote cluster where the issuer differs. The [Security]({{< relref "/overview/ai-agents/security" >}}) page covers this token handling in detail.
+The user authenticates once through their enterprise identity provider. Muster bridges that identity to each remote cluster. It reuses the same token where the issuer is trusted, or exchanges it for one valid on the remote cluster where the issuer differs. The [Security]({{< relref "/overview/ai-agents/security" >}}) page covers this token handling in detail.
 
 Two deployment shapes are supported:
 
@@ -88,7 +92,7 @@ Two deployment shapes are supported:
 
 Muster can package a multi-step operation—authenticate, port-forward, query, correlate—as a single named **workflow** that an agent invokes with one call. It's not just convenient. It makes the AI assistant dramatically cheaper, because one workflow call replaces the whole discover-query-correlate loop the agent would otherwise run itself.
 
-A paired A/B trial measured this directly on four real management-cluster alerts, using the same agent, model, and prompt, differing only in whether the agent was given the raw aggregated tools or the matching workflow tool:
+A paired A/B trial measured this directly on four real management-cluster alerts. It used the same agent, model, and prompt, differing only in whether the agent was given the raw aggregated tools or the matching workflow tool:
 
 | Metric | Raw aggregated tools | Workflow tool | Reduction |
 |---|--:|--:|--:|

--- a/src/content/overview/ai-agents/architecture/index.md
+++ b/src/content/overview/ai-agents/architecture/index.md
@@ -39,7 +39,7 @@ flowchart TB
 
 `muster serve` is the central component, typically running on a management cluster. It hosts all business logic, manages the lifecycle of downstream MCP server processes, monitors their health, and exposes a [meta-tools]({{< relref "/overview/ai-agents/meta-tools" >}}) interface over HTTPS, using the MCP HTTP and SSE transports.
 
-Modern AI assistants—VS Code with GitHub Copilot, Cursor, and the developer portal chat—support remote, OAuth-protected MCP servers natively. You point them straight at the aggregator's URL and they handle the [OAuth flow]({{< relref "/overview/ai-agents/security" >}}) themselves:
+Modern AI assistants—Claude Code, Cursor, VS Code with GitHub Copilot, the developer portal chat, and other MCP-capable tools—support remote, OAuth-protected MCP servers natively. You point them straight at the aggregator's URL and they handle the [OAuth flow]({{< relref "/overview/ai-agents/security" >}}) themselves:
 
 ```json
 {

--- a/src/content/overview/ai-agents/architecture/index.md
+++ b/src/content/overview/ai-agents/architecture/index.md
@@ -25,9 +25,9 @@ Muster runs as a central **aggregator**, the `muster serve` process, that holds 
 flowchart TB
   client["AI assistant<br/>(VS Code / Cursor / portal chat)"]
   serve["muster serve<br/>(aggregator, management cluster)"]
-  k8sA["mcp-kubernetes<br/>(management cluster A)"]
-  k8sB["mcp-kubernetes<br/>(management cluster B)"]
-  other["other MCP servers<br/>(Prometheus, Teleport)"]
+  k8sA["mcp-kubernetes + mcp-prometheus<br/>(management cluster A)"]
+  k8sB["mcp-kubernetes + mcp-prometheus<br/>(management cluster B)"]
+  other["other MCP servers<br/>(Grafana, Teleport)"]
 
   client -- "HTTPS (MCP, OAuth)" --> serve
   serve --> k8sA
@@ -61,15 +61,15 @@ The aggregator resolves tool-name conflicts by prefixing external tools with the
 
 ## Fleet-wide aggregation
 
-For a customer operating several management clusters, a **central** Muster instance aggregates the `mcp-kubernetes` server on each management cluster, giving SREs a single MCP endpoint for the entire fleet:
+For a customer operating several management clusters, a **central** Muster instance aggregates the `mcp-kubernetes` and `mcp-prometheus` servers on each management cluster, giving SREs a single MCP endpoint for the entire fleet:
 
 {{< mermaid >}}
 flowchart LR
   user["SRE / developer"]
   central["Central Muster<br/>(management cluster)"]
-  mcpA["mcp-kubernetes<br/>(MC A)"]
-  mcpB["mcp-kubernetes<br/>(MC B)"]
-  mcpC["mcp-kubernetes<br/>(MC C)"]
+  mcpA["mcp-kubernetes + mcp-prometheus<br/>(MC A)"]
+  mcpB["mcp-kubernetes + mcp-prometheus<br/>(MC B)"]
+  mcpC["mcp-kubernetes + mcp-prometheus<br/>(MC C)"]
 
   user -- "one SSO login,<br/>one endpoint" --> central
   central --> mcpA
@@ -81,8 +81,8 @@ The user authenticates once through their enterprise identity provider. Muster b
 
 Two deployment shapes are supported:
 
-- **Single management cluster**: Muster and `mcp-kubernetes` on one management cluster. The simplest setup.
-- **Multiple management clusters**: a central Muster that bridges SSO to `mcp-kubernetes` on remote management clusters. Required when a customer runs more than one management cluster.
+- **Single management cluster**: Muster with `mcp-kubernetes` and `mcp-prometheus` on one management cluster. The simplest setup.
+- **Multiple management clusters**: a central Muster that bridges SSO to the `mcp-kubernetes` and `mcp-prometheus` servers on remote management clusters. Required when a customer runs more than one management cluster.
 
 ## Workflows cut agent token cost
 

--- a/src/content/overview/ai-agents/architecture/index.md
+++ b/src/content/overview/ai-agents/architecture/index.md
@@ -92,15 +92,15 @@ Two deployment shapes are supported:
 
 Muster can package a multi-step operation—authenticate, port-forward, query, correlate—as a single named **workflow** that an agent invokes with one call. It's not just convenient. It makes the AI assistant dramatically cheaper, because one workflow call replaces the whole discover-query-correlate loop the agent would otherwise run itself.
 
-A paired A/B trial measured this directly on four real management-cluster alerts. It used the same agent, model, and prompt, differing only in whether the agent was given the raw aggregated tools or the matching workflow tool:
+One internal lab trial measured this directly on four real management-cluster alerts, with the same agent, model, and prompt, differing only in whether the agent was given the raw aggregated tools or the matching workflow tool. The numbers below are illustrative of the *shape* of the saving rather than a guarantee—the ratios hold across a range of investigations, but the absolute figures depend on the model and its pricing:
 
 | Metric | Raw aggregated tools | Workflow tool | Reduction |
 |---|--:|--:|--:|
-| Total cost (USD) | $4.32 | $1.57 | 2.8x |
+| Cost | $4.32 | $1.57 | 2.8x |
 | Messages | 334 | 71 | 4.7x |
 | Cache-read input tokens | 11.0M | 1.1M | 9.6x |
 | Tool-call invocations | 68 | 4 | 17x |
 
-Cache-read input tokens dominate the bill, so the 10x reduction there is the real cost lever. The savings scale with how much investigation an alert needs.
+Cache-read input tokens dominate the bill, so the 10x reduction there is the real cost lever, and it holds regardless of the per-token price. The savings scale with how much investigation an alert needs.
 
 The trade-off is scope: a workflow only checks what it was authored to check. For a first responder handling the specific alert that paged, that focus is a feature. For open-ended "what's broken here?" exploration, an agent with the raw tools surfaces more adjacent context at higher cost. Both modes run through the same gateway—see [meta-tools]({{< relref "/overview/ai-agents/meta-tools" >}}) for how an agent reaches each one.

--- a/src/content/overview/ai-agents/architecture/index.md
+++ b/src/content/overview/ai-agents/architecture/index.md
@@ -1,0 +1,102 @@
+---
+title: Muster architecture
+linkTitle: Architecture
+description: How the central Muster aggregator exposes one OAuth-protected MCP endpoint, aggregates per-cluster mcp-kubernetes servers across a fleet, and why workflows cut agent token cost.
+weight: 20
+mermaid: true
+menu:
+  principal:
+    parent: overview-ai-agents
+    identifier: overview-ai-agents-architecture
+owner:
+  - https://github.com/orgs/giantswarm/teams/team-bumblebee
+last_review_date: 2026-06-20
+user_questions:
+  - How is Muster structured?
+  - How does Muster give access to multiple clusters?
+  - Why do workflows reduce AI agent cost?
+---
+
+Muster runs as a central **aggregator**, the `muster serve` process, that holds all the logic and exposes a single, OAuth-protected MCP endpoint. Your AI assistant connects straight to that endpoint over HTTPS.
+
+## The aggregator
+
+{{< mermaid >}}
+flowchart TB
+  client["AI assistant<br/>(VS Code / Cursor / portal chat)"]
+  serve["muster serve<br/>(aggregator, management cluster)"]
+  k8sA["mcp-kubernetes<br/>(management cluster A)"]
+  k8sB["mcp-kubernetes<br/>(management cluster B)"]
+  other["other MCP servers<br/>(Prometheus, Teleport)"]
+
+  client -- "HTTPS (MCP, OAuth)" --> serve
+  serve --> k8sA
+  serve --> k8sB
+  serve --> other
+{{< /mermaid >}}
+
+`muster serve` is the central component, typically running on a management cluster. It hosts all business logic, manages the lifecycle of downstream MCP server processes, monitors their health, and exposes a [meta-tools]({{< relref "/overview/ai-agents/meta-tools" >}}) interface over HTTPS, using the MCP HTTP and SSE transports.
+
+Modern AI assistants—VS Code with GitHub Copilot, Cursor, and the developer portal chat—support remote, OAuth-protected MCP servers natively. You point them straight at the aggregator's URL and they handle the [OAuth flow]({{< relref "/overview/ai-agents/security" >}}) themselves:
+
+```json
+{
+  "mcpServers": {
+    "muster": {
+      "url": "https://muster.<management-cluster>.<base-domain>/mcp"
+    }
+  }
+}
+```
+
+All aggregation, downstream authentication, and tool management live server-side, where they can be operated and updated centrally—there is nothing to keep running on your machine.
+
+## The optional local bridge
+
+Some MCP clients can't connect to a remote, OAuth-protected server directly—they only speak stdio, or lack a built-in OAuth flow. For those, `muster agent` is a thin local bridge: it converts stdio to HTTPS and performs OAuth on the client's behalf. It holds no business logic, so it stays a single lightweight binary. If your assistant supports remote MCP with OAuth—most now do—you don't need it.
+
+## Conflict-free tool names
+
+The aggregator resolves tool-name conflicts by prefixing external tools with their server name, so `get_pods` from the Kubernetes server becomes `x_kubernetes_get_pods` and `query` from Prometheus becomes `x_prometheus_query`. Tool registries update dynamically as servers start, stop, or change—the assistant's next discovery call reflects the new capabilities without any IDE restart.
+
+## Fleet-wide aggregation
+
+For a customer operating several management clusters, a **central** Muster instance aggregates the `mcp-kubernetes` server on each management cluster, giving SREs a single MCP endpoint for the entire fleet:
+
+{{< mermaid >}}
+flowchart LR
+  user["SRE / developer"]
+  central["Central Muster<br/>(management cluster)"]
+  mcpA["mcp-kubernetes<br/>(MC A)"]
+  mcpB["mcp-kubernetes<br/>(MC B)"]
+  mcpC["mcp-kubernetes<br/>(MC C)"]
+
+  user -- "one SSO login,<br/>one endpoint" --> central
+  central --> mcpA
+  central --> mcpB
+  central --> mcpC
+{{< /mermaid >}}
+
+The user authenticates once through their enterprise identity provider. Muster bridges that identity to each remote cluster—reusing the same token where the issuer is trusted, or exchanging it for one valid on the remote cluster where the issuer differs. The [Security]({{< relref "/overview/ai-agents/security" >}}) page covers this token handling in detail.
+
+Two deployment shapes are supported:
+
+- **Single management cluster**: Muster and `mcp-kubernetes` on one management cluster. The simplest setup.
+- **Multiple management clusters**: a central Muster that bridges SSO to `mcp-kubernetes` on remote management clusters. Required when a customer runs more than one management cluster.
+
+## Workflows cut agent token cost
+
+Muster can package a multi-step operation—authenticate, port-forward, query, correlate—as a single named **workflow** that an agent invokes with one call. It's not just convenient; it makes the AI assistant dramatically cheaper, because one workflow call replaces the whole discover-query-correlate loop the agent would otherwise run itself.
+
+A paired A/B trial measured this directly on four real management-cluster alerts, using the same agent, model, and prompt, differing only in whether the agent was given the raw aggregated tools or the matching workflow tool:
+
+| Metric | Raw aggregated tools | Workflow tool | Reduction |
+|---|--:|--:|--:|
+| Total cost (USD) | $4.32 | $1.57 | 2.8x |
+| Messages | 334 | 71 | 4.7x |
+| Cache-read input tokens | 11.0M | 1.1M | 9.6x |
+| Tool-call invocations | 68 | 4 | 17x |
+
+Cache-read input tokens dominate the bill, so the roughly 10x reduction there is the real cost lever. The savings scale with how much investigation an alert needs.
+
+The trade-off is scope: a workflow only checks what it was authored to check. For a first responder handling the specific alert that paged, that focus is a feature; for open-ended "what's broken here?" exploration, an agent with the raw tools surfaces more adjacent context at higher cost. Both modes run through the same gateway—see [meta-tools]({{< relref "/overview/ai-agents/meta-tools" >}}) for how an agent reaches each one.

--- a/src/content/overview/ai-agents/architecture/index.md
+++ b/src/content/overview/ai-agents/architecture/index.md
@@ -86,7 +86,7 @@ Two deployment shapes are supported:
 
 ## Workflows cut agent token cost
 
-Muster can package a multi-step operation—authenticate, port-forward, query, correlate—as a single named **workflow** that an agent invokes with one call. It's not just convenient; it makes the AI assistant dramatically cheaper, because one workflow call replaces the whole discover-query-correlate loop the agent would otherwise run itself.
+Muster can package a multi-step operation—authenticate, port-forward, query, correlate—as a single named **workflow** that an agent invokes with one call. It's not just convenient. It makes the AI assistant dramatically cheaper, because one workflow call replaces the whole discover-query-correlate loop the agent would otherwise run itself.
 
 A paired A/B trial measured this directly on four real management-cluster alerts, using the same agent, model, and prompt, differing only in whether the agent was given the raw aggregated tools or the matching workflow tool:
 
@@ -97,6 +97,6 @@ A paired A/B trial measured this directly on four real management-cluster alerts
 | Cache-read input tokens | 11.0M | 1.1M | 9.6x |
 | Tool-call invocations | 68 | 4 | 17x |
 
-Cache-read input tokens dominate the bill, so the roughly 10x reduction there is the real cost lever. The savings scale with how much investigation an alert needs.
+Cache-read input tokens dominate the bill, so the 10x reduction there is the real cost lever. The savings scale with how much investigation an alert needs.
 
-The trade-off is scope: a workflow only checks what it was authored to check. For a first responder handling the specific alert that paged, that focus is a feature; for open-ended "what's broken here?" exploration, an agent with the raw tools surfaces more adjacent context at higher cost. Both modes run through the same gateway—see [meta-tools]({{< relref "/overview/ai-agents/meta-tools" >}}) for how an agent reaches each one.
+The trade-off is scope: a workflow only checks what it was authored to check. For a first responder handling the specific alert that paged, that focus is a feature. For open-ended "what's broken here?" exploration, an agent with the raw tools surfaces more adjacent context at higher cost. Both modes run through the same gateway—see [meta-tools]({{< relref "/overview/ai-agents/meta-tools" >}}) for how an agent reaches each one.

--- a/src/content/overview/ai-agents/introduction/index.md
+++ b/src/content/overview/ai-agents/introduction/index.md
@@ -22,7 +22,7 @@ Muster is a universal control plane built on the [Model Context Protocol (MCP)](
 
 MCP lets an AI assistant call tools exposed by an MCP server—for example, "list the pods in this namespace" against a Kubernetes cluster. That works well for a single server. It breaks down quickly once you have many.
 
-A Giant Swarm customer typically operates a fleet: several management clusters, each with its own Kubernetes API, plus supporting systems such as Prometheus for metrics or Teleport for access. Wiring an assistant directly to all of these means:
+A Giant Swarm customer typically operates a fleet: several management clusters, each with its own Kubernetes API, plus supporting systems such as Prometheus for metrics or Teleport for access. Wiring an assistant directly to these means:
 
 - A separate MCP server connection to configure and maintain for every cluster and every system.
 - Separate credentials and authentication flows for each one.

--- a/src/content/overview/ai-agents/introduction/index.md
+++ b/src/content/overview/ai-agents/introduction/index.md
@@ -41,7 +41,7 @@ Three properties make the aggregation "intelligent" rather than a simple proxy:
 ## What you get
 
 - **One endpoint, one login.** Authenticate once via your enterprise SSO and reach your whole fleet. Muster handles forwarding and exchanging tokens to downstream servers and clusters transparently—see [Security]({{< relref "/overview/ai-agents/security" >}}).
-- **Lower cost.** Because agents only load the tools they actually use, and because multi-step operations can be packaged as single [workflow]({{< relref "/overview/ai-agents/meta-tools" >}}) calls, the token cost of an AI interaction drops substantially.
+- **Lower cost.** Because agents only load the tools they actually use, and because multi-step operations can be packaged as single [workflow]({{< relref "/overview/ai-agents/architecture" >}}#workflows-cut-agent-token-cost) calls, the token cost of an AI interaction drops substantially.
 - **Capabilities beyond Kubernetes.** Any MCP server can sit behind Muster—metrics, dashboards, access brokers, and custom internal tools—all reachable through the same connection.
 
 Continue with the [architecture]({{< relref "/overview/ai-agents/architecture" >}}) to see how the gateway is structured, or jump straight to [setting up your AI agent]({{< relref "/getting-started/ai-agent-setup" >}}).

--- a/src/content/overview/ai-agents/introduction/index.md
+++ b/src/content/overview/ai-agents/introduction/index.md
@@ -1,0 +1,47 @@
+---
+title: Introduction to Muster
+linkTitle: Introduction
+description: What Muster is, the MCP-server-sprawl problem it solves, and how intelligent tool aggregation makes AI assistants on the platform cheaper and more capable.
+weight: 10
+menu:
+  principal:
+    parent: overview-ai-agents
+    identifier: overview-ai-agents-introduction
+owner:
+  - https://github.com/orgs/giantswarm/teams/team-bumblebee
+last_review_date: 2026-06-20
+user_questions:
+  - What is Muster?
+  - Why do I need an MCP gateway?
+  - What problem does Muster solve?
+---
+
+Muster is a universal control plane built on the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/). It aggregates multiple MCP servers behind a single interface and gives AI agents intelligent tool discovery, OAuth-based authentication, workflow orchestration, and dynamic tool loading.
+
+## The MCP server sprawl problem
+
+MCP lets an AI assistant call tools exposed by an MCP server—for example, "list the pods in this namespace" against a Kubernetes cluster. That works well for a single server. It breaks down quickly once you have many.
+
+A Giant Swarm customer typically operates a fleet: several management clusters, each with its own Kubernetes API, plus supporting systems such as Prometheus for metrics or Teleport for access. Wiring an assistant directly to all of these means:
+
+- A separate MCP server connection to configure and maintain for every cluster and every system.
+- Separate credentials and authentication flows for each one.
+- Every server's full tool list loaded into the assistant's context window at once—hundreds of tools, most of them irrelevant to the task at hand. That pollutes the context and drives up token cost on every interaction.
+
+## Intelligent aggregation
+
+Muster acts as a **meta-MCP server**: a single aggregation point that manages many downstream MCP servers and presents their combined capabilities through one connection. Your AI assistant connects to Muster, not to each server individually.
+
+Three properties make the aggregation "intelligent" rather than a simple proxy:
+
+- **Conflict-free naming.** When two servers expose a tool with the same name, Muster prefixes external tools with their server name, so a tool such as `x_kubernetes_get_pods` or `x_prometheus_query` never collides.
+- **A small, stable tool surface.** Instead of exposing every underlying tool, Muster exposes a handful of [meta-tools]({{< relref "/overview/ai-agents/meta-tools" >}}). Agents discover and invoke the full set of capabilities on demand, so the context stays lean and adding or removing a downstream server doesn't change the assistant's configuration.
+- **Live lifecycle management.** Muster manages downstream server processes, monitors their health, and updates its tool registry dynamically—no IDE restart required when capabilities change.
+
+## What you get
+
+- **One endpoint, one login.** Authenticate once via your enterprise SSO and reach your whole fleet. Muster handles forwarding and exchanging tokens to downstream servers and clusters transparently—see [Security]({{< relref "/overview/ai-agents/security" >}}).
+- **Lower cost.** Because agents only load the tools they actually use, and because multi-step operations can be packaged as single [workflow]({{< relref "/overview/ai-agents/meta-tools" >}}) calls, the token cost of an AI interaction drops substantially.
+- **Capabilities beyond Kubernetes.** Any MCP server can sit behind Muster—metrics, dashboards, access brokers, and custom internal tools—all reachable through the same connection.
+
+Continue with the [architecture]({{< relref "/overview/ai-agents/architecture" >}}) to see how the gateway is structured, or jump straight to [setting up your AI agent]({{< relref "/getting-started/ai-agent-setup" >}}).

--- a/src/content/overview/ai-agents/meta-tools/index.md
+++ b/src/content/overview/ai-agents/meta-tools/index.md
@@ -77,4 +77,4 @@ Several mechanisms work together so that an agent pays context cost only for the
 
 The combined effect: an assistant interacting with Muster carries a tiny, stable tool surface. The cost of any given task scales with what that task touches—not with the size of the whole platform.
 
-To see these meta-tools in action from your IDE, follow [Set up your AI agent]({{< relref "/getting-started/ai-agent-setup" >}}).
+For the full argument and response schema of each meta-tool, see the [meta-tools reference]({{< relref "/reference/muster/meta-tools" >}}). To see these meta-tools in action from your IDE, follow [Set up your AI agent]({{< relref "/getting-started/ai-agent-setup" >}}).

--- a/src/content/overview/ai-agents/meta-tools/index.md
+++ b/src/content/overview/ai-agents/meta-tools/index.md
@@ -1,0 +1,58 @@
+---
+title: Meta-tools and tool discovery
+linkTitle: Meta-tools
+description: The small set of meta-tools Muster exposes to AI agents, how lazy discovery keeps the context window lean, and the prefixes that group external, core, and workflow tools.
+weight: 30
+menu:
+  principal:
+    parent: overview-ai-agents
+    identifier: overview-ai-agents-meta-tools
+owner:
+  - https://github.com/orgs/giantswarm/teams/team-bumblebee
+last_review_date: 2026-06-20
+user_questions:
+  - What are Muster's meta-tools?
+  - How does Muster keep my AI agent's context small?
+  - What do the x_, core_, and workflow_ tool prefixes mean?
+---
+
+A single management cluster can expose hundreds of MCP tools—one per Kubernetes operation, per cluster, plus everything from any other server behind the gateway. Loading all of them into an AI assistant's context window at startup is wasteful: it pollutes the context and inflates the token cost of every interaction, most of it for tools the assistant never uses.
+
+Muster avoids this with **meta-tool indirection**. Instead of exposing every underlying tool, it exposes a small, fixed set of meta-tools. The assistant uses these to discover and invoke the full set of capabilities on demand.
+
+## The meta-tool surface
+
+Muster exposes 11 meta-tools:
+
+| Meta-tool | Purpose |
+|---|---|
+| `list_tools` | Discover all available tools |
+| `filter_tools` | Search tools by name or description pattern |
+| `describe_tool` | Get the detailed schema for a specific tool |
+| `call_tool` | Execute any tool by name |
+| `list_core_tools` | List Muster's built-in tools only |
+| `list_resources` / `get_resource` / `describe_resource` | Access MCP resources |
+| `list_prompts` / `get_prompt` / `describe_prompt` | Access MCP prompts |
+
+The assistant sees only these meta-tools in its MCP configuration—not the 100+ underlying tools. It discovers what it needs via `list_tools` or `filter_tools`, inspects a candidate with `describe_tool`, and runs it with `call_tool`. Because the configuration never names individual tools, adding or removing a downstream MCP server changes what `list_tools` returns without any change to the assistant's setup.
+
+## Tool naming
+
+Every tool reachable through `call_tool` falls into one of three families, distinguished by prefix:
+
+- **`x_<server>_<tool>`**: a tool from an external MCP server, prefixed with the server name to avoid conflicts. For example `x_kubernetes_get_pods` or `x_prometheus_query`.
+- **`core_<area>_<tool>`**: one of Muster's built-in tools, such as service and workflow management (`core_service_*`, `core_workflow_*`).
+- **`workflow_<name>`**: a dynamically generated tool for a [workflow]({{< relref "/overview/ai-agents/architecture" >}}#workflows-cut-agent-token-cost). Authoring a workflow registers a matching `workflow_<name>` tool that the agent can discover and call like any other.
+
+## Lazy discovery keeps context lean
+
+Several mechanisms work together so that an agent pays context cost only for the tools it actually uses:
+
+- **Filter-based discovery.** Rather than parsing every tool definition, an agent narrows the list with a pattern such as `filter_tools(pattern="kubernetes")` and only pulls schemas for the matches.
+- **AutoStart control.** A downstream MCP server can be defined but not started until it's needed. Muster won't spin up the process or load its tool definitions for a server that isn't relevant to the current task.
+- **Dynamic registration.** When a server starts—manually, or as part of a workflow—its tools are discovered, prefixed, and registered immediately. The agent's next `list_tools` call reflects the new capabilities, no IDE restart required.
+- **Prerequisite encapsulation.** Complex setups such as port forwarding or authentication are encapsulated so that the relevant tools only become available once their prerequisites are satisfied.
+
+The combined effect: an assistant interacting with Muster carries a tiny, stable tool surface, and the cost of any given task scales with what that task touches—not with the size of the whole platform.
+
+To see these meta-tools in action from your IDE, follow [Set up your AI agent]({{< relref "/getting-started/ai-agent-setup" >}}).

--- a/src/content/overview/ai-agents/meta-tools/index.md
+++ b/src/content/overview/ai-agents/meta-tools/index.md
@@ -27,14 +27,36 @@ Muster exposes 11 meta-tools:
 | Meta-tool | Purpose |
 |---|---|
 | `list_tools` | Discover all available tools |
-| `filter_tools` | Search tools by name or description pattern |
-| `describe_tool` | Get the detailed schema for a specific tool |
+| `filter_tools` | Discover tools cheaply: filter by name, description, or labels, rank by a natural-language query, and get a bounded, summarized page |
+| `describe_tool` | Get the authoritative full description and schema for a specific tool |
 | `call_tool` | Execute any tool by name |
 | `list_core_tools` | List Muster's built-in tools only |
 | `list_resources` / `get_resource` / `describe_resource` | Access MCP resources |
 | `list_prompts` / `get_prompt` / `describe_prompt` | Access MCP prompts |
 
 The assistant sees only these meta-tools in its MCP configuration—not the 100+ underlying tools. It discovers what it needs via `list_tools` or `filter_tools`, inspects a candidate with `describe_tool`, and runs it with `call_tool`. Because the configuration never names individual tools, adding or removing a downstream MCP server changes what `list_tools` returns without any change to the assistant's setup.
+
+## Discovering tools with `filter_tools`
+
+`filter_tools` is the cheap, scalable way to find tools across a large catalog. It returns a bounded page of one-line summaries instead of every full description and schema. The agent spends context only on plausible candidates, then calls `describe_tool` for the authoritative detail of the one it picks.
+
+It accepts several ways to narrow the catalog, which you can combine:
+
+- **`pattern`**: glob match against tool names (supports `*`). Case-insensitive unless you set `case_sensitive: true`.
+- **`description_filter`**: case-insensitive substring match against tool descriptions.
+- **`query`**: a natural-language query. When set, matching tools are relevance-ranked with Okapi BM25 over each tool's name and summary, returned best-first with a `score`, and non-matching tools are dropped.
+- **`labels`**: a facet of `key=value` pairs. A tool must carry every requested label to match, for example `{"category": "observability"}`. Labels come from a workflow's `metadata.labels` and are propagated onto its `workflow_<name>` tool.
+
+The response is a bounded summary page:
+
+- **`limit`**: maximum tools returned in this page. Defaults to **5**. Raise it to page through more matches.
+- **`offset`**: number of matching tools to skip before this page. Defaults to `0`.
+- **`total`**: the number of tools matching the filters across the whole catalog.
+- **`truncated`**: `true` when more matches exist beyond the current page, the signal to page further or refine the query.
+- **`summary`**: a one-line, length-capped excerpt returned per tool instead of the full description.
+- **`include_schema`**: defaults to `false`. When `true`, each entry carries its full description and input schema instead of the one-line summary, which costs much more context.
+
+`describe_tool` stays the authoritative source for a tool's full description and input schema. Use `filter_tools` to shortlist, then `describe_tool` on the chosen tool before you call it.
 
 ## Tool naming
 
@@ -48,7 +70,7 @@ Every tool reachable through `call_tool` falls into one of three families, disti
 
 Several mechanisms work together so that an agent pays context cost only for the tools it actually uses:
 
-- **Filter-based discovery.** Rather than parsing every tool definition, an agent narrows the list with a pattern such as `filter_tools(pattern="kubernetes")` and only pulls schemas for the matches.
+- **Filter-based discovery.** Rather than parsing every tool definition, an agent narrows the list with `filter_tools` by name pattern, labels, or a ranked natural-language `query`, and gets back a short page of summaries. It pulls full schemas only for the candidate it chooses, via `describe_tool`.
 - **AutoStart control.** A downstream MCP server can be defined but not started until it's needed. Muster won't spin up the process or load its tool definitions for a server that isn't relevant to the current task.
 - **Dynamic registration.** When a server starts—manually, or as part of a workflow—its tools are discovered, prefixed, and registered immediately. The agent's next `list_tools` call reflects the new capabilities, no IDE restart required.
 - **Prerequisite encapsulation.** Complex setups such as port forwarding or authentication are encapsulated so that the relevant tools only become available once their prerequisites are satisfied.

--- a/src/content/overview/ai-agents/meta-tools/index.md
+++ b/src/content/overview/ai-agents/meta-tools/index.md
@@ -16,7 +16,7 @@ user_questions:
   - What do the x_, core_, and workflow_ tool prefixes mean?
 ---
 
-A single management cluster can expose hundreds of MCP tools—one per Kubernetes operation, per cluster, plus everything from any other server behind the gateway. Loading them all into an AI assistant's context window at startup is wasteful: it pollutes the context and inflates the token cost of every interaction, most of it for tools the assistant never uses.
+A single management cluster can expose hundreds of MCP tools—one per Kubernetes operation, per cluster, plus everything from any other server behind the gateway. Loading them all into an AI assistant's context window at startup is wasteful. It pollutes the context and inflates the token cost of every interaction, most of it for tools the assistant never uses.
 
 Muster avoids this with **meta-tool indirection**. Instead of exposing every underlying tool, it exposes a small, fixed set of meta-tools. The assistant uses these to discover and invoke the full set of capabilities on demand.
 
@@ -53,6 +53,6 @@ Several mechanisms work together so that an agent pays context cost only for the
 - **Dynamic registration.** When a server starts—manually, or as part of a workflow—its tools are discovered, prefixed, and registered immediately. The agent's next `list_tools` call reflects the new capabilities, no IDE restart required.
 - **Prerequisite encapsulation.** Complex setups such as port forwarding or authentication are encapsulated so that the relevant tools only become available once their prerequisites are satisfied.
 
-The combined effect: an assistant interacting with Muster carries a tiny, stable tool surface, and the cost of any given task scales with what that task touches—not with the size of the whole platform.
+The combined effect: an assistant interacting with Muster carries a tiny, stable tool surface. The cost of any given task scales with what that task touches—not with the size of the whole platform.
 
 To see these meta-tools in action from your IDE, follow [Set up your AI agent]({{< relref "/getting-started/ai-agent-setup" >}}).

--- a/src/content/overview/ai-agents/meta-tools/index.md
+++ b/src/content/overview/ai-agents/meta-tools/index.md
@@ -16,7 +16,7 @@ user_questions:
   - What do the x_, core_, and workflow_ tool prefixes mean?
 ---
 
-A single management cluster can expose hundreds of MCP tools—one per Kubernetes operation, per cluster, plus everything from any other server behind the gateway. Loading all of them into an AI assistant's context window at startup is wasteful: it pollutes the context and inflates the token cost of every interaction, most of it for tools the assistant never uses.
+A single management cluster can expose hundreds of MCP tools—one per Kubernetes operation, per cluster, plus everything from any other server behind the gateway. Loading them all into an AI assistant's context window at startup is wasteful: it pollutes the context and inflates the token cost of every interaction, most of it for tools the assistant never uses.
 
 Muster avoids this with **meta-tool indirection**. Instead of exposing every underlying tool, it exposes a small, fixed set of meta-tools. The assistant uses these to discover and invoke the full set of capabilities on demand.
 

--- a/src/content/overview/ai-agents/security/index.md
+++ b/src/content/overview/ai-agents/security/index.md
@@ -23,7 +23,7 @@ Muster treats authentication as a first-class concern at two levels: protecting 
 
 The aggregator requires the OAuth 2.1 authorization code flow with PKCE. The first time your AI assistant connects—or when you run `muster auth login` from the CLI—your browser opens for SSO against your enterprise identity provider. Tokens are stored locally with restricted file permissions. Access tokens are short-lived—30 minutes by default—and your MCP client refreshes them automatically in the background, so you stay connected without re-authenticating.
 
-Because authentication happens over the OAuth 2.1 flow, an assistant that supports remote MCP servers natively (such as VS Code or Cursor) can connect straight to the aggregator's HTTPS URL and run this flow itself, with no local bridge process. Production deployments require HTTPS for all OAuth endpoints.
+Because authentication uses the OAuth 2.1 flow, an assistant that supports remote MCP servers natively can connect straight to the aggregator's HTTPS URL. Examples include VS Code and Cursor. They run this flow themselves, with no local bridge process. Production deployments require HTTPS for all OAuth endpoints.
 
 ## Muster-to-downstream authentication
 
@@ -41,13 +41,13 @@ flowchart TB
   s1 --> s2 --> s3 --> s4 --> s5 --> s6 --> s7
 {{< /mermaid >}}
 
-When a downstream server returns a `401`, Muster detects the challenge, hands back an "authentication required" response with an authorization URL, and—once you authenticate in the browser—exchanges the code for tokens scoped to your session. Subsequent calls to that server carry the token automatically.
+When a downstream server returns a `401`, Muster detects the challenge and hands back an "authentication required" response with an authorization URL. Once you authenticate in the browser, it exchanges the code for tokens scoped to your session. Subsequent calls to that server carry the token automatically.
 
 ## Per-user tool visibility
 
 Per-user state is keyed by the OAuth `sub` (subject) claim extracted from each authenticated request. There is no separate session-ID layer. The access token itself identifies the user.
 
-A direct benefit is **per-user tool visibility**: each user only sees tools from the MCP servers they have personally authenticated with. If you haven't authenticated to a given cluster—or your identity provider doesn't grant you access to it—its tools simply don't appear in your `list_tools` results. Cluster-level authorization is still enforced by each cluster's own Kubernetes RBAC: a tool call you aren't permitted to make is rejected by the cluster, not allowed by the gateway.
+A direct benefit is **per-user tool visibility**: each user only sees tools from the MCP servers they have personally authenticated with. If you haven't authenticated to a given cluster—or your identity provider doesn't grant you access to it—its tools simply don't appear in your `list_tools` results. Cluster-level authorization is still enforced by each cluster's own Kubernetes RBAC. A tool call you aren't permitted to make is rejected by the cluster, not allowed by the gateway.
 
 ## Single sign-on across clusters
 

--- a/src/content/overview/ai-agents/security/index.md
+++ b/src/content/overview/ai-agents/security/index.md
@@ -27,7 +27,7 @@ Because authentication happens over the OAuth 2.1 flow, an assistant that suppor
 
 ## Muster-to-downstream authentication
 
-The downstream MCP servers behind Muster (such as `mcp-kubernetes` on each cluster) are themselves protected. Muster acts as an OAuth proxy on your behalf:
+The downstream MCP servers behind Muster (such as `mcp-kubernetes` and `mcp-prometheus` on each cluster) are themselves protected. Muster acts as an OAuth proxy on your behalf:
 
 {{< mermaid >}}
 flowchart TB

--- a/src/content/overview/ai-agents/security/index.md
+++ b/src/content/overview/ai-agents/security/index.md
@@ -1,0 +1,78 @@
+---
+title: AI agent security and SSO
+linkTitle: Security
+description: How Muster secures AI agent access with OAuth 2.1, per-user tool visibility keyed on identity, and single sign-on across clusters via token forwarding and exchange.
+weight: 40
+mermaid: true
+menu:
+  principal:
+    parent: overview-ai-agents
+    identifier: overview-ai-agents-security
+owner:
+  - https://github.com/orgs/giantswarm/teams/team-bumblebee
+last_review_date: 2026-06-20
+user_questions:
+  - How does Muster authenticate AI agents?
+  - Can AI agents only see the tools I'm allowed to use?
+  - How does single sign-on work across clusters?
+---
+
+Muster treats authentication as a first-class concern at two levels: protecting access to the gateway itself, and handling authentication to the downstream MCP servers on a user's behalf. Both are built on OAuth 2.1.
+
+## Agent-to-Muster authentication
+
+The aggregator requires the OAuth 2.1 authorization code flow with PKCE. The first time your AI assistant connects—or when you run `muster auth login` from the CLI—your browser opens for SSO against your enterprise identity provider. Tokens are stored locally with restricted file permissions. Access tokens are short-lived—30 minutes by default—and your MCP client refreshes them automatically in the background, so you stay connected without re-authenticating.
+
+Because authentication happens over the OAuth 2.1 flow, an assistant that supports remote MCP servers natively (such as VS Code or Cursor) can connect straight to the aggregator's HTTPS URL and run this flow itself, with no local bridge process. Production deployments require HTTPS for all OAuth endpoints.
+
+## Muster-to-downstream authentication
+
+The downstream MCP servers behind Muster (such as `mcp-kubernetes` on each cluster) are themselves protected. Muster acts as an OAuth proxy on your behalf:
+
+{{< mermaid >}}
+flowchart TB
+  s1["1. Assistant invokes a tool that needs server X"]
+  s2["2. Muster forwards the request to server X"]
+  s3["3. Server X replies 401 (authentication required)"]
+  s4["4. Muster returns an authorization URL to the assistant"]
+  s5["5. User authenticates in the browser"]
+  s6["6. Muster retries the request with the acquired token"]
+  s7["7. Server X returns the result"]
+  s1 --> s2 --> s3 --> s4 --> s5 --> s6 --> s7
+{{< /mermaid >}}
+
+When a downstream server returns a `401`, Muster detects the challenge, hands back an "authentication required" response with an authorization URL, and—once you authenticate in the browser—exchanges the code for tokens scoped to your session. Subsequent calls to that server carry the token automatically.
+
+## Per-user tool visibility
+
+Per-user state is keyed by the OAuth `sub` (subject) claim extracted from each authenticated request. There is no separate session-ID layer; the access token itself identifies the user.
+
+A direct benefit is **per-user tool visibility**: each user only sees tools from the MCP servers they have personally authenticated with. If you haven't authenticated to a given cluster—or your identity provider doesn't grant you access to it—its tools simply don't appear in your `list_tools` results. Cluster-level authorization is still enforced by each cluster's own Kubernetes RBAC: a tool call you aren't permitted to make is rejected by the cluster, not silently allowed by the gateway.
+
+## Single sign-on across clusters
+
+When several downstream servers trust the same identity provider, Muster provides SSO so you authenticate once and reach the whole fleet. It uses two mechanisms depending on the trust relationship:
+
+- **Token forwarding**: reuse the same access token across servers that trust the same issuer. The latest valid token is resolved per request.
+- **RFC 8693 token exchange**: exchange a local ID token for one valid on a remote identity provider. This is what enables cross-cluster SSO: authenticating to remote management clusters and their workload clusters through a central management cluster.
+
+After login, the CLI waits for SSO-configured servers to finish connecting. `muster auth status` distinguishes servers still completing SSO setup ("SSO Pending") from those that genuinely need a manual login, so you get an accurate picture of what you can reach:
+
+```text
+MCP Servers
+  cluster-a-mcp-kubernetes   Connected [SSO: Forwarded]
+  cluster-b-mcp-kubernetes   Connected [SSO: Exchanged]
+  cluster-c-mcp-kubernetes   Connected [SSO: Exchanged]
+```
+
+## Signing out
+
+Muster offers three distinct logout operations for different needs:
+
+- **Per-device logout** (`muster auth logout`): revokes the entire token family for the current device. Your other devices are unaffected.
+- **Per-server disconnect**: clears the downstream token for a single server and drops its cached capabilities, leaving your other connections intact.
+- **Sign out everywhere**: clears all downstream tokens and cached capabilities for your identity across every device.
+
+Per-device isolation comes from OAuth refresh-token families, not a custom session layer—so revoking one device never disturbs the others.
+
+For the hands-on login flow and an RBAC troubleshooting guide, see [Set up your AI agent]({{< relref "/getting-started/ai-agent-setup" >}}).

--- a/src/content/overview/ai-agents/security/index.md
+++ b/src/content/overview/ai-agents/security/index.md
@@ -45,9 +45,9 @@ When a downstream server returns a `401`, Muster detects the challenge, hands ba
 
 ## Per-user tool visibility
 
-Per-user state is keyed by the OAuth `sub` (subject) claim extracted from each authenticated request. There is no separate session-ID layer; the access token itself identifies the user.
+Per-user state is keyed by the OAuth `sub` (subject) claim extracted from each authenticated request. There is no separate session-ID layer. The access token itself identifies the user.
 
-A direct benefit is **per-user tool visibility**: each user only sees tools from the MCP servers they have personally authenticated with. If you haven't authenticated to a given cluster—or your identity provider doesn't grant you access to it—its tools simply don't appear in your `list_tools` results. Cluster-level authorization is still enforced by each cluster's own Kubernetes RBAC: a tool call you aren't permitted to make is rejected by the cluster, not silently allowed by the gateway.
+A direct benefit is **per-user tool visibility**: each user only sees tools from the MCP servers they have personally authenticated with. If you haven't authenticated to a given cluster—or your identity provider doesn't grant you access to it—its tools simply don't appear in your `list_tools` results. Cluster-level authorization is still enforced by each cluster's own Kubernetes RBAC: a tool call you aren't permitted to make is rejected by the cluster, not allowed by the gateway.
 
 ## Single sign-on across clusters
 

--- a/src/content/overview/developer-portal/ai-chat/index.md
+++ b/src/content/overview/developer-portal/ai-chat/index.md
@@ -34,7 +34,7 @@ The chat answers questions about your clusters and about the portal and platform
 
 For cluster questions, the assistant turns your request into live tool calls against the relevant cluster, reads the results, and replies with a focused answer rather than a raw resource dump. For platform and portal questions, it answers from the portal's own context without touching any cluster.
 
-A focused question costs less and answers faster than a broad one. Asking about a specific cluster, app, or symptom lets the assistant go straight to the relevant data; an open-ended "what's broken everywhere?" makes it cast a much wider net.
+A focused question costs less and answers faster than a broad one. Asking about a specific cluster, app, or symptom lets the assistant go straight to the relevant data. An open-ended "what's broken everywhere?" makes it cast a much wider net.
 
 ## How it works
 
@@ -63,7 +63,7 @@ To keep responses fast and cheap, Muster doesn't load every cluster tool into th
 The chat acts as you, not as a shared service account. It uses your portal sign-on to authenticate to Muster, and you only see and reach the clusters your identity is allowed to.
 
 - **Per-user visibility**: you only see tools from the clusters you've authenticated with and that your identity provider grants you access to. Clusters you can't reach simply don't appear.
-- **Cluster RBAC still applies**: a request you aren't permitted to make is rejected by the cluster's own Kubernetes RBAC, not silently allowed by the gateway.
+- **Cluster RBAC still applies**: a request you aren't permitted to make is rejected by the cluster's own Kubernetes RBAC, not allowed by the gateway.
 
 The [AI agent security page]({{< relref "/overview/ai-agents/security" >}}) explains the OAuth flow, per-user tool visibility, and single sign-on across clusters.
 

--- a/src/content/overview/developer-portal/ai-chat/index.md
+++ b/src/content/overview/developer-portal/ai-chat/index.md
@@ -1,0 +1,76 @@
+---
+title: AI chat in the developer portal
+linkTitle: AI chat
+description: Ask plain-language questions about your clusters and platform directly in the developer portal, answered by an AI assistant powered by Muster.
+weight: 40
+mermaid: true
+menu:
+  principal:
+    parent: overview-developer-portal
+    identifier: overview-developer-portal-ai-chat
+owner:
+  - https://github.com/orgs/giantswarm/teams/team-bumblebee
+last_review_date: 2026-06-20
+user_questions:
+  - What is the developer portal AI chat?
+  - Can I ask questions about my clusters in the portal?
+  - How does the portal chat answer questions?
+---
+
+The developer portal includes a built-in AI chat. You ask a question in plain language and get an answer grounded in live platform state, without leaving the portal or switching to a terminal. It's the same assistant experience you'd configure in your [IDE]({{< relref "/getting-started/ai-agent-setup" >}}), but already wired up and waiting in the browser.
+
+Behind the chat is **Muster**, the platform's MCP gateway. The portal connects to your central Muster instance, so the assistant can reach your whole fleet through one secure, authenticated endpoint. For the concepts behind that gateway, see [AI agents on the platform]({{< relref "/overview/ai-agents" >}}).
+
+## What you can ask
+
+The chat answers questions about your clusters and about the portal and platform itself. A few examples:
+
+- `check the pods in <management-cluster>`
+- `is <workload-cluster> on <management-cluster> healthy?`
+- `why is <app> failing?`
+- `what's driving memory usage on <management-cluster>?`
+- `what applications are available for deployment?`
+- `what can I do here in the portal?`
+
+For cluster questions, the assistant turns your request into live tool calls against the relevant cluster, reads the results, and replies with a focused answer rather than a raw resource dump. For platform and portal questions, it answers from the portal's own context without touching any cluster.
+
+A focused question costs less and answers faster than a broad one. Asking about a specific cluster, app, or symptom lets the assistant go straight to the relevant data; an open-ended "what's broken everywhere?" makes it cast a much wider net.
+
+## How it works
+
+{{< mermaid >}}
+flowchart LR
+  chat["Portal AI chat"]
+  muster["Central Muster"]
+  k8sA["mcp-kubernetes<br/>(cluster A)"]
+  promA["mcp-prometheus<br/>(cluster A)"]
+  k8sB["mcp-kubernetes<br/>(cluster B)"]
+  promB["mcp-prometheus<br/>(cluster B)"]
+
+  chat -- "one connection, your identity" --> muster
+  muster --> k8sA
+  muster --> promA
+  muster --> k8sB
+  muster --> promB
+{{< /mermaid >}}
+
+The chat connects to the central Muster aggregator over its OAuth-protected endpoint. On each management cluster Muster aggregates both `mcp-kubernetes`, which exposes Kubernetes resources, and `mcp-prometheus`, which exposes metrics. So the assistant reaches your entire fleet through a single connection instead of a separate one per cluster and per system. The [architecture page]({{< relref "/overview/ai-agents/architecture" >}}) covers this fleet-wide aggregation in detail.
+
+To keep responses fast and cheap, Muster doesn't load every cluster tool into the assistant at once. It exposes a small set of [meta-tools]({{< relref "/overview/ai-agents/meta-tools" >}}) that the assistant uses to discover and call only the tools a given question needs. Common investigations, such as summarizing pod health, can be packaged as single workflow calls that resolve a question in one step.
+
+## Per-user access and security
+
+The chat acts as you, not as a shared service account. It uses your portal sign-on to authenticate to Muster, and you only see and reach the clusters your identity is allowed to.
+
+- **Per-user visibility**: you only see tools from the clusters you've authenticated with and that your identity provider grants you access to. Clusters you can't reach simply don't appear.
+- **Cluster RBAC still applies**: a request you aren't permitted to make is rejected by the cluster's own Kubernetes RBAC, not silently allowed by the gateway.
+
+The [AI agent security page]({{< relref "/overview/ai-agents/security" >}}) explains the OAuth flow, per-user tool visibility, and single sign-on across clusters.
+
+## Current limitations
+
+- **Cluster access is read-only.** The Kubernetes access behind the chat runs in a non-destructive mode: the assistant can inspect resources, logs, and events, but it can't create, change, or delete them. It answers questions and helps you investigate; cluster changes still go through your GitOps workflow.
+- **Answers reflect live state at the moment you ask.** The assistant reasons over the data returned by each tool call. Cluster conditions can change between questions, so treat a health answer as a point-in-time snapshot.
+- **Quality depends on how the question is scoped.** Specific, well-scoped questions get the best answers; very broad questions take longer, cost more, and can return less precise results.
+
+To use the same assistant from your editor instead of the browser, follow [Set up your AI agent]({{< relref "/getting-started/ai-agent-setup" >}}).

--- a/src/content/overview/developer-portal/ai-chat/index.md
+++ b/src/content/overview/developer-portal/ai-chat/index.md
@@ -32,7 +32,7 @@ The chat answers questions about your clusters and about the portal and platform
 - `what applications are available for deployment?`
 - `what can I do here in the portal?`
 
-For cluster questions, the assistant turns your request into live tool calls against the relevant cluster, reads the results, and replies with a focused answer rather than a raw resource dump. For platform and portal questions, it answers from the portal's own context without touching any cluster.
+For cluster questions, the assistant turns your request into live tool calls against the relevant cluster. It reads the results and replies with a focused answer rather than a raw resource dump. For platform and portal questions, it answers from the portal's own context without touching any cluster.
 
 A focused question costs less and answers faster than a broad one. Asking about a specific cluster, app, or symptom lets the assistant go straight to the relevant data. An open-ended "what's broken everywhere?" makes it cast a much wider net.
 

--- a/src/content/reference/muster/_index.md
+++ b/src/content/reference/muster/_index.md
@@ -1,0 +1,83 @@
+---
+linkTitle: Muster CLI
+title: Muster CLI and resource reference
+description: Reference for the Muster command-line interface, the meta-tools it exposes to AI agents, and the MCPServer and Workflow custom resources.
+weight: 40
+layout: single
+menu:
+  principal:
+    identifier: reference-muster
+    parent: reference
+last_review_date: 2026-06-21
+user_questions:
+  - Which commands does the Muster CLI offer?
+  - What meta-tools does Muster expose to AI agents?
+  - What fields do the MCPServer and Workflow custom resources support?
+owner:
+  - https://github.com/orgs/giantswarm/teams/team-bumblebee
+---
+
+`muster` is the command-line interface for [Muster]({{< relref "/overview/ai-agents/introduction" >}}), the MCP gateway that gives AI agents unified, secure access to your fleet. This section documents the CLI commands, the meta-tools Muster exposes to agents, and the custom resources you author to extend it.
+
+For a conceptual overview, start with [AI agents on the platform]({{< relref "/overview/ai-agents" >}}). To connect your IDE, follow [Set up your AI agent]({{< relref "/getting-started/ai-agent-setup" >}}).
+
+## Reference pages {#pages}
+
+| Page | Description |
+|---|---|
+| [Meta-tools]({{< relref "/reference/muster/meta-tools" >}}) | The meta-tools Muster exposes to agents, plus the `core_*` tool catalog |
+| [Custom resources]({{< relref "/reference/muster/crds" >}}) | The `MCPServer` and `Workflow` schemas |
+
+## CLI commands {#commands}
+
+| Command | Description |
+|---|---|
+| [`serve`]({{< relref "/reference/muster/cli/serve" >}}) | Start the aggregator server |
+| [`standalone`]({{< relref "/reference/muster/cli/standalone" >}}) | Run the aggregator and agent in one process |
+| [`agent`]({{< relref "/reference/muster/cli/agent" >}}) | Connect to the aggregator as a client, or bridge it over stdio |
+| [`context`]({{< relref "/reference/muster/cli/context" >}}) | Manage named endpoint contexts |
+| [`auth`]({{< relref "/reference/muster/cli/auth" >}}) | Authenticate to a remote aggregator |
+| [`list`]({{< relref "/reference/muster/cli/list" >}}) | List resources |
+| [`get`]({{< relref "/reference/muster/cli/get" >}}) | Get details for one resource |
+| [`create`]({{< relref "/reference/muster/cli/create" >}}) | Create a workflow or MCP server definition |
+| [`call`]({{< relref "/reference/muster/cli/call" >}}) | Call an MCP tool by name |
+| [`start`]({{< relref "/reference/muster/cli/start" >}}) | Start a service or run a workflow |
+| [`stop`]({{< relref "/reference/muster/cli/stop" >}}) | Stop a service |
+| [`check`]({{< relref "/reference/muster/cli/check" >}}) | Check that a resource is available |
+| [`events`]({{< relref "/reference/muster/cli/events" >}}) | List resource events |
+| [`version`]({{< relref "/reference/muster/cli/version" >}}) | Print CLI and server version |
+| [`self-update`]({{< relref "/reference/muster/cli/self-update" >}}) | Update the CLI from GitHub |
+
+## Common flags {#common-flags}
+
+The client commands that talk to a running aggregator (`list`, `get`, `create`, `call`, `start`, `stop`, `check`, `events`) share these flags:
+
+| Name | Description |
+|---|---|
+| `--output`, `-o` | Output format: `table` (default), `wide`, `json`, or `yaml` |
+| `--no-headers` | Suppress the header row in table output |
+| `--quiet`, `-q` | Suppress non-essential output |
+| `--debug` | Enable debug logging, showing MCP protocol messages |
+| `--config-path` | Configuration directory. Defaults to `~/.config/muster` |
+| `--endpoint` | Remote aggregator endpoint URL. Reads `MUSTER_ENDPOINT` when unset |
+| `--context` | Use a named context. Reads `MUSTER_CONTEXT` when unset |
+| `--auth` | Authentication mode: `auto` (default), `prompt`, or `none`. Reads `MUSTER_AUTH_MODE` when unset |
+
+Most of these commands need a running aggregator. Start one with [`muster serve`]({{< relref "/reference/muster/cli/serve" >}}), or point `--endpoint` at a remote one.
+
+## Configuration {#config}
+
+Muster reads its configuration from `~/.config/muster` by default. Override the directory with `--config-path`:
+
+```nohighlight
+~/.config/muster/
+├── config.yaml      # aggregator port, host, transport, namespace
+├── mcpservers/      # MCPServer definitions
+└── workflows/       # Workflow definitions
+```
+
+In Kubernetes mode, Muster reads `MCPServer` and `Workflow` custom resources from the cluster instead. See [Deploy Muster]({{< relref "/tutorials/ai-agents/deploy-muster" >}}).
+
+## Contributing {#contributing}
+
+See the [GitHub project](https://github.com/giantswarm/muster) for source code, issues, and pull requests.

--- a/src/content/reference/muster/_index.md
+++ b/src/content/reference/muster/_index.md
@@ -76,7 +76,7 @@ Muster reads its configuration from `~/.config/muster` by default. Override the 
 └── workflows/       # Workflow definitions
 ```
 
-In Kubernetes mode, Muster reads `MCPServer` and `Workflow` custom resources from the cluster instead. See [Deploy Muster]({{< relref "/tutorials/ai-agents/deploy-muster" >}}).
+In Kubernetes mode, Muster reads `MCPServer` and `Workflow` custom resources from the cluster instead. See [Deploy Muster]({{< relref "/tutorials/ai-agents/self-hosting/deploy-muster" >}}).
 
 ## Contributing {#contributing}
 

--- a/src/content/reference/muster/cli/_index.md
+++ b/src/content/reference/muster/cli/_index.md
@@ -1,0 +1,55 @@
+---
+linkTitle: CLI commands
+title: Muster CLI command reference
+description: Per-command reference for the Muster command-line interface, covering the aggregator server, the agent bridge, authentication, and resource management.
+weight: 10
+layout: single
+menu:
+  principal:
+    identifier: reference-muster-cli
+    parent: reference-muster
+last_review_date: 2026-06-21
+user_questions:
+  - Which commands does the Muster CLI offer?
+owner:
+  - https://github.com/orgs/giantswarm/teams/team-bumblebee
+---
+
+The `muster` binary groups its commands into a few areas: running the aggregator, connecting to it, authenticating, and managing resources. Each command has its own page below.
+
+## Server and bridge {#server}
+
+| Command | Description |
+|---|---|
+| [`serve`]({{< relref "/reference/muster/cli/serve" >}}) | Start the aggregator server that other commands and IDEs connect to |
+| [`standalone`]({{< relref "/reference/muster/cli/standalone" >}}) | Run the aggregator and agent together in a single process |
+| [`agent`]({{< relref "/reference/muster/cli/agent" >}}) | Connect to the aggregator as a client, or bridge it to a stdio-only IDE |
+
+## Connection and authentication {#connection}
+
+| Command | Description |
+|---|---|
+| [`context`]({{< relref "/reference/muster/cli/context" >}}) | Manage named contexts, each pointing at a Muster endpoint |
+| [`auth`]({{< relref "/reference/muster/cli/auth" >}}) | Log in to, inspect, and log out of a remote aggregator |
+
+## Resources {#resources}
+
+| Command | Description |
+|---|---|
+| [`list`]({{< relref "/reference/muster/cli/list" >}}) | List services, MCP servers, workflows, executions, tools, resources, or prompts |
+| [`get`]({{< relref "/reference/muster/cli/get" >}}) | Get details for a single resource |
+| [`create`]({{< relref "/reference/muster/cli/create" >}}) | Create a `Workflow` or `MCPServer` definition |
+| [`call`]({{< relref "/reference/muster/cli/call" >}}) | Call any MCP tool by name |
+| [`start`]({{< relref "/reference/muster/cli/start" >}}) | Start a service or run a workflow |
+| [`stop`]({{< relref "/reference/muster/cli/stop" >}}) | Stop a running service |
+| [`check`]({{< relref "/reference/muster/cli/check" >}}) | Check that an MCP server or workflow is available |
+| [`events`]({{< relref "/reference/muster/cli/events" >}}) | List and filter resource events |
+
+## Utility {#utility}
+
+| Command | Description |
+|---|---|
+| [`version`]({{< relref "/reference/muster/cli/version" >}}) | Print the CLI version and, if reachable, the server version |
+| [`self-update`]({{< relref "/reference/muster/cli/self-update" >}}) | Update the CLI to the latest GitHub release |
+
+The flags shared by the resource commands are documented under [common flags]({{< relref "/reference/muster" >}}#common-flags).

--- a/src/content/reference/muster/cli/agent.md
+++ b/src/content/reference/muster/cli/agent.md
@@ -1,0 +1,56 @@
+---
+linkTitle: agent
+title: "'muster agent' command reference"
+description: Reference for the 'muster agent' command, which connects to the Muster aggregator as a client or bridges it to a stdio-only IDE.
+weight: 30
+menu:
+  principal:
+    parent: reference-muster-cli
+owner:
+  - https://github.com/orgs/giantswarm/teams/team-bumblebee
+user_questions:
+  - How do I connect my IDE to Muster?
+  - What does 'muster agent --mcp-server' do?
+  - How do I explore Muster tools interactively?
+last_review_date: 2026-06-21
+---
+
+`muster agent` connects to a running aggregator as an MCP client. Modern IDEs and the developer portal chat connect to the aggregator URL directly over remote, OAuth-protected MCP, so `muster agent` is an optional local bridge. Use it for clients that can only speak stdio, or to explore tools by hand.
+
+The aggregator must be running first. Start it with [`muster serve`]({{< relref "/reference/muster/cli/serve" >}}).
+
+## Usage
+
+```nohighlight
+muster agent [flags]
+```
+
+The command runs in one of three modes:
+
+- **Normal** (default): connects, lists tools, and waits for tool-update notifications.
+- **REPL** (`--repl`): an interactive prompt to list and run tools, resources, and prompts.
+- **MCP server** (`--mcp-server`): runs an MCP server over stdio that an IDE configures as its MCP endpoint. This is the local-bridge mode for stdio-only clients.
+
+## Flags {#flags}
+
+| Name | Description |
+|---|---|
+| `--endpoint` | Aggregator MCP endpoint URL. Reads the configured context when unset |
+| `--context` | Use a named context. Reads `MUSTER_CONTEXT` when unset |
+| `--transport` | Transport for the connection: `streamable-http` (default) or `sse` |
+| `--repl` | Start the interactive prompt |
+| `--mcp-server` | Run as an MCP server over stdio, for stdio-only IDEs |
+| `--timeout` | How long to wait for notifications. Defaults to `5m` |
+| `--auth` | Authentication mode: `auto` (default), `prompt`, or `none`. Reads `MUSTER_AUTH_MODE` when unset |
+| `--disable-auto-sso` | Don't authenticate to remote MCP servers automatically after Muster auth |
+| `--silent` | Attempt silent re-auth using OIDC `prompt=none`. Needs IdP support, not available with Dex |
+| `--verbose` | Enable verbose logging, including keepalive messages |
+| `--json-rpc` | Log full JSON-RPC messages |
+| `--no-color` | Disable colored output |
+| `--config-path` | Configuration directory. Defaults to `~/.config/muster` |
+
+## Related
+
+- [Set up your AI agent]({{< relref "/getting-started/ai-agent-setup" >}}) - Connect an IDE to Muster.
+- [`muster serve`]({{< relref "/reference/muster/cli/serve" >}}) - Start the aggregator.
+- [`muster auth`]({{< relref "/reference/muster/cli/auth" >}}) - Authenticate to a remote aggregator.

--- a/src/content/reference/muster/cli/auth.md
+++ b/src/content/reference/muster/cli/auth.md
@@ -1,0 +1,80 @@
+---
+linkTitle: auth
+title: "'muster auth' command reference"
+description: Reference for the 'muster auth' command, which authenticates the Muster CLI to a remote OAuth-protected aggregator.
+weight: 50
+menu:
+  principal:
+    parent: reference-muster-cli
+owner:
+  - https://github.com/orgs/giantswarm/teams/team-bumblebee
+user_questions:
+  - How do I log in to a remote Muster?
+  - How do I check my Muster authentication status?
+  - How do I log out of Muster?
+last_review_date: 2026-06-21
+---
+
+`muster auth` manages authentication to a remote, OAuth-protected aggregator. Use it to log in, check your current identity and token status, and log out. For how OAuth works in Muster, see the [security overview]({{< relref "/overview/ai-agents/security" >}}).
+
+## Usage
+
+```nohighlight
+muster auth <subcommand> [flags]
+```
+
+## Subcommands {#subcommands}
+
+| Subcommand | Description |
+|---|---|
+| `login` | Authenticate to a Muster aggregator using OAuth |
+| `status` | Show authentication status |
+| `whoami` | Show the current authenticated identity |
+| `logout` | Clear stored authentication tokens |
+
+## Flags {#flags}
+
+These flags apply to every `auth` subcommand:
+
+| Name | Description |
+|---|---|
+| `--endpoint` | Endpoint URL to authenticate to |
+| `--context` | Use a named context. Reads `MUSTER_CONTEXT` when unset |
+| `--config-path` | Configuration directory. Defaults to `~/.config/muster` |
+| `--quiet`, `-q` | Suppress non-essential output |
+
+### `login` flags {#login-flags}
+
+| Name | Description |
+|---|---|
+| `--all` | Log in to the aggregator and every pending MCP server behind it |
+| `--server` | Name of an aggregator-managed MCP server to authenticate to |
+| `--silent` | Attempt silent re-auth using OIDC `prompt=none`. Needs IdP support, not available with Dex |
+
+### `logout` flags {#logout-flags}
+
+| Name | Description |
+|---|---|
+| `--all` | Clear all stored tokens |
+| `--yes`, `-y` | Skip the confirmation prompt for `--all` |
+| `--server`, `-s` | Name of an MCP server to disconnect |
+
+## Examples {#examples}
+
+Log in to a remote aggregator and to every MCP server that still needs authentication:
+
+```nohighlight
+muster auth login \
+  --endpoint https://muster.<management-cluster>.<base-domain>/mcp --all
+```
+
+Authenticate to one downstream MCP server after the aggregator is connected:
+
+```nohighlight
+muster auth login --server kubernetes
+```
+
+## Related
+
+- [Access control]({{< relref "/tutorials/ai-agents/access-control" >}}) - How identity maps to cluster permissions.
+- [`muster context`]({{< relref "/reference/muster/cli/context" >}}) - Manage the endpoints you authenticate to.

--- a/src/content/reference/muster/cli/call.md
+++ b/src/content/reference/muster/cli/call.md
@@ -1,0 +1,47 @@
+---
+linkTitle: call
+title: "'muster call' command reference"
+description: Reference for the 'muster call' command, which invokes any MCP tool behind the Muster aggregator by name.
+weight: 90
+menu:
+  principal:
+    parent: reference-muster-cli
+owner:
+  - https://github.com/orgs/giantswarm/teams/team-bumblebee
+user_questions:
+  - How do I call an MCP tool from the Muster CLI?
+  - How do I run a Muster workflow tool by name?
+last_review_date: 2026-06-21
+---
+
+`muster call` invokes any MCP tool by name, including the `core_*` tools, the `x_*` tools from aggregated servers, and the `workflow_*` tools. The aggregator must be running, or `--endpoint` must point at a remote one.
+
+## Usage
+
+```nohighlight
+muster call <tool-name> [--arg=value ...]
+```
+
+Pass arguments as `--key=value` or `--key value` flags. To pass a structured argument, use `--json` with a JSON object instead.
+
+## Flags {#flags}
+
+| Name | Description |
+|---|---|
+| `--json` | Pass the tool arguments as a single JSON object |
+
+Any other `--key=value` flag is forwarded to the tool as an argument. `call` also accepts the [common flags]({{< relref "/reference/muster" >}}#common-flags).
+
+## Examples {#examples}
+
+```nohighlight
+muster call core_service_list
+muster call core_service_status --name=prometheus
+muster call workflow_deploy --environment=production --replicas=3
+muster call core_mcpserver_list --output json
+```
+
+## Related
+
+- [Meta-tools]({{< relref "/reference/muster/meta-tools" >}}) - The tool families and the `core_*` catalog.
+- [`muster start`]({{< relref "/reference/muster/cli/start" >}}) - Run a workflow by name.

--- a/src/content/reference/muster/cli/check.md
+++ b/src/content/reference/muster/cli/check.md
@@ -1,0 +1,46 @@
+---
+linkTitle: check
+title: "'muster check' command reference"
+description: Reference for the 'muster check' command, which checks whether a Muster MCP server or workflow is available.
+weight: 120
+menu:
+  principal:
+    parent: reference-muster-cli
+owner:
+  - https://github.com/orgs/giantswarm/teams/team-bumblebee
+user_questions:
+  - How do I check that a Muster workflow is available?
+  - How do I check an MCP server's status?
+last_review_date: 2026-06-21
+---
+
+`muster check` reports whether a resource is available and properly configured. For a workflow, "available" means every tool the workflow references is present in your session. The aggregator must be running, or `--endpoint` must point at a remote one.
+
+## Usage
+
+```nohighlight
+muster check <resource-type> <name>
+```
+
+## Resource types {#types}
+
+| Type | Description |
+|---|---|
+| `mcpserver` | Check an MCP server's status |
+| `workflow` | Check that a workflow is available, with all required tools present |
+
+## Flags {#flags}
+
+`check` accepts the [common flags]({{< relref "/reference/muster" >}}#common-flags).
+
+## Examples {#examples}
+
+```nohighlight
+muster check mcpserver prometheus
+muster check workflow my-deployment
+```
+
+## Related
+
+- [`muster list`]({{< relref "/reference/muster/cli/list" >}}) - List resources.
+- [Troubleshooting]({{< relref "/tutorials/ai-agents/troubleshooting" >}}) - When a workflow's tools are missing.

--- a/src/content/reference/muster/cli/context.md
+++ b/src/content/reference/muster/cli/context.md
@@ -1,0 +1,66 @@
+---
+linkTitle: context
+title: "'muster context' command reference"
+description: Reference for the 'muster context' command, which manages named contexts that each point at a Muster endpoint.
+weight: 40
+menu:
+  principal:
+    parent: reference-muster-cli
+owner:
+  - https://github.com/orgs/giantswarm/teams/team-bumblebee
+user_questions:
+  - How do I switch between Muster endpoints?
+  - How do I add a Muster context?
+last_review_date: 2026-06-21
+---
+
+`muster context` manages named contexts. Each context points at a Muster endpoint, so you can switch between a local aggregator and one or more remote management clusters without retyping URLs. Running `muster context` with no subcommand lists the contexts.
+
+## Usage
+
+```nohighlight
+muster context [subcommand]
+```
+
+## Subcommands {#subcommands}
+
+| Subcommand | Aliases | Description |
+|---|---|---|
+| `list` | `ls` | List all configured contexts |
+| `current` | | Show the name of the active context |
+| `use <name>` | `switch` | Switch the active context |
+| `add <name> --endpoint <url>` | | Add a new context |
+| `update <name> --endpoint <url>` | `set` | Change an existing context's endpoint |
+| `rename <old-name> <new-name>` | | Rename a context |
+| `show <name>` | `describe`, `get` | Show details for one context |
+| `delete <name>` | `rm`, `remove` | Delete a context |
+
+## Flags {#flags}
+
+| Subcommand | Name | Description |
+|---|---|---|
+| `add` | `--endpoint` | Endpoint URL for the context (required) |
+| `add` | `--use` | Set as the active context after adding |
+| `update` | `--endpoint` | New endpoint URL (required) |
+| `show` | `--output`, `-o` | Output format: `text` (default), `json`, or `yaml` |
+| `delete` | `--force`, `-f` | Skip the confirmation prompt |
+| (all) | `--quiet`, `-q` | Suppress non-essential output |
+
+## Examples {#examples}
+
+Add a context for a remote management cluster and make it active:
+
+```nohighlight
+muster context add prod \
+  --endpoint https://muster.<management-cluster>.<base-domain>/mcp --use
+```
+
+Switch back to a local aggregator:
+
+```nohighlight
+muster context use local
+```
+
+## Related
+
+- [`muster auth`]({{< relref "/reference/muster/cli/auth" >}}) - Authenticate to the endpoint behind a context.

--- a/src/content/reference/muster/cli/create.md
+++ b/src/content/reference/muster/cli/create.md
@@ -1,0 +1,67 @@
+---
+linkTitle: create
+title: "'muster create' command reference"
+description: Reference for the 'muster create' command, which creates Muster Workflow and MCPServer definitions.
+weight: 80
+menu:
+  principal:
+    parent: reference-muster-cli
+owner:
+  - https://github.com/orgs/giantswarm/teams/team-bumblebee
+user_questions:
+  - How do I create an MCP server definition with the Muster CLI?
+  - How do I create a Muster workflow from the command line?
+last_review_date: 2026-06-21
+---
+
+`muster create` creates a resource definition. The aggregator must be running, or `--endpoint` must point at a remote one.
+
+## Usage
+
+```nohighlight
+muster create <resource-type> <name> [flags]
+```
+
+## Resource types {#types}
+
+| Type | Description |
+|---|---|
+| `workflow` | A `Workflow` definition |
+| `mcpserver` | An `MCPServer` definition: `stdio`, `streamable-http`, or `sse` |
+
+## Flags {#flags}
+
+For `mcpserver`, these flags map to fields on the [`MCPServer`]({{< relref "/reference/muster/crds" >}}#mcpserver) resource:
+
+| Name | Description |
+|---|---|
+| `--type` | Server type: `stdio`, `streamable-http`, or `sse` |
+| `--command` | Executable for a `stdio` server |
+| `--args` | Command-line arguments for a `stdio` server |
+| `--url` | Endpoint URL for a `streamable-http` or `sse` server |
+| `--tool-prefix` | Prefix prepended to the server's tool names |
+| `--timeout` | Connection timeout in seconds. Defaults to `30` |
+| `--autoStart` | Start the server automatically when Muster initializes |
+| `--env` | Environment variable, as `KEY=VALUE`. Repeat for several |
+| `--description` | Human-readable description |
+
+`create` also accepts the [common flags]({{< relref "/reference/muster" >}}#common-flags).
+
+## Examples {#examples}
+
+```nohighlight
+muster create mcpserver my-stdio-server \
+  --type=stdio --command=npx --args="@modelcontextprotocol/server-git" --autoStart=true
+
+muster create mcpserver my-http-server \
+  --type=streamable-http --url=https://api.example.com/mcp --timeout=30
+
+muster create workflow example-workflow
+```
+
+For the full set of `MCPServer` and `Workflow` fields, including authentication and control flow, see [custom resources]({{< relref "/reference/muster/crds" >}}). To author a workflow the code-grounded way, see [Author a Muster workflow]({{< relref "/tutorials/ai-agents/authoring-workflows" >}}).
+
+## Related
+
+- [Managing MCP servers]({{< relref "/tutorials/ai-agents/managing-mcp-servers" >}}) - The full `MCPServer` workflow.
+- [Custom resources]({{< relref "/reference/muster/crds" >}}) - The resource schemas.

--- a/src/content/reference/muster/cli/events.md
+++ b/src/content/reference/muster/cli/events.md
@@ -1,0 +1,51 @@
+---
+linkTitle: events
+title: "'muster events' command reference"
+description: Reference for the 'muster events' command, which lists and filters events for Muster resources.
+weight: 130
+menu:
+  principal:
+    parent: reference-muster-cli
+owner:
+  - https://github.com/orgs/giantswarm/teams/team-bumblebee
+user_questions:
+  - How do I see events for Muster resources?
+  - How do I follow Muster events live?
+last_review_date: 2026-06-21
+---
+
+`muster events` lists and filters events for Muster resources, in both Kubernetes and filesystem modes. The aggregator must be running, or `--endpoint` must point at a remote one.
+
+## Usage
+
+```nohighlight
+muster events [flags]
+```
+
+## Flags {#flags}
+
+| Name | Description |
+|---|---|
+| `--resource-type` | Filter by resource type: `mcpserver` or `workflow` |
+| `--resource-name` | Filter by resource name |
+| `--namespace` | Filter by namespace |
+| `--type` | Filter by event type: `Normal` or `Warning` |
+| `--since` | Show events after this time, for example `1h`, `30m`, or an absolute timestamp |
+| `--until` | Show events before this time |
+| `--limit` | Maximum number of events. Defaults to `50` |
+| `--follow`, `-f` | Stream new events as they occur |
+
+`events` also accepts the [common flags]({{< relref "/reference/muster" >}}#common-flags).
+
+## Examples {#examples}
+
+```nohighlight
+muster events
+muster events --resource-type mcpserver
+muster events --type Warning --since 1h
+```
+
+## Related
+
+- [`muster check`]({{< relref "/reference/muster/cli/check" >}}) - Check that a resource is available.
+- [Troubleshooting]({{< relref "/tutorials/ai-agents/troubleshooting" >}}) - Diagnose connection problems.

--- a/src/content/reference/muster/cli/get.md
+++ b/src/content/reference/muster/cli/get.md
@@ -1,0 +1,54 @@
+---
+linkTitle: get
+title: "'muster get' command reference"
+description: Reference for the 'muster get' command, which retrieves details about a single Muster resource.
+weight: 70
+menu:
+  principal:
+    parent: reference-muster-cli
+owner:
+  - https://github.com/orgs/giantswarm/teams/team-bumblebee
+user_questions:
+  - How do I inspect a single Muster resource?
+  - How do I see a workflow execution's result?
+last_review_date: 2026-06-21
+---
+
+`muster get` retrieves details about one resource. The aggregator must be running, or `--endpoint` must point at a remote one.
+
+## Usage
+
+```nohighlight
+muster get <type> <name|uri|id> [flags]
+```
+
+## Resource types {#types}
+
+| Type | Identified by | Description |
+|---|---|---|
+| `service` | name | Detailed status of a service |
+| `mcpserver` | name | MCP server details and configuration |
+| `workflow` | name | Workflow definition and details |
+| `workflow-execution` | execution ID | Workflow execution details and results |
+| `tool` | name | MCP tool details, including its input schema |
+| `resource` | URI | MCP resource metadata |
+| `prompt` | name | MCP prompt details, including its arguments |
+
+## Flags {#flags}
+
+`get` accepts the [common flags]({{< relref "/reference/muster" >}}#common-flags). Use `--output yaml` or `--output json` to inspect the full resource.
+
+## Examples {#examples}
+
+```nohighlight
+muster get service prometheus
+muster get workflow auth-flow
+muster get workflow-execution abc123-def456-789
+muster get mcpserver kubernetes --output yaml
+muster get tool core_service_list
+```
+
+## Related
+
+- [`muster list`]({{< relref "/reference/muster/cli/list" >}}) - List resources.
+- [Custom resources]({{< relref "/reference/muster/crds" >}}) - The `MCPServer` and `Workflow` schemas.

--- a/src/content/reference/muster/cli/list.md
+++ b/src/content/reference/muster/cli/list.md
@@ -1,0 +1,69 @@
+---
+linkTitle: list
+title: "'muster list' command reference"
+description: Reference for the 'muster list' command, which lists Muster services, MCP servers, workflows, executions, and MCP primitives.
+weight: 60
+menu:
+  principal:
+    parent: reference-muster-cli
+owner:
+  - https://github.com/orgs/giantswarm/teams/team-bumblebee
+user_questions:
+  - How do I list Muster services and workflows?
+  - How do I list the tools behind Muster?
+last_review_date: 2026-06-21
+---
+
+`muster list` lists resources in the Muster environment. The aggregator must be running, or `--endpoint` must point at a remote one.
+
+## Usage
+
+```nohighlight
+muster list <resource-type> [flags]
+```
+
+## Resource types {#types}
+
+The trailing `(s)` means both singular and plural work, for example `service` or `services`.
+
+| Type | Description |
+|---|---|
+| `service(s)` | All services with their status |
+| `mcpserver(s)` | All MCP server definitions |
+| `workflow(s)` | All workflow definitions |
+| `workflow-execution(s)` | Workflow execution history |
+| `tool(s)` | All MCP tools from the aggregated servers |
+| `resource(s)` | All MCP resources from the aggregated servers |
+| `prompt(s)` | All MCP prompts from the aggregated servers |
+
+## Flags {#flags}
+
+These flags filter the MCP primitives (`tool`, `resource`, `prompt`):
+
+| Name | Description |
+|---|---|
+| `--filter` | Filter by name pattern. Wildcards `*` and `?` are supported |
+| `--description` | Filter by description content, as a case-insensitive substring |
+| `--server` | Filter by server-name prefix |
+
+For `mcpserver`:
+
+| Name | Description |
+|---|---|
+| `--all` | Show all servers, including unreachable ones |
+| `--verbose` | Show detailed error information for failed or unreachable servers |
+
+`list` also accepts the [common flags]({{< relref "/reference/muster" >}}#common-flags), including `--output`.
+
+## Examples {#examples}
+
+```nohighlight
+muster list mcpserver
+muster list workflow
+muster list tool --filter 'x_kubernetes_*'
+```
+
+## Related
+
+- [`muster get`]({{< relref "/reference/muster/cli/get" >}}) - Get details for a single resource.
+- [`muster check`]({{< relref "/reference/muster/cli/check" >}}) - Check that a resource is available.

--- a/src/content/reference/muster/cli/self-update.md
+++ b/src/content/reference/muster/cli/self-update.md
@@ -1,0 +1,26 @@
+---
+linkTitle: self-update
+title: "'muster self-update' command reference"
+description: Reference for the 'muster self-update' command, which updates the Muster CLI to the latest GitHub release.
+weight: 150
+menu:
+  principal:
+    parent: reference-muster-cli
+owner:
+  - https://github.com/orgs/giantswarm/teams/team-bumblebee
+user_questions:
+  - How do I update the Muster CLI?
+last_review_date: 2026-06-21
+---
+
+`muster self-update` checks for the latest release of Muster on GitHub and updates the local binary in place.
+
+## Usage
+
+```nohighlight
+muster self-update
+```
+
+## Related
+
+- [`muster version`]({{< relref "/reference/muster/cli/version" >}}) - Check the current version.

--- a/src/content/reference/muster/cli/serve.md
+++ b/src/content/reference/muster/cli/serve.md
@@ -39,7 +39,7 @@ To connect an IDE that can't reach the endpoint directly, bridge it with [`muste
 
 ### OAuth protection {#oauth}
 
-These flags turn Muster into an OAuth 2.1 protected resource and enable the MCP client proxy for authenticating to remote MCP servers. Full setup needs a configuration file. See [Set up OAuth for Muster]({{< relref "/tutorials/ai-agents/oauth-setup" >}}).
+These flags turn Muster into an OAuth 2.1 protected resource and enable the MCP client proxy for authenticating to remote MCP servers. Full setup needs a configuration file. See [Set up OAuth for Muster]({{< relref "/tutorials/ai-agents/self-hosting/oauth-setup" >}}).
 
 | Name | Description |
 |---|---|

--- a/src/content/reference/muster/cli/serve.md
+++ b/src/content/reference/muster/cli/serve.md
@@ -1,0 +1,56 @@
+---
+linkTitle: serve
+title: "'muster serve' command reference"
+description: Reference for the 'muster serve' command, which starts the Muster aggregator server that AI agents and other Muster commands connect to.
+weight: 10
+menu:
+  principal:
+    parent: reference-muster-cli
+owner:
+  - https://github.com/orgs/giantswarm/teams/team-bumblebee
+user_questions:
+  - How do I start the Muster aggregator server?
+  - How do I enable OAuth protection for Muster?
+last_review_date: 2026-06-21
+---
+
+`muster serve` starts the aggregator server. It connects the configured MCP servers, exposes their tools behind one unified MCP endpoint, and keeps that endpoint available for IDEs, the developer portal chat, and the other `muster` commands.
+
+## Usage
+
+```nohighlight
+muster serve [flags]
+```
+
+With no flags, Muster loads its configuration from `~/.config/muster`, starts the MCP servers and services marked for autostart, and prints a summary with the connection details.
+
+To connect an IDE that can't reach the endpoint directly, bridge it with [`muster agent --mcp-server`]({{< relref "/reference/muster/cli/agent" >}}). IDEs that support remote, OAuth-protected MCP connect straight to the aggregator URL instead.
+
+## Flags {#flags}
+
+| Name | Description |
+|---|---|
+| `--config-path` | Configuration directory. Defaults to `~/.config/muster` |
+| `--debug` | Enable general debug logging |
+| `--silent` | Disable console log output. Does not silence OTLP export |
+| `--yolo` | Disable the denylist for destructive tool calls. Use with caution |
+| `--enable-events` | Enable Kubernetes event emission (alpha) |
+| `--extra-ca-file` | PEM file whose certificates are appended to the system trust pool at startup |
+
+### OAuth protection {#oauth}
+
+These flags turn Muster into an OAuth 2.1 protected resource and enable the MCP client proxy for authenticating to remote MCP servers. Full setup needs a configuration file. See [Set up OAuth for Muster]({{< relref "/tutorials/ai-agents/oauth-setup" >}}).
+
+| Name | Description |
+|---|---|
+| `--oauth-server` | Enable OAuth 2.1 protection for the Muster server |
+| `--oauth-server-base-url` | Base URL of the Muster server for OAuth, for example `https://muster.<management-cluster>.<base-domain>` |
+| `--oauth-mcp-client` | Enable the OAuth MCP client proxy for remote MCP server authentication |
+| `--oauth-mcp-client-public-url` | Publicly accessible URL of the Muster server for OAuth callbacks |
+| `--oauth-mcp-client-id` | OAuth client identifier. Auto-derived from the public URL when empty |
+
+## Related
+
+- [`muster standalone`]({{< relref "/reference/muster/cli/standalone" >}}) - Run the aggregator and agent in one process.
+- [`muster agent`]({{< relref "/reference/muster/cli/agent" >}}) - Connect to a running aggregator.
+- [Muster architecture]({{< relref "/overview/ai-agents/architecture" >}}) - How the aggregator works.

--- a/src/content/reference/muster/cli/standalone.md
+++ b/src/content/reference/muster/cli/standalone.md
@@ -1,0 +1,32 @@
+---
+linkTitle: standalone
+title: "'muster standalone' command reference"
+description: Reference for the 'muster standalone' command, which runs the Muster aggregator and the agent together in a single process.
+weight: 20
+menu:
+  principal:
+    parent: reference-muster-cli
+owner:
+  - https://github.com/orgs/giantswarm/teams/team-bumblebee
+user_questions:
+  - How do I run Muster as a single-process MCP server?
+  - What does 'muster standalone' do?
+last_review_date: 2026-06-21
+---
+
+`muster standalone` starts the aggregator server and the agent in one process. It's the simplest way to expose Muster to a stdio-only client without running [`muster serve`]({{< relref "/reference/muster/cli/serve" >}}) and [`muster agent`]({{< relref "/reference/muster/cli/agent" >}}) separately.
+
+## Usage
+
+```nohighlight
+muster standalone [flags]
+```
+
+## Flags {#flags}
+
+Standalone accepts the flags of both [`muster serve`]({{< relref "/reference/muster/cli/serve" >}}) and [`muster agent`]({{< relref "/reference/muster/cli/agent" >}}). The `--silent` flag defaults to `true` here, so the aggregator's console logging doesn't interfere with the stdio MCP stream.
+
+## Related
+
+- [`muster serve`]({{< relref "/reference/muster/cli/serve" >}}) - Start the aggregator on its own.
+- [`muster agent`]({{< relref "/reference/muster/cli/agent" >}}) - Connect to a running aggregator.

--- a/src/content/reference/muster/cli/start.md
+++ b/src/content/reference/muster/cli/start.md
@@ -1,0 +1,49 @@
+---
+linkTitle: start
+title: "'muster start' command reference"
+description: Reference for the 'muster start' command, which starts a Muster service or runs a workflow.
+weight: 100
+menu:
+  principal:
+    parent: reference-muster-cli
+owner:
+  - https://github.com/orgs/giantswarm/teams/team-bumblebee
+user_questions:
+  - How do I start a Muster service?
+  - How do I run a Muster workflow from the command line?
+last_review_date: 2026-06-21
+---
+
+`muster start` starts a service or runs a workflow. The aggregator must be running, or `--endpoint` must point at a remote one.
+
+## Usage
+
+```nohighlight
+muster start <resource-type> <name> [parameters]
+```
+
+## Resource types {#types}
+
+| Type | Description |
+|---|---|
+| `service` | Start a service by name |
+| `workflow` | Run a workflow, with optional parameters as flags |
+
+Workflow parameters are passed as `--key=value` flags and validated against the workflow's [argument schema]({{< relref "/reference/muster/crds" >}}#workflow).
+
+## Flags {#flags}
+
+`start` accepts the [common flags]({{< relref "/reference/muster" >}}#common-flags). For workflows, additional `--key=value` flags supply the workflow arguments.
+
+## Examples {#examples}
+
+```nohighlight
+muster start service prometheus
+muster start workflow deploy-app --environment=production --replicas=3
+```
+
+## Related
+
+- [`muster stop`]({{< relref "/reference/muster/cli/stop" >}}) - Stop a running service.
+- [`muster call`]({{< relref "/reference/muster/cli/call" >}}) - Run a workflow as a `workflow_<name>` tool.
+- [Author a Muster workflow]({{< relref "/tutorials/ai-agents/authoring-workflows" >}}) - Write workflows.

--- a/src/content/reference/muster/cli/stop.md
+++ b/src/content/reference/muster/cli/stop.md
@@ -1,0 +1,42 @@
+---
+linkTitle: stop
+title: "'muster stop' command reference"
+description: Reference for the 'muster stop' command, which stops a running Muster service.
+weight: 110
+menu:
+  principal:
+    parent: reference-muster-cli
+owner:
+  - https://github.com/orgs/giantswarm/teams/team-bumblebee
+user_questions:
+  - How do I stop a Muster service?
+last_review_date: 2026-06-21
+---
+
+`muster stop` stops a running service. The aggregator must be running, or `--endpoint` must point at a remote one.
+
+## Usage
+
+```nohighlight
+muster stop service <name>
+```
+
+## Resource types {#types}
+
+| Type | Description |
+|---|---|
+| `service` | Stop a service by name |
+
+## Flags {#flags}
+
+`stop` accepts the [common flags]({{< relref "/reference/muster" >}}#common-flags).
+
+## Examples {#examples}
+
+```nohighlight
+muster stop service prometheus
+```
+
+## Related
+
+- [`muster start`]({{< relref "/reference/muster/cli/start" >}}) - Start a service or run a workflow.

--- a/src/content/reference/muster/cli/version.md
+++ b/src/content/reference/muster/cli/version.md
@@ -1,0 +1,26 @@
+---
+linkTitle: version
+title: "'muster version' command reference"
+description: Reference for the 'muster version' command, which prints the Muster CLI and server version.
+weight: 140
+menu:
+  principal:
+    parent: reference-muster-cli
+owner:
+  - https://github.com/orgs/giantswarm/teams/team-bumblebee
+user_questions:
+  - How do I check which version of Muster I'm running?
+last_review_date: 2026-06-21
+---
+
+`muster version` prints the CLI version. When the aggregator server is reachable, it also prints the server version.
+
+## Usage
+
+```nohighlight
+muster version
+```
+
+## Related
+
+- [`muster self-update`]({{< relref "/reference/muster/cli/self-update" >}}) - Update the CLI to the latest release.

--- a/src/content/reference/muster/crds.md
+++ b/src/content/reference/muster/crds.md
@@ -1,0 +1,257 @@
+---
+linkTitle: Custom resources
+title: Muster custom resource reference
+description: Field reference for the Muster MCPServer and Workflow custom resources, grounded in the API types shipped at version 0.10.0.
+weight: 30
+menu:
+  principal:
+    parent: reference-muster
+    identifier: reference-muster-crds
+owner:
+  - https://github.com/orgs/giantswarm/teams/team-bumblebee
+user_questions:
+  - What fields does the Muster MCPServer resource support?
+  - What fields does a Muster Workflow support?
+  - How do I shape a workflow's returned result?
+last_review_date: 2026-06-21
+---
+
+Muster defines two custom resources: `MCPServer`, which registers a downstream MCP server, and `Workflow`, which packages a multi-step operation into one agent-callable tool. Both belong to the API group `muster.giantswarm.io/v1alpha1`. This reference is grounded in the API types shipped at version `0.10.0`.
+
+In Kubernetes mode, you author these as custom resources. With file-based configuration, the same schema applies under `mcpservers/` and `workflows/`. To create one from the CLI, see [`muster create`]({{< relref "/reference/muster/cli/create" >}}).
+
+## MCPServer {#mcpserver}
+
+An `MCPServer` tells Muster how to reach a downstream MCP server and how to expose its tools.
+
+```yaml
+apiVersion: muster.giantswarm.io/v1alpha1
+kind: MCPServer
+metadata:
+  name: kubernetes
+  namespace: muster
+spec:
+  type: streamable-http
+  url: https://mcp-kubernetes.<management-cluster>.<base-domain>/mcp
+  autoStart: true
+  family:
+    name: kubernetes
+    instanceArg: management_cluster
+  auth:
+    type: oauth
+    forwardToken: true
+```
+
+### `spec` fields {#mcpserver-spec}
+
+| Field | Type | Description |
+|---|---|---|
+| `type` | string | Required. One of `stdio`, `streamable-http`, or `sse` |
+| `command` | string | Executable for a `stdio` server. Required when `type` is `stdio` |
+| `args` | array | Command-line arguments. Only allowed when `type` is `stdio` |
+| `url` | string | Endpoint URL. Required when `type` is `streamable-http` or `sse` |
+| `env` | map | Environment variables for the server |
+| `headers` | map | HTTP headers for requests to a remote server. Only allowed for `streamable-http` or `sse` |
+| `toolPrefix` | string | Prefix prepended to the server's tool names, to avoid conflicts |
+| `family` | object | Group equivalent instances under one exposed surface. See [families](#mcpserver-family) |
+| `description` | string | Human-readable description. Up to 500 characters |
+| `autoStart` | boolean | Start the server when Muster initializes or when dependencies become available. Defaults to `false` |
+| `auth` | object | Authentication for a remote server. See [auth](#mcpserver-auth) |
+| `timeout` | integer | Connection timeout in seconds for remote operations. Defaults to `30`, between `1` and `300` |
+
+### Families {#mcpserver-family}
+
+A family groups equivalent servers, such as one `mcp-kubernetes` per management cluster, under a single exposed name. Tools appear as `<prefix>_<family-name>_<tool>` with a required argument that selects the instance.
+
+| Field | Type | Description |
+|---|---|---|
+| `family.name` | string | Required. Family identifier. Servers sharing this name share the exposed surface |
+| `family.instanceArg` | string | Required. Name of the required argument callers use to select the instance, for example `management_cluster` |
+
+All servers in a family must agree on `instanceArg`. When they diverge, Muster falls back to per-server prefixing for the family and logs a warning. The argument is always required, even for a single-instance family, so agent skills stay stable as instances come and go.
+
+### Authentication {#mcpserver-auth}
+
+`spec.auth` configures Single Sign-On to a remote server. For the concepts, see the [security overview]({{< relref "/overview/ai-agents/security" >}}).
+
+| Field | Type | Description |
+|---|---|---|
+| `auth.type` | string | `oauth` or `none`. Defaults to `none` |
+| `auth.forwardToken` | boolean | Forward the user's ID token to this server instead of a separate OAuth flow. The server must trust Muster's client ID. Defaults to `false` |
+| `auth.requiredAudiences` | array | Extra audiences the forwarded ID token should carry, requested from the IdP at login |
+| `auth.tokenExchange` | object | RFC 8693 token exchange for cross-cluster SSO. See [token exchange](#mcpserver-token-exchange) |
+| `auth.authorizationServer` | object | Opt-out for backends without RFC 9728 metadata. See [authorization server](#mcpserver-authz-server) |
+
+`authorizationServer` is mutually exclusive with `forwardToken: true` and with `tokenExchange.enabled: true`. It's only valid when `type` is `oauth`. Token exchange takes precedence over `forwardToken` when both are set.
+
+#### Token exchange {#mcpserver-token-exchange}
+
+`auth.tokenExchange` exchanges Muster's local token for one valid on a remote cluster's IdP. Use it when the remote cluster runs its own Dex.
+
+| Field | Type | Description |
+|---|---|---|
+| `enabled` | boolean | Whether to attempt token exchange. Defaults to `false` |
+| `dexTokenEndpoint` | string | URL of the remote Dex token endpoint. Required when `enabled` is `true` |
+| `expectedIssuer` | string | Expected `iss` claim in the exchanged token. Derived from `dexTokenEndpoint` when unset |
+| `connectorId` | string | ID of the remote Dex OIDC connector that trusts the local Dex. Required when `enabled` is `true` |
+| `scopes` | string | Scopes for the exchanged token. Defaults to `openid profile email groups` |
+| `clientCredentialsSecretRef` | object | Reference to a `Secret` with client credentials, when the remote Dex requires client authentication |
+
+`clientCredentialsSecretRef` takes `name`, optional `namespace` (defaults to the `MCPServer` namespace), `clientIdKey` (defaults to `client-id`), and `clientSecretKey` (defaults to `client-secret`). For a worked example, see [multi-cluster token exchange]({{< relref "/tutorials/ai-agents/multi-mc-token-exchange" >}}).
+
+#### Authorization server {#mcpserver-authz-server}
+
+`auth.authorizationServer` pins the OAuth authorization server for backends that publish RFC 8414 metadata at their origin instead of RFC 9728. See [connecting custom MCP servers]({{< relref "/tutorials/ai-agents/connecting-custom-mcp-servers" >}}).
+
+| Field | Type | Description |
+|---|---|---|
+| `issuer` | string | Required. The OAuth 2.0 / OIDC issuer URL. Must be HTTPS, no trailing slash |
+| `scopes` | string | Space-separated OAuth scope tokens |
+
+### `status` {#mcpserver-status}
+
+The reconciler reports infrastructure state in `status.state`. For a `stdio` server: `Running`, `Starting`, `Stopped`, or `Failed`. For a remote server: `Connected`, `Auth Required`, `Connecting`, `Disconnected`, or `Failed`. Per-user authentication state is tracked separately, not in the resource status.
+
+## Workflow {#workflow}
+
+A `Workflow` defines an ordered set of steps that Muster runs server-side, exposed to agents as a `workflow_<name>` tool. To author one, see [Author a Muster workflow]({{< relref "/tutorials/ai-agents/authoring-workflows" >}}).
+
+```yaml
+apiVersion: muster.giantswarm.io/v1alpha1
+kind: Workflow
+metadata:
+  name: crashlooping-pods
+spec:
+  description: List pods in CrashLoopBackOff on a cluster.
+  args:
+    cluster:
+      type: string
+      required: true
+  steps:
+    - id: pods
+      tool: x_kubernetes_get_pods
+      args:
+        management_cluster: "{{ .input.cluster }}"
+  output:
+    pods: "{{ .results.pods.items }}"
+    count: "{{ len .results.pods.items }}"
+```
+
+### `spec` fields {#workflow-spec}
+
+| Field | Type | Description |
+|---|---|---|
+| `description` | string | Human-readable description. Up to 1000 characters. This is the only text the agent uses to discover the workflow |
+| `args` | map | Argument schema, keyed by argument name. See [argument definitions](#workflow-args) |
+| `steps` | array | Required, at least one. The execution flow. See [steps](#workflow-step) |
+| `onFailure` | array | Best-effort cleanup sub-steps run when the workflow fails on a step that doesn't allow failure. They run sequentially and tolerate their own failures |
+| `output` | object | Templated projection that shapes the returned document. See [output projection](#workflow-output) |
+
+### Argument definitions {#workflow-args}
+
+Each entry under `spec.args` validates one workflow argument.
+
+| Field | Type | Description |
+|---|---|---|
+| `type` | string | Required. One of `string`, `integer`, `boolean`, `number`, `object`, `array` |
+| `required` | boolean | Whether the argument must be provided. Defaults to `false` |
+| `default` | any | Default value when the argument is omitted |
+| `description` | string | Human-readable documentation. Up to 500 characters |
+
+### Steps {#workflow-step}
+
+A step is exactly one of: a tool call (`tool`), a sequential loop (`forEach`), or a concurrent group (`parallel`). The CRD enforces this with a validation rule.
+
+| Field | Type | Description |
+|---|---|---|
+| `id` | string | Required. Unique within the workflow. Pattern `^[a-zA-Z0-9_-]+$`, up to 63 characters |
+| `tool` | string | Name of the tool to run. Mutually exclusive with `forEach` and `parallel` |
+| `args` | map | Arguments for the tool. Values may be any JSON type and support templating |
+| `condition` | object | Gate that decides whether the step runs. See [conditions](#workflow-condition) |
+| `forEach` | object | Run a body of sub-steps once per list item. See [forEach](#workflow-foreach) |
+| `parallel` | array | Run a group of sub-steps concurrently. Each resolves its arguments from the state before the group started; siblings can't reference each other |
+| `output` | boolean | Whether this step's result is included in the returned document. See [output flag](#workflow-output-flag) |
+| `store` | boolean | Deprecated alias for `output`. See [output flag](#workflow-output-flag) |
+| `allowFailure` | boolean | Continue to the next step on error. Defaults to `false` |
+| `description` | string | Human-readable documentation. Up to 500 characters |
+
+#### `forEach` {#workflow-foreach}
+
+A `forEach` step runs a flat body of sub-steps once per item. It can't nest another `forEach` or `parallel`.
+
+| Field | Type | Description |
+|---|---|---|
+| `items` | string | Required. Template that resolves to an array, for example `{{ .input.clusters }}` |
+| `as` | string | Loop variable name, available as `{{ .vars.<as> }}`. Defaults to `item` |
+| `steps` | array | Required, at least one. The sub-steps run for each item |
+
+Inside the loop, the current item is `{{ .vars.<as> }}` and its index is `{{ .vars.<as>_index }}`. A sub-step result is addressable per iteration as `{{ .results.<id>_<index> }}`; the plain `{{ .results.<id> }}` holds the last iteration's result.
+
+#### Sub-steps {#workflow-substep}
+
+The entries of `forEach.steps`, `parallel`, and `onFailure` are sub-steps. A sub-step is always a tool call, never a nested loop or group, which keeps the schema non-recursive. It takes `id` and `tool` (both required), plus the optional `args`, `condition`, `output`, `store` (deprecated), `allowFailure`, and `description` fields, with the same meaning as on a step.
+
+### Conditions {#workflow-condition}
+
+A condition selects its evaluation source with exactly one of `template`, `tool`, or `fromStep`. A `tool` or `fromStep` condition must declare `expect` or `expectNot`. Both rules are enforced at apply time and on the structured authoring path.
+
+| Field | Type | Description |
+|---|---|---|
+| `template` | string | Boolean Go-template gate. The step runs only when it renders to `true`, for example `{{ eq .input.env "production" }}`. When set, `expect`/`expectNot` are ignored |
+| `tool` | string | Tool to run for the check |
+| `args` | map | Arguments for the condition tool |
+| `fromStep` | string | Step ID whose result the check reads |
+| `expect` | object | Positive expectation. See [expectations](#workflow-condition-expect) |
+| `expectNot` | object | Negative expectation |
+
+#### Expectations {#workflow-condition-expect}
+
+| Field | Type | Description |
+|---|---|---|
+| `success` | boolean | Whether the tool call should succeed |
+| `jsonPath` | map | Path-to-value checks against the result |
+
+As of version `0.10.0`, `jsonPath` and `expectNot.jsonPath` use the same path navigator as step arguments and templates. Paths support array indexing such as `items[0].name`, and an optional full Go-template form that exposes the result as `.result`, for example `{{ (index .result.items 0).name }}`. Existing dotted paths keep working.
+
+### Output flag {#workflow-output-flag}
+
+As of version `0.10.0`, every step result is always referenceable by later steps as `{{ .results.<id>.<field> }}`, regardless of any flag. Chaining one value from a step into the next no longer forces that step's whole result into the response.
+
+The per-step `output` flag controls only whether a result appears in the returned document. `store` is a deprecated alias kept for backward compatibility: it affects visibility only, and a workflow that still uses it logs a one-line deprecation warning on both the structured authoring path and the reconciler. Prefer `output`.
+
+### Output projection {#workflow-output}
+
+`spec.output` is a templated object, rendered once after all steps complete, against `.input`, `.results`, and `.vars`. It replaces the default `{execution_id, workflow, status, input, steps[], ...}` envelope, so a workflow can return a small, shaped response. When omitted, the default envelope is returned unchanged.
+
+The projection preserves JSON types: a leaf's type comes from the value it evaluates to, not from how its rendered text looks.
+
+- A bare reference such as `{{ .results.pods.items }}` keeps its original JSON type, so an array stays an array.
+- A computed leaf keeps its result type, so `{{ len .results.events.items }}` is a number.
+- A leaf that mixes literal text with an action, such as `v{{ .version }}`, renders to a string.
+
+This preserves values whose form matters, such as versions or zero-padded IDs like `08`, without any coercion.
+
+When `spec.output` is declared, the per-step `output` and `store` flags no longer affect the returned document. Muster logs a one-line warning naming the now-inert flags.
+
+### `status` {#workflow-status}
+
+The reconciler validates the spec and reports `status.valid`, any `status.validationErrors`, the `status.referencedTools` (informational; actual availability depends on the user's session), the `status.stepCount`, and standard conditions.
+
+### Templating context {#workflow-templating}
+
+Step arguments and templates render with the [Sprig](https://masterminds.github.io/sprig/) function library. The available context:
+
+| Reference | Description |
+|---|---|
+| `{{ .input.<arg> }}` | A workflow argument |
+| `{{ .results.<id>.<field> }}` | A field from an earlier step's result, always available |
+| `{{ .vars.<name> }}` | A loop variable inside `forEach` |
+| `{{ .context.<x> }}` | Execution context values |
+
+The engine renders with `missingkey=error`, so a reference to a missing key fails the step rather than rendering empty.
+
+## Related
+
+- [Author a Muster workflow]({{< relref "/tutorials/ai-agents/authoring-workflows" >}}) - Write workflows step by step.
+- [Managing MCP servers]({{< relref "/tutorials/ai-agents/managing-mcp-servers" >}}) - Register and operate `MCPServer` resources.
+- [Meta-tools]({{< relref "/reference/muster/meta-tools" >}}) - The tools these resources expose to agents.

--- a/src/content/reference/muster/crds.md
+++ b/src/content/reference/muster/crds.md
@@ -97,7 +97,7 @@ All servers in a family must agree on `instanceArg`. When they diverge, Muster f
 | `scopes` | string | Scopes for the exchanged token. Defaults to `openid profile email groups` |
 | `clientCredentialsSecretRef` | object | Reference to a `Secret` with client credentials, when the remote Dex requires client authentication |
 
-`clientCredentialsSecretRef` takes `name`, optional `namespace` (defaults to the `MCPServer` namespace), `clientIdKey` (defaults to `client-id`), and `clientSecretKey` (defaults to `client-secret`). For a worked example, see [multi-cluster token exchange]({{< relref "/tutorials/ai-agents/multi-mc-token-exchange" >}}).
+`clientCredentialsSecretRef` takes `name`, optional `namespace` (defaults to the `MCPServer` namespace), `clientIdKey` (defaults to `client-id`), and `clientSecretKey` (defaults to `client-secret`). For a worked example, see [multi-cluster token exchange]({{< relref "/tutorials/ai-agents/self-hosting/multi-mc-token-exchange" >}}).
 
 #### Authorization server {#mcpserver-authz-server}
 

--- a/src/content/reference/muster/meta-tools.md
+++ b/src/content/reference/muster/meta-tools.md
@@ -1,0 +1,117 @@
+---
+linkTitle: Meta-tools
+title: Muster meta-tools reference
+description: Reference for the meta-tools Muster exposes to AI agents, the filter_tools discovery arguments and response shape, and the catalog of built-in tools.
+weight: 20
+menu:
+  principal:
+    parent: reference-muster
+    identifier: reference-muster-meta-tools
+owner:
+  - https://github.com/orgs/giantswarm/teams/team-bumblebee
+user_questions:
+  - What meta-tools does Muster expose?
+  - What arguments does filter_tools take?
+  - Which built-in core tools does Muster provide?
+last_review_date: 2026-06-21
+---
+
+Muster exposes a small, fixed set of meta-tools to an AI agent instead of the hundreds of underlying tools behind the gateway. The agent discovers what it needs on demand and pays context cost only for the tools it uses. For the concept and the reasoning, see [Meta-tools and tool discovery]({{< relref "/overview/ai-agents/meta-tools" >}}). This page is the field-level reference, verified against Muster `v0.10.0`.
+
+## The meta-tools {#meta-tools}
+
+Muster exposes 11 meta-tools:
+
+| Meta-tool | Purpose |
+|---|---|
+| `list_tools` | List all available tools from connected MCP servers |
+| `filter_tools` | Discover tools cheaply, with a bounded, summarized page |
+| `describe_tool` | Get the full description and input schema for one tool |
+| `call_tool` | Execute a tool by name with the given arguments |
+| `list_core_tools` | List Muster's built-in tools only |
+| `list_resources` | List all available MCP resources |
+| `describe_resource` | Get details about one MCP resource |
+| `get_resource` | Retrieve a resource's contents |
+| `list_prompts` | List all available MCP prompts |
+| `describe_prompt` | Get details about one MCP prompt |
+| `get_prompt` | Get a prompt with the given arguments |
+
+The agent sees only these meta-tools in its MCP configuration. It shortlists candidates with `filter_tools`, inspects the chosen one with `describe_tool`, and runs it with `call_tool`.
+
+## Discovering tools with `filter_tools` {#filter-tools}
+
+`filter_tools` is the discovery tier. It returns a bounded page of one-line summaries rather than every full description and schema, so the agent spends context only on plausible candidates.
+
+### Arguments {#filter-tools-args}
+
+| Argument | Type | Default | Description |
+|---|---|---|---|
+| `pattern` | string | | Glob match against tool names. Supports `*`. Case-insensitive unless `case_sensitive` is set |
+| `description_filter` | string | | Case-insensitive substring match against tool descriptions |
+| `query` | string | | Natural-language query. When set, matches are relevance-ranked with Okapi BM25 over each tool's name and summary, returned best-first with a `score`, and non-matches are dropped |
+| `labels` | object | | Label facets as `key=value` pairs. A tool must carry every requested label to match. Labels come from a workflow's `metadata.labels` |
+| `case_sensitive` | boolean | `false` | Whether pattern matching is case-sensitive |
+| `include_schema` | boolean | `false` | When `true`, each entry carries its full description and input schema instead of a one-line summary. This costs much more context |
+| `limit` | number | `5` | Maximum tools returned in this page. Raise it to page through more matches |
+| `offset` | number | `0` | Number of matching tools to skip before this page |
+
+### Response {#filter-tools-response}
+
+The response is a bounded summary page:
+
+```json
+{
+  "filters": { "...": "the filter arguments applied" },
+  "total": 12,
+  "truncated": true,
+  "tools": [
+    {
+      "name": "x_prometheus_query",
+      "summary": "Run a PromQL query against a managed cluster.",
+      "score": 4.21,
+      "labels": { "category": "observability" }
+    }
+  ],
+  "total_tools": 213,
+  "filtered_count": 5
+}
+```
+
+| Field | Description |
+|---|---|
+| `total` | Number of tools matching the filters across the whole catalog |
+| `truncated` | `true` when more matches exist beyond this page, the signal to page further or refine the query |
+| `tools` | The current page. Each entry has `name`, plus `summary` (or `description` when `include_schema` is set), `score` when ranked by a query, `labels` when present, and `inputSchema` when `include_schema` is `true` |
+| `total_tools` | The size of the full catalog. Retained for backward compatibility |
+| `filtered_count` | The current page size, equal to `len(tools)`. Deprecated: prefer `total` for the match count |
+
+`describe_tool` stays the authoritative source for a tool's full description and input schema. Use `filter_tools` to shortlist, then `describe_tool` on the chosen tool before you call it.
+
+## Tool naming {#naming}
+
+Every tool reachable through `call_tool` falls into one of three families, distinguished by prefix:
+
+- **`x_<server>_<tool>`**: a tool from an external MCP server, prefixed with the server name to avoid conflicts, for example `x_kubernetes_get_pods`.
+- **`core_<area>_<tool>`**: one of Muster's built-in tools.
+- **`workflow_<name>`**: a tool generated from a [`Workflow`]({{< relref "/reference/muster/crds" >}}#workflow) resource.
+
+When an `MCPServer` declares a `family`, its tools are exposed under the family name (`<prefix>_<family>_<tool>`) with a required argument that selects which instance handles the call. See [`MCPServer`]({{< relref "/reference/muster/crds" >}}#mcpserver).
+
+## Built-in tool catalog {#core-tools}
+
+Muster's `core_*` tools manage the resources it owns. List them at runtime with `list_core_tools`, or `muster list tool --filter 'core_*'`. The catalog as of `v0.10.0`:
+
+| Area | Tools |
+|---|---|
+| Authentication | `core_auth_login`, `core_auth_logout` |
+| Configuration | `core_config_get` |
+| MCP servers | `core_mcpserver_list`, `core_mcpserver_get`, `core_mcpserver_create`, `core_mcpserver_update`, `core_mcpserver_delete`, `core_mcpserver_validate` |
+| Services | `core_service_list`, `core_service_status`, `core_service_start`, `core_service_stop`, `core_service_restart` |
+| Workflows | `core_workflow_list`, `core_workflow_get`, `core_workflow_create`, `core_workflow_update`, `core_workflow_delete`, `core_workflow_validate`, `core_workflow_available`, `core_workflow_run`, `core_workflow_execution_list`, `core_workflow_execution_get` |
+| Events | `core_events` |
+
+## Related
+
+- [Meta-tools and tool discovery]({{< relref "/overview/ai-agents/meta-tools" >}}) - The concept and the token-cost rationale.
+- [Custom resources]({{< relref "/reference/muster/crds" >}}) - The `MCPServer` and `Workflow` schemas these tools manage.
+- [`muster call`]({{< relref "/reference/muster/cli/call" >}}) - Call any of these tools from the CLI.

--- a/src/content/tutorials/ai-agents/_index.md
+++ b/src/content/tutorials/ai-agents/_index.md
@@ -32,6 +32,6 @@ For the concepts behind everything here, see the [AI agents overview]({{< relref
 
 ## Operating the platform versus self-hosting
 
-The guides above are about **operating the platform**: authoring workflows, managing MCP servers, wiring multi-cluster access, mapping RBAC and SSO, and troubleshooting. They apply whether Muster is run for you on the managed Giant Swarm platform or you host it yourself.
+The guides in this section are about **operating the platform**: authoring workflows, managing MCP servers, wiring multi-cluster access, mapping RBAC and SSO, and troubleshooting. They apply whether Muster is run for you on the managed Giant Swarm platform or you host it yourself.
 
 If you also **run your own Muster**, the [self-hosting]({{< relref "/tutorials/ai-agents/self-hosting" >}}) subsection covers deploying the Helm charts, protecting the endpoint with OAuth, and bridging single sign-on across multiple management clusters. Those guides don't apply on the managed Giant Swarm platform, where Muster is already deployed and protected for you.

--- a/src/content/tutorials/ai-agents/_index.md
+++ b/src/content/tutorials/ai-agents/_index.md
@@ -23,6 +23,7 @@ For the concepts behind everything here, see the [AI agents overview]({{< relref
 ## In this section
 
 - [Author a workflow]({{< relref "/tutorials/ai-agents/authoring-workflows" >}}): package a multi-step operation as a single `workflow_<name>` tool, written the code-grounded way.
+- [Save tokens with workflows]({{< relref "/tutorials/ai-agents/saving-tokens-with-workflows" >}}): why one workflow call is dramatically cheaper than a raw-tool loop, with the measured numbers and the design rules that maximize the saving.
 - [Manage MCP servers]({{< relref "/tutorials/ai-agents/managing-mcp-servers" >}}): add and configure downstream servers with `MCPServer` resources.
 - [Connect custom MCP servers]({{< relref "/tutorials/ai-agents/connecting-custom-mcp-servers" >}}): bring third-party servers behind the gateway, including ones that don't publish standard discovery metadata.
 - [Give agents multi-cluster access]({{< relref "/tutorials/ai-agents/multi-cluster-access" >}}): expose a whole fleet through one central Muster.

--- a/src/content/tutorials/ai-agents/_index.md
+++ b/src/content/tutorials/ai-agents/_index.md
@@ -29,3 +29,9 @@ For the concepts behind everything here, see the [AI agents overview]({{< relref
 - [Give agents multi-cluster access]({{< relref "/tutorials/ai-agents/multi-cluster-access" >}}): expose a whole fleet through one central Muster.
 - [Map RBAC and SSO]({{< relref "/tutorials/ai-agents/access-control" >}}): connect identity-provider groups to cluster permissions.
 - [Troubleshoot agent access]({{< relref "/tutorials/ai-agents/troubleshooting" >}}): work through authentication loops, missing tools, and disconnected clusters.
+
+## Self-hosting and operations
+
+- [Deploy Muster]({{< relref "/tutorials/ai-agents/deploy-muster" >}}): install the CRD and application Helm charts and run the aggregator in custom-resource discovery mode.
+- [Set up OAuth]({{< relref "/tutorials/ai-agents/oauth-setup" >}}): protect the endpoint with Dex and configure the proxy that authenticates to downstream servers.
+- [Multi-cluster token exchange]({{< relref "/tutorials/ai-agents/multi-mc-token-exchange" >}}): bridge single sign-on to remote management clusters with RFC 8693.

--- a/src/content/tutorials/ai-agents/_index.md
+++ b/src/content/tutorials/ai-agents/_index.md
@@ -30,8 +30,8 @@ For the concepts behind everything here, see the [AI agents overview]({{< relref
 - [Map RBAC and SSO]({{< relref "/tutorials/ai-agents/access-control" >}}): connect identity-provider groups to cluster permissions.
 - [Troubleshoot agent access]({{< relref "/tutorials/ai-agents/troubleshooting" >}}): work through authentication loops, missing tools, and disconnected clusters.
 
-## Self-hosting and operations
+## Operating the platform versus self-hosting
 
-- [Deploy Muster]({{< relref "/tutorials/ai-agents/deploy-muster" >}}): install the CRD and application Helm charts and run the aggregator in custom-resource discovery mode.
-- [Set up OAuth]({{< relref "/tutorials/ai-agents/oauth-setup" >}}): protect the endpoint with Dex and configure the proxy that authenticates to downstream servers.
-- [Multi-cluster token exchange]({{< relref "/tutorials/ai-agents/multi-mc-token-exchange" >}}): bridge single sign-on to remote management clusters with RFC 8693.
+The guides above are about **operating the platform**: authoring workflows, managing MCP servers, wiring multi-cluster access, mapping RBAC and SSO, and troubleshooting. They apply whether Muster is run for you on the managed Giant Swarm platform or you host it yourself.
+
+If you also **run your own Muster**, the [self-hosting]({{< relref "/tutorials/ai-agents/self-hosting" >}}) subsection covers deploying the Helm charts, protecting the endpoint with OAuth, and bridging single sign-on across multiple management clusters. Those guides don't apply on the managed Giant Swarm platform, where Muster is already deployed and protected for you.

--- a/src/content/tutorials/ai-agents/_index.md
+++ b/src/content/tutorials/ai-agents/_index.md
@@ -1,0 +1,30 @@
+---
+title: AI agents and Muster
+linkTitle: AI agents
+description: How-to guides for platform teams operating Muster, authoring workflows, managing MCP servers, and wiring multi-cluster access, RBAC, and single sign-on.
+weight: 60
+menu:
+  principal:
+    parent: tutorials
+    identifier: tutorials-ai-agents
+owner:
+  - https://github.com/orgs/giantswarm/teams/team-bumblebee
+last_review_date: 2026-06-20
+user_questions:
+  - How do I author a Muster workflow?
+  - How do I add an MCP server to Muster?
+  - How do I give AI agents access to multiple clusters?
+---
+
+These guides are for platform teams and power users who operate Muster, rather than for people who just want to ask their AI assistant a question. If you only need to connect your IDE or the developer portal chat, start with [Set up your AI agent]({{< relref "/getting-started/ai-agent-setup" >}}) instead.
+
+For the concepts behind everything here, see the [AI agents overview]({{< relref "/overview/ai-agents" >}}): what Muster is, how the [aggregator]({{< relref "/overview/ai-agents/architecture" >}}) works, the [meta-tools]({{< relref "/overview/ai-agents/meta-tools" >}}) agents actually see, and the [security model]({{< relref "/overview/ai-agents/security" >}}).
+
+## In this section
+
+- [Author a workflow]({{< relref "/tutorials/ai-agents/authoring-workflows" >}}): package a multi-step operation as a single `workflow_<name>` tool, written the code-grounded way.
+- [Manage MCP servers]({{< relref "/tutorials/ai-agents/managing-mcp-servers" >}}): add and configure downstream servers with `MCPServer` resources.
+- [Connect custom MCP servers]({{< relref "/tutorials/ai-agents/connecting-custom-mcp-servers" >}}): bring third-party servers behind the gateway, including ones that don't publish standard discovery metadata.
+- [Give agents multi-cluster access]({{< relref "/tutorials/ai-agents/multi-cluster-access" >}}): expose a whole fleet through one central Muster.
+- [Map RBAC and SSO]({{< relref "/tutorials/ai-agents/access-control" >}}): connect identity-provider groups to cluster permissions.
+- [Troubleshoot agent access]({{< relref "/tutorials/ai-agents/troubleshooting" >}}): work through authentication loops, missing tools, and disconnected clusters.

--- a/src/content/tutorials/ai-agents/access-control/index.md
+++ b/src/content/tutorials/ai-agents/access-control/index.md
@@ -1,0 +1,94 @@
+---
+title: Map RBAC and single sign-on
+linkTitle: RBAC and SSO
+description: Connect identity-provider groups to Kubernetes RBAC so AI agents act with each user's own permissions, and handle large tokens and group limits.
+weight: 50
+menu:
+  principal:
+    parent: tutorials-ai-agents
+    identifier: tutorials-ai-agents-access-control
+owner:
+  - https://github.com/orgs/giantswarm/teams/team-bumblebee
+last_review_date: 2026-06-20
+user_questions:
+  - How do AI agents inherit my cluster permissions?
+  - Why does my agent get a forbidden error from a cluster?
+  - Why do users with many groups fail to authenticate?
+---
+
+An AI agent acting through Muster has exactly the permissions of the person driving it—no more. Authorization isn't something Muster grants; it flows from the user's identity-provider groups through to each cluster's Kubernetes RBAC. This guide explains how that chain works and how to keep it healthy.
+
+## The permission chain
+
+Three layers combine to decide what an agent can do:
+
+1. **Identity provider:** the user authenticates through enterprise single sign-on. Their token carries group claims.
+2. **Muster:** keys all per-user state on the OAuth `sub` (subject) claim and forwards or exchanges the user's token to each downstream server. Muster never widens access—it can't let an agent do something the user's token doesn't permit.
+3. **Kubernetes RBAC:** each cluster binds identity-provider groups to roles. A tool call the user isn't permitted to make is rejected by the cluster itself.
+
+Because Muster keys visibility on identity, each user only sees tools from servers they've personally authenticated with. This is **per-user tool visibility**: a cluster a user can't reach simply doesn't appear in their tool list. See the [security model]({{< relref "/overview/ai-agents/security" >}}) for the mechanics.
+
+## Bind identity-provider groups to cluster roles
+
+For an agent to do anything useful on a cluster, the user's groups must be bound to a Kubernetes role there. This is standard OIDC RBAC: a `ClusterRoleBinding` (or `RoleBinding`) whose subject is the group from the identity provider.
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: platform-team-view
+subjects:
+  - kind: Group
+    name: "platform-team"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: view
+  apiGroup: rbac.authorization.k8s.io
+```
+
+Manage these bindings through your usual GitOps pipeline, the same as any other cluster RBAC. The group name must match exactly what the identity provider puts in the token.
+
+## Forward or exchange the token
+
+Muster needs the user's token to reach a downstream server in a form the cluster's OIDC accepts:
+
+- **Token forwarding** (`auth.forwardToken: true`): reuse the user's token where the downstream server trusts the same issuer. For Kubernetes OIDC, add the audience the cluster expects with `requiredAudiences` so the forwarded token is accepted:
+
+```yaml
+spec:
+  auth:
+    type: oauth
+    forwardToken: true
+    requiredAudiences:
+      - "dex-k8s-authenticator"
+```
+
+- **Token exchange** (`auth.tokenExchange`): for remote clusters with their own identity provider, exchange the central token for one the remote provider issues. See [multi-cluster access]({{< relref "/tutorials/ai-agents/multi-cluster-access" >}}#cross-cluster-single-sign-on-with-token-exchange).
+
+## When an agent hits a forbidden error
+
+A message like this in the agent output means RBAC, not a Muster bug:
+
+```text
+networkpolicies.networking.k8s.io is forbidden: User "<user>" cannot list
+resource "networkpolicies" in API group "networking.k8s.io" in the namespace
+"kube-system"
+```
+
+The user authenticated fine, but their groups aren't bound to a role that allows the action. Fix it by binding the right identity-provider group to an appropriate role on that cluster. The agent picks up the new permission on its next call—no reconnect needed.
+
+## Large tokens {#large-tokens}
+
+Enterprise tokens that carry many group claims can break two limits:
+
+- **Ingress header buffers.** A token with many groups can exceed the default nginx header buffer, and the request is rejected before it reaches the server. Raise `large_client_header_buffers` on the `mcp-kubernetes` ingress to accept large tokens.
+- **Group count.** Users in a very large number of groups were once rejected outright. The OAuth layer now truncates excessive groups to a configurable limit instead of rejecting the request, so heavily-grouped users can still authenticate. If a user belongs to more groups than the limit, make sure the groups that matter for cluster RBAC are within it.
+
+If a user can authenticate from a small account but fails from a heavily-grouped one, suspect these limits first.
+
+## Related
+
+- [Security model]({{< relref "/overview/ai-agents/security" >}}): per-user visibility, token forwarding, and exchange.
+- [Multi-cluster access]({{< relref "/tutorials/ai-agents/multi-cluster-access" >}}): cross-cluster single sign-on.
+- [Troubleshooting]({{< relref "/tutorials/ai-agents/troubleshooting" >}}): authentication loops and missing tools.

--- a/src/content/tutorials/ai-agents/access-control/index.md
+++ b/src/content/tutorials/ai-agents/access-control/index.md
@@ -16,7 +16,7 @@ user_questions:
   - Why do users with many groups fail to authenticate?
 ---
 
-An AI agent acting through Muster has exactly the permissions of the person driving it—no more. Authorization isn't something Muster grants; it flows from the user's identity-provider groups through to each cluster's Kubernetes RBAC. This guide explains how that chain works and how to keep it healthy.
+An AI agent acting through Muster has exactly the permissions of the person driving it—no more. Authorization isn't something Muster grants. It flows from the user's identity-provider groups through to each cluster's Kubernetes RBAC. This guide explains how that chain works and how to keep it healthy.
 
 ## The permission chain
 
@@ -83,9 +83,9 @@ The user authenticated fine, but their groups aren't bound to a role that allows
 Enterprise tokens that carry many group claims can break two limits:
 
 - **Ingress header buffers.** A token with many groups can exceed the default nginx header buffer, and the request is rejected before it reaches the server. Raise `large_client_header_buffers` on the `mcp-kubernetes` ingress to accept large tokens.
-- **Group count.** Users in a very large number of groups were once rejected outright. The OAuth layer now truncates excessive groups to a configurable limit instead of rejecting the request, so heavily-grouped users can still authenticate. If a user belongs to more groups than the limit, make sure the groups that matter for cluster RBAC are within it.
+- **Group count.** Users in a very large number of groups were once rejected outright. The OAuth layer now truncates excessive groups to a configurable limit instead of rejecting the request, so users in many groups can still authenticate. If a user belongs to more groups than the limit, make sure the groups that matter for cluster RBAC are within it.
 
-If a user can authenticate from a small account but fails from a heavily-grouped one, suspect these limits first.
+If a user can authenticate from a small account but fails from one that belongs to many groups, suspect these limits first.
 
 ## Related
 

--- a/src/content/tutorials/ai-agents/authoring-workflows/index.md
+++ b/src/content/tutorials/ai-agents/authoring-workflows/index.md
@@ -1,0 +1,282 @@
+---
+title: Author a Muster workflow
+linkTitle: Author a workflow
+description: Write a Muster Workflow resource that packages a multi-step operation into one named tool an AI agent can discover and call, grounded in the fields the engine actually implements.
+weight: 10
+menu:
+  principal:
+    parent: tutorials-ai-agents
+    identifier: tutorials-ai-agents-authoring-workflows
+owner:
+  - https://github.com/orgs/giantswarm/teams/team-bumblebee
+last_review_date: 2026-06-20
+user_questions:
+  - How do I author a Muster workflow?
+  - What fields does a Muster Workflow support?
+  - Why doesn't my AI agent find my workflow?
+  - How do I keep a workflow's token cost low?
+---
+
+A workflow packages a multi-step operation into a single named tool. You write it as a `Workflow` custom resource; Muster registers it as a `workflow_<name>` tool that an agent discovers and calls with one request. Muster runs the steps server-side and returns one shaped result. That's the whole value: it collapses what would otherwise be many agent round-trips—each one paying prompt tokens both ways—into a single call. A paired trial measured roughly a 10x reduction in cache-read tokens when an agent used a workflow instead of the raw tools; see [why workflows cut agent cost]({{< relref "/overview/ai-agents/architecture" >}}#workflows-cut-agent-token-cost).
+
+This guide documents what the engine implements. Author against these fields and your workflow behaves predictably.
+
+## The execution model
+
+A workflow is an ordered list of steps that Muster runs server-side, returning one condensed JSON document. Top-level steps run **sequentially**, but a step isn't always a single tool call: each top-level step is exactly one of a plain `tool` call, a `forEach` loop, or a `parallel` group. A workflow-level `onFailure` block can run best-effort cleanup when a step fails. Design every workflow around one fact: it collapses many agent round-trips into a single call, and its response cost is the sum over everything it runs.
+
+> Control flow (`forEach`, `parallel`, `onFailure`, and template conditions) requires Muster 0.8.0 or later. Plain sequential `tool` steps work on every version.
+
+## A complete example
+
+This read-only workflow lists not-running pods and crash-loop events on a management cluster, then returns both as one digest:
+
+```yaml
+apiVersion: muster.giantswarm.io/v1alpha1
+kind: Workflow
+metadata:
+  name: pod-health
+  namespace: muster
+spec:
+  description: >-
+    Pod health digest for a management cluster. Answers "check the pods in
+    <mc>" and "are any pods failing on <mc>?". Lists not-running pods and
+    BackOff events in one pass. Stop when the result is empty: no not-running
+    pods and no BackOff events means the cluster is healthy, so write a
+    one-line "all pods healthy" summary and stop. If a pod is crash-looping,
+    you may make one follow-up call to read its logs with tailLines 30.
+  args:
+    management_cluster:
+      type: string
+      required: true
+      description: The full MCP server name, for example my-cluster-mcp-kubernetes.
+  steps:
+    - id: not_running
+      tool: x_kubernetes_list
+      args:
+        management_cluster: "{{ .input.management_cluster }}"
+        resourceType: pods
+        allNamespaces: true
+        fieldSelector: "status.phase!=Running"
+        output: slim
+        limit: 25
+      store: true
+    - id: backoff_events
+      tool: x_kubernetes_list
+      args:
+        management_cluster: "{{ .input.management_cluster }}"
+        resourceType: events
+        allNamespaces: true
+        fieldSelector: "reason=BackOff"
+        fullOutput: true
+        limit: 10
+      store: true
+      allowFailure: true
+```
+
+The sections below explain why each field is there.
+
+## The fields that matter
+
+### `spec.description` is the only text the agent sees
+
+When an agent lists tools, the **only** workflow text it gets is `spec.description` (maximum 1000 characters). The step-level `description` fields are stored on the resource but never reach the agent, so a directive placed there silently does nothing. Put everything you want the agent to know in `spec.description`.
+
+Three blocks belong in most descriptions:
+
+- A **stop-when-healthy rule**: the explicit conditions that mean no follow-up is needed, plus a directive to write a one-line summary and stop. Without it, an agent treats a clean result as an invitation to keep exploring, and cost balloons.
+- A **pinned follow-up rule**: the one extra call the agent may make (for example, reading logs with `tailLines: 30`), so it drills the right thing instead of improvising.
+- An **event-noise hint**: which objects are relevant, so the agent ignores unrelated events.
+
+### The description also controls discoverability
+
+An agent finds a workflow through the `filter_tools` meta-tool, whose description filter is a **case-insensitive substring match** over `spec.description`. There's no stemming, ranking, or synonym matching. So the description must literally contain the terms an agent searches by.
+
+A workflow described only as `"check the pods in <mc>"` is invisible to a search for `"pod health"`, because that phrase isn't a substring of the description—and the agent silently falls back to raw tools. Lead the description with **both** the topic keyword (`pod health`, `cluster health`, `failing pods`) **and** the natural question phrasing. The 1000-character budget is large enough for both.
+
+### `args` define and validate the inputs
+
+Each entry in `spec.args` is typed (`string`, `integer`, `boolean`, `number`, `object`, or `array`), can be `required`, and can carry a `default` and a `description`. Muster validates and defaults the inputs before the first step runs. A missing required argument fails execution immediately. Extra arguments that aren't in the schema are tolerated.
+
+### `store: true` is load-bearing
+
+Without `store: true`, a step still runs, but Muster emits only `{id, tool, status}` for it—the actual data is discarded before the agent sees the response. Set `store: true` on every step whose data the agent must read. Only the last step's result is merged into the top level automatically if it isn't stored. When in doubt, store it.
+
+### `allowFailure: true` for legitimately optional steps
+
+By default, a single step error fails the whole workflow and flips its result to an error, which sends the agent chasing the failure with expensive discovery calls. Set `allowFailure: true` on steps that may legitimately fail or return nothing: a resource type not every cluster uses, an optional backend such as the metrics server (`x_prometheus_*`), or a list that depends on RBAC that might be scoped differently. In the example above, the events list is marked optional so a cluster without recent crash-loop events still returns a clean digest.
+
+A workflow can mix servers in one digest, for example correlating Kubernetes state with an `x_prometheus_query` step, so a single call returns both the failing pods and the matching metrics. Mark the metrics step `allowFailure: true` so a cluster without `mcp-prometheus` deployed still returns the Kubernetes half.
+
+## Control flow
+
+Beyond plain `tool` steps, a top-level step can be a loop or a concurrent group, and the workflow can declare cleanup. These need Muster 0.8.0 or later. A step sets **exactly one** of `tool`, `forEach`, or `parallel`; setting none or more than one is rejected at apply time.
+
+### `forEach` loops
+
+`forEach` runs a flat body of sub-steps once per item of a list, sequentially. Use it instead of hand-copying the same step per element:
+
+```yaml
+- id: per_cluster
+  forEach:
+    items: "{{ .input.clusters }}"   # must resolve to an array
+    as: cluster                       # the item is {{ .vars.cluster }}
+    steps:
+      - id: status
+        tool: x_kubernetes_list
+        args:
+          management_cluster: "{{ .vars.cluster }}"
+          resourceType: pods
+          output: slim
+          limit: 25
+        store: true
+```
+
+- `items` must be a reference that resolves to an array. A scalar, or a string built from a richer template, is rejected at runtime.
+- The current item is bound to `{{ .vars.<as> }}` (default `item`) and its zero-based index to `{{ .vars.<as>_index }}`.
+- After the loop, `{{ .results.<subStepID> }}` holds the last iteration's result; every iteration stays addressable as `{{ .results.<subStepID>_<index> }}`, for example `status_0` and `status_1`.
+- `allowFailure: true` on the `forEach` step tolerates a failing iteration.
+
+A loop multiplies cost: the per-step budget caps below apply to **every** iteration, so a loop over a large list is the easiest way to blow the token budget.
+
+### `parallel` groups
+
+`parallel` runs its sub-steps concurrently and joins before the next top-level step, so total latency is the **max** over the group rather than the sum. It's the right tool for fanning out independent reads:
+
+```yaml
+- id: fan_out
+  parallel:
+    - id: nodes
+      tool: x_kubernetes_list
+      args: { management_cluster: "{{ .input.management_cluster }}", resourceType: nodes, output: slim }
+      store: true
+    - id: events
+      tool: x_kubernetes_list
+      args: { management_cluster: "{{ .input.management_cluster }}", resourceType: events, fullOutput: true, limit: 10 }
+      store: true
+```
+
+- Each sub-step sees a snapshot of the results as they were **before** the group started, so siblings can't read each other's output. A sub-step that needs another sub-step's result must be a later top-level step.
+- Stored sub-step results merge back into the workflow after the join, so later steps see them normally.
+- Only latency is parallelized; response **size** is still the sum, so the per-step caps still apply.
+
+### `onFailure` cleanup
+
+A workflow-level `onFailure` block lists sub-steps that run best-effort when the workflow fails on a step that doesn't allow failure. Each handler can read `{{ .results.<id> }}` from any step that stored a result before the failure, so a rollback can reference what it must undo:
+
+```yaml
+spec:
+  steps:
+    - id: backup
+      tool: postgres_backup
+      store: true
+    - id: migrate
+      tool: postgres_migrate
+  onFailure:
+    - id: restore
+      tool: postgres_restore
+      args:
+        backup_name: "{{ .results.backup.backup_name }}"
+```
+
+`onFailure` is workflow-level only; there's no per-step failure handler. For read-only health digests you rarely need it; `allowFailure` already covers the case where a resource might not exist. It earns its place in imperative pipelines such as deploy, migrate, and rollback.
+
+## Templating
+
+Step arguments are Go templates resolved server-side per step. Rendering uses `missingkey=error`, so referencing an undefined key **fails the step** rather than rendering an empty string. Four roots are in scope:
+
+- `{{ .input.<arg> }}`: a workflow argument. It's always `.input.<arg>`, never a bare `{{ .<arg> }}`. The bare form fails with a missing-key error.
+- `{{ .results.<stepID>.<field> }}`: a field from a prior step that set `store: true`. Nested map navigation works.
+- `{{ .vars.<name> }}`: a `forEach` loop variable: the loop item `{{ .vars.<as> }}` and its index `{{ .vars.<as>_index }}`. There's no other way to set `.vars`.
+- `{{ .context.<x> }}`: an alias for `.results`.
+
+A template that's a **single bare access** (`{{ .input.port }}`) preserves the original type, so an integer stays an integer. Any richer template—string concatenation such as `"{{ .input.host }}:{{ .input.port }}"`, or one using a [sprig](https://masterminds.github.io/sprig/) function—renders to a string. Keep that in mind for tools that type-check their arguments. The full sprig function set is available.
+
+## Conditions
+
+A step can carry an optional `condition` that skips it (status `skipped`, not failed) when the condition is false. A condition selects its source with **exactly one** of `template`, `tool`, or `fromStep`.
+
+The cheapest form is a boolean Go-template gate, evaluated in-process with no tool call. It's also the only way to express compound logic, since there are no `and`/`or` operators—write the boolean expression with sprig functions:
+
+```yaml
+- id: prod_only
+  tool: x_security_run_checks
+  args:
+    management_cluster: "{{ .input.management_cluster }}"
+  condition:
+    template: '{{ eq .input.env "production" }}'
+```
+
+Alternatively, run a tool or reference a prior stored step and test the outcome. A `tool` or `fromStep` condition must declare `expect` or `expectNot`:
+
+```yaml
+- id: production_only
+  tool: x_security_run_checks
+  args:
+    management_cluster: "{{ .input.management_cluster }}"
+  condition:
+    fromStep: detect_environment
+    expect:
+      jsonPath:
+        "type": "production"
+```
+
+The `jsonPath` is a **simple dotted path** over the result object: `data.field` works, but array indexing such as `items[0].name` doesn't. For the read-only health digests that AI agents call most, conditions are rarely needed; prefer `allowFailure` for the case where a resource might not exist.
+
+## Budget for cost
+
+Total response size is the **sum** over everything the workflow runs, including each `forEach` iteration and every `parallel` sub-step, so an unbounded step is what eventually produces a multi-million-token outlier even when the typical run is small. Latency is the sum for sequential steps but the max within a `parallel` group. Cap every list, get, and log step:
+
+- Set `limit:` on every list. Ten events is plenty; more just feeds noise.
+- Set `tailLines: 30` on any log fetch. The default is 100 and the maximum is 1000—enough to blow the prompt window on a healthy system.
+- Set `output: slim` on lists to strip verbose fields.
+
+## Know the `mcp-kubernetes` output knobs
+
+These bite every workflow that reads Kubernetes:
+
+- `output:` and `fullOutput:` are independent. `output:` strips verbose fields; `fullOutput:` switches off the per-kind summary. For **events** you must set `fullOutput: true`, otherwise `reason`, `message`, `type`, and `count` are dropped.
+- On older `mcp-kubernetes` (before `v0.1.86`), `output:` and `fullOutput:` are **list-only**. A single `output:` on a get-style call there flips the whole workflow to an error. From `v0.1.86` onward, `output:` is accepted on read tools too.
+- `fieldSelector: reason=BackOff` on events is the **authoritative** crash-loop signal. Filtering on `status.phase!=Running` misses it, and a summary view reports crash-loopers as `Running`. Never gate pod health on phase or summary alone.
+
+## What the engine doesn't support
+
+These look plausible but are rejected at apply time or silently ignored. Avoid them:
+
+| Looks plausible | Reality |
+|---|---|
+| `{{ .<arg> }}` | Always `{{ .input.<arg> }}`; the bare form fails. |
+| `outputs:` on a step | Removed from the schema; use `store: true`. |
+| `spec.name`, custom annotations to steer the agent | Not part of the schema; pruned or ignored. |
+| Directives on a step's `description` | Never reach the agent; move them to `spec.description`. |
+| `and`/`or` in a condition | One source per condition; compose logic in a `template`. |
+| `forEach` or `parallel` nested inside a sub-step | Sub-steps are plain tool calls only; control flow doesn't nest. |
+| `parallel` siblings reading each other's results | Each sibling sees a pre-group snapshot; sequence them as top-level steps instead. |
+| Per-step `onFailure` | `onFailure` is workflow-level only. |
+
+## Apply and iterate
+
+Iterate live, then promote to your GitOps pipeline:
+
+1. Apply the resource directly while you're shaping it. Muster's reconciler reloads it within seconds, with no restart of the agent or the consuming app:
+
+   ```bash
+   kubectl apply -f pod-health.yaml
+   ```
+
+2. Confirm it's valid and see the tools it references:
+
+   ```bash
+   kubectl get workflow pod-health -o yaml
+   ```
+
+   The `status.valid` field and any `status.validationErrors` tell you whether the spec passed structural validation.
+
+3. Verify the **raw** workflow output over a direct Muster session before spending agent tokens. Because agent runs vary, run a scenario several times and compare.
+4. Once the YAML is validated, fold it into the GitOps repository that manages your clusters so it ships the same way as the rest of your platform configuration.
+
+## Related
+
+- [Manage MCP servers]({{< relref "/tutorials/ai-agents/managing-mcp-servers" >}}): the servers whose tools your workflow steps call.
+- [Meta-tools and discovery]({{< relref "/overview/ai-agents/meta-tools" >}}): how an agent finds and invokes a `workflow_<name>` tool.
+- [Troubleshooting]({{< relref "/tutorials/ai-agents/troubleshooting" >}}): when a workflow runs but the agent never picks it.

--- a/src/content/tutorials/ai-agents/authoring-workflows/index.md
+++ b/src/content/tutorials/ai-agents/authoring-workflows/index.md
@@ -17,9 +17,9 @@ user_questions:
   - How do I keep a workflow's token cost low?
 ---
 
-A workflow packages a multi-step operation into a single named tool. You write it as a `Workflow` custom resource; Muster registers it as a `workflow_<name>` tool that an agent discovers and calls with one request. Muster runs the steps server-side and returns one shaped result. That's the whole value: it collapses what would otherwise be many agent round-trips—each one paying prompt tokens both ways—into a single call. A paired trial measured roughly a 10x reduction in cache-read tokens when an agent used a workflow instead of the raw tools; see [why workflows cut agent cost]({{< relref "/overview/ai-agents/architecture" >}}#workflows-cut-agent-token-cost).
+A workflow packages a multi-step operation into a single named tool. You write it as a `Workflow` custom resource, and Muster registers it as a `workflow_<name>` tool that an agent discovers and calls with one request. Muster runs the steps server-side and returns one shaped result. That's the whole value: it collapses what would otherwise be many agent round-trips, each paying prompt tokens both ways, into a single call. A paired trial measured a 10x reduction in cache-read tokens when an agent used a workflow instead of the raw tools. See [why workflows cut agent cost]({{< relref "/overview/ai-agents/architecture" >}}#workflows-cut-agent-token-cost).
 
-This guide documents what the engine implements. Author against these fields and your workflow behaves predictably.
+This guide documents what the engine implements. Write against these fields and your workflow behaves predictably.
 
 ## The execution model
 
@@ -80,7 +80,7 @@ The sections below explain why each field is there.
 
 ### `spec.description` is the only text the agent sees
 
-When an agent lists tools, the **only** workflow text it gets is `spec.description` (maximum 1000 characters). The step-level `description` fields are stored on the resource but never reach the agent, so a directive placed there silently does nothing. Put everything you want the agent to know in `spec.description`.
+When an agent lists tools, the **only** workflow text it gets is `spec.description` (maximum 1000 characters). The step-level `description` fields are stored on the resource but never reach the agent, so a directive placed there does nothing. Put everything you want the agent to know in `spec.description`.
 
 Three blocks belong in most descriptions:
 
@@ -92,7 +92,7 @@ Three blocks belong in most descriptions:
 
 An agent finds a workflow through the `filter_tools` meta-tool, whose description filter is a **case-insensitive substring match** over `spec.description`. There's no stemming, ranking, or synonym matching. So the description must literally contain the terms an agent searches by.
 
-A workflow described only as `"check the pods in <mc>"` is invisible to a search for `"pod health"`, because that phrase isn't a substring of the description—and the agent silently falls back to raw tools. Lead the description with **both** the topic keyword (`pod health`, `cluster health`, `failing pods`) **and** the natural question phrasing. The 1000-character budget is large enough for both.
+A workflow described only as `"check the pods in <mc>"` is invisible to a search for `"pod health"`, because that phrase isn't a substring of the description, and the agent falls back to raw tools. Lead the description with **both** the topic keyword (`pod health`, `cluster health`, `failing pods`) **and** the natural question phrasing. The 1000-character budget is large enough for both.
 
 ### `args` define and validate the inputs
 
@@ -104,13 +104,13 @@ Without `store: true`, a step still runs, but Muster emits only `{id, tool, stat
 
 ### `allowFailure: true` for legitimately optional steps
 
-By default, a single step error fails the whole workflow and flips its result to an error, which sends the agent chasing the failure with expensive discovery calls. Set `allowFailure: true` on steps that may legitimately fail or return nothing: a resource type not every cluster uses, an optional backend such as the metrics server (`x_prometheus_*`), or a list that depends on RBAC that might be scoped differently. In the example above, the events list is marked optional so a cluster without recent crash-loop events still returns a clean digest.
+By default, a single step error fails the whole workflow and flips its result to an error, which sends the agent chasing the failure with expensive discovery calls. Set `allowFailure: true` on steps that may legitimately fail or return nothing: a resource type not every cluster uses, an optional backend such as the metrics server (`x_prometheus_*`), or a list that depends on RBAC that might be scoped differently. In the earlier example, the events list is marked optional so a cluster without recent crash-loop events still returns a clean digest.
 
 A workflow can mix servers in one digest, for example correlating Kubernetes state with an `x_prometheus_query` step, so a single call returns both the failing pods and the matching metrics. Mark the metrics step `allowFailure: true` so a cluster without `mcp-prometheus` deployed still returns the Kubernetes half.
 
 ## Control flow
 
-Beyond plain `tool` steps, a top-level step can be a loop or a concurrent group, and the workflow can declare cleanup. These need Muster 0.8.0 or later. A step sets **exactly one** of `tool`, `forEach`, or `parallel`; setting none or more than one is rejected at apply time.
+Beyond plain `tool` steps, a top-level step can be a loop or a concurrent group, and the workflow can declare cleanup. These need Muster 0.8.0 or later. A step sets **exactly one** of `tool`, `forEach`, or `parallel`. Setting none or more than one is rejected at apply time.
 
 ### `forEach` loops
 
@@ -162,7 +162,7 @@ A loop multiplies cost: the per-step budget caps below apply to **every** iterat
 
 ### `onFailure` cleanup
 
-A workflow-level `onFailure` block lists sub-steps that run best-effort when the workflow fails on a step that doesn't allow failure. Each handler can read `{{ .results.<id> }}` from any step that stored a result before the failure, so a rollback can reference what it must undo:
+A workflow-level `onFailure` block lists sub-steps that run best-effort when the workflow fails on a step that isn't marked `allowFailure`. Each handler can read `{{ .results.<id> }}` from any step that stored a result before the failure, so a rollback can reference what it must undo:
 
 ```yaml
 spec:
@@ -179,7 +179,7 @@ spec:
         backup_name: "{{ .results.backup.backup_name }}"
 ```
 
-`onFailure` is workflow-level only; there's no per-step failure handler. For read-only health digests you rarely need it; `allowFailure` already covers the case where a resource might not exist. It earns its place in imperative pipelines such as deploy, migrate, and rollback.
+`onFailure` is workflow-level only. There's no per-step failure handler. For read-only health digests you seldom need it, and `allowFailure` already covers the case where a resource might not exist. It earns its place in imperative pipelines such as deploy, migrate, and rollback.
 
 ## Templating
 
@@ -188,7 +188,7 @@ Step arguments are Go templates resolved server-side per step. Rendering uses `m
 - `{{ .input.<arg> }}`: a workflow argument. It's always `.input.<arg>`, never a bare `{{ .<arg> }}`. The bare form fails with a missing-key error.
 - `{{ .results.<stepID>.<field> }}`: a field from a prior step that set `store: true`. Nested map navigation works.
 - `{{ .vars.<name> }}`: a `forEach` loop variable: the loop item `{{ .vars.<as> }}` and its index `{{ .vars.<as>_index }}`. There's no other way to set `.vars`.
-- `{{ .context.<x> }}`: an alias for `.results`.
+- `{{ .context.<x> }}`: another name for `.results`.
 
 A template that's a **single bare access** (`{{ .input.port }}`) preserves the original type, so an integer stays an integer. Any richer template—string concatenation such as `"{{ .input.host }}:{{ .input.port }}"`, or one using a [sprig](https://masterminds.github.io/sprig/) function—renders to a string. Keep that in mind for tools that type-check their arguments. The full sprig function set is available.
 
@@ -221,7 +221,7 @@ Alternatively, run a tool or reference a prior stored step and test the outcome.
         "type": "production"
 ```
 
-The `jsonPath` is a **simple dotted path** over the result object: `data.field` works, but array indexing such as `items[0].name` doesn't. For the read-only health digests that AI agents call most, conditions are rarely needed; prefer `allowFailure` for the case where a resource might not exist.
+The `jsonPath` is a **simple dotted path** over the result object: `data.field` works, but array indexing such as `items[0].name` doesn't. For the read-only health digests that AI agents call most, conditions are seldom needed. Prefer `allowFailure` for the case where a resource might not exist.
 
 ## Budget for cost
 
@@ -241,7 +241,7 @@ These bite every workflow that reads Kubernetes:
 
 ## What the engine doesn't support
 
-These look plausible but are rejected at apply time or silently ignored. Avoid them:
+These look plausible but are rejected at apply time or ignored. Avoid them:
 
 | Looks plausible | Reality |
 |---|---|

--- a/src/content/tutorials/ai-agents/authoring-workflows/index.md
+++ b/src/content/tutorials/ai-agents/authoring-workflows/index.md
@@ -23,7 +23,9 @@ This guide documents what the engine implements. Write against these fields and 
 
 ## The execution model
 
-A workflow is an ordered list of steps that Muster runs server-side, returning one condensed JSON document. Top-level steps run **sequentially**, but a step isn't always a single tool call. Each top-level step is exactly one of a plain `tool` call, a `forEach` loop, or a `parallel` group. A workflow-level `onFailure` block can run best-effort cleanup when a step fails. Design every workflow around one fact: it collapses many agent round-trips into a single call, and its response cost is the sum over everything it runs.
+A workflow is an ordered list of steps that Muster runs server-side, returning one JSON document. Top-level steps run **sequentially**, but a step isn't always a single tool call. Each top-level step is exactly one of a plain `tool` call, a `forEach` loop, or a `parallel` group. A workflow-level `onFailure` block can run best-effort cleanup when a step fails. Design every workflow around one fact: it collapses many agent round-trips into a single call, and its response cost is the sum over everything it returns.
+
+Every step's result is **always** available to later steps and the response projection through `{{ .results.<id>.<field> }}`. That holds regardless of any flag. You separately control what the *agent* sees back. The per-step `output` flag picks which step results land in the returned document. The workflow-level `spec.output` projection replaces that document with a shape you define.
 
 > Control flow (`forEach`, `parallel`, `onFailure`, and template conditions) requires Muster 0.8.0 or later. Plain sequential `tool` steps work on every version.
 
@@ -60,7 +62,7 @@ spec:
         fieldSelector: "status.phase!=Running"
         output: slim
         limit: 25
-      store: true
+      output: true
     - id: backoff_events
       tool: x_kubernetes_list
       args:
@@ -70,7 +72,7 @@ spec:
         fieldSelector: "reason=BackOff"
         fullOutput: true
         limit: 10
-      store: true
+      output: true
       allowFailure: true
 ```
 
@@ -98,9 +100,37 @@ A workflow described only as `"check the pods in <mc>"` is invisible to a search
 
 Each entry in `spec.args` is typed (`string`, `integer`, `boolean`, `number`, `object`, or `array`), can be `required`, and can carry a `default` and a `description`. Muster validates and defaults the inputs before the first step runs. A missing required argument fails execution immediately. Extra arguments that aren't in the schema are tolerated.
 
-### `store: true` is load-bearing
+### `output: true` selects what the agent sees
 
-Without `store: true`, a step still runs, but Muster emits only `{id, tool, status}` for it—the actual data is discarded before the agent sees the response. Set `store: true` on every step whose data the agent must read. Only the last step's result is merged into the top level automatically if it isn't stored. When in doubt, store it.
+Every step result is recorded. Later steps and the response projection can read it through `{{ .results.<id>.<field> }}`, with or without a flag. The per-step `output` flag controls one thing: whether the step's data lands in the document the agent receives. Without it, Muster emits only `{id, tool, status}` for the step and drops the data before the response. Set `output: true` on every step whose data the agent must read. The last step's result is merged into the top level even when you set no flag.
+
+The step-level `output` boolean differs from the `output: slim` argument inside `args`. That argument is a tool's own response knob. In the earlier example, `not_running` sets both. `output: slim` trims the Kubernetes payload, and step-level `output: true` returns the trimmed result.
+
+`store: true` is deprecated. It's the older name for `output: true` and still works. Muster logs a deprecation warning for each step that uses it. Referencing a step result no longer needs it, so prefer `output`. When a step sets neither, `output` wins if present, and `store` is the fallback. The warning fires on the create or validate path and on the CRD reconciler.
+
+### Shape the response with `spec.output`
+
+For the tightest response, declare a workflow-level `spec.output` projection. It's a templated map, rendered once after every step completes. It **replaces** the default `{execution_id, workflow, status, input, steps[], ...}` envelope with the shape you define. It reads `.input`, `.results`, and `.vars`. Every step result is available to it, no matter how you flag the step.
+
+```yaml
+spec:
+  steps:
+    - id: not_running
+      tool: x_kubernetes_list
+      args: { management_cluster: "{{ .input.management_cluster }}", resourceType: pods, fieldSelector: "status.phase!=Running", output: slim, limit: 25 }
+    - id: backoff_events
+      tool: x_kubernetes_list
+      args: { management_cluster: "{{ .input.management_cluster }}", resourceType: events, fieldSelector: "reason=BackOff", fullOutput: true, limit: 10 }
+      allowFailure: true
+  output:
+    not_running_pods: "{{ .results.not_running.items }}"
+    backoff_count: "{{ len .results.backoff_events.items }}"
+    cluster: "{{ .input.management_cluster }}"
+```
+
+The projection **preserves JSON types**. A leaf's type comes from the value it evaluates to, not from how the rendered text looks. A single bare reference like `{{ .results.not_running.items }}` keeps its real type, so an array stays an array. A `{{ len ... }}` leaf is a number. A leaf that mixes literal text with an action, such as `"cluster {{ .input.management_cluster }}"`, renders to a string. Values whose form matters survive without coercion, including leading zeros, versions, and IDs like `08` and `1.20`.
+
+When `spec.output` is declared, the per-step `output` and `store` flags no longer affect the returned document. The projection defines it in full. Muster logs a one-line warning naming any flags it made inert. Drop those flags, or drop the projection. The projection is the strongest token lever a workflow has, since it returns a small, shaped payload instead of the full step envelope.
 
 ### `allowFailure: true` for legitimately optional steps
 
@@ -129,7 +159,7 @@ Beyond plain `tool` steps, a top-level step can be a loop or a concurrent group,
           resourceType: pods
           output: slim
           limit: 25
-        store: true
+        output: true
 ```
 
 - `items` must be a reference that resolves to an array. A scalar, or a string built from a richer template, is rejected at runtime.
@@ -149,27 +179,27 @@ A loop multiplies cost: the per-step budget caps below apply to **every** iterat
     - id: nodes
       tool: x_kubernetes_list
       args: { management_cluster: "{{ .input.management_cluster }}", resourceType: nodes, output: slim }
-      store: true
+      output: true
     - id: events
       tool: x_kubernetes_list
       args: { management_cluster: "{{ .input.management_cluster }}", resourceType: events, fullOutput: true, limit: 10 }
-      store: true
+      output: true
 ```
 
 - Each sub-step sees a snapshot of the results as they were **before** the group started, so siblings can't read each other's output. A sub-step that needs another sub-step's result must be a later top-level step.
-- Stored sub-step results merge back into the workflow after the join, so later steps see them normally.
+- Sub-step results merge back into the workflow after the join, so later steps reference them normally; flag the ones you want in the response with `output: true`.
 - Only latency is parallelized; response **size** is still the sum, so the per-step caps still apply.
 
 ### `onFailure` cleanup
 
-A workflow-level `onFailure` block lists sub-steps that run best-effort when the workflow fails on a step that isn't marked `allowFailure`. Each handler can read `{{ .results.<id> }}` from any step that stored a result before the failure, so a rollback can reference what it must undo:
+A workflow-level `onFailure` block lists sub-steps that run best-effort when the workflow fails on a step that isn't marked `allowFailure`. Each handler can read `{{ .results.<id> }}` from any step that ran before the failure, so a rollback can reference what it must undo:
 
 ```yaml
 spec:
   steps:
     - id: backup
       tool: postgres_backup
-      store: true
+      output: true
     - id: migrate
       tool: postgres_migrate
   onFailure:
@@ -186,7 +216,7 @@ spec:
 Step arguments are Go templates resolved server-side per step. Rendering uses `missingkey=error`, so referencing an undefined key **fails the step** rather than rendering an empty string. Four roots are in scope:
 
 - `{{ .input.<arg> }}`: a workflow argument. It's always `.input.<arg>`, never a bare `{{ .<arg> }}`. The bare form fails with a missing-key error.
-- `{{ .results.<stepID>.<field> }}`: a field from a prior step that set `store: true`. Nested map navigation works.
+- `{{ .results.<stepID>.<field> }}`: a field from any prior step, available regardless of that step's `output` flag. Nested map navigation and array indexing both work (`{{ (index .results.list.items 0).name }}`).
 - `{{ .vars.<name> }}`: a `forEach` loop variable: the loop item `{{ .vars.<as> }}` and its index `{{ .vars.<as>_index }}`. There's no other way to set `.vars`.
 - `{{ .context.<x> }}`: another name for `.results`.
 
@@ -221,7 +251,7 @@ Alternatively, run a tool or reference a prior stored step and test the outcome.
         "type": "production"
 ```
 
-The `jsonPath` is a **simple dotted path** over the result object: `data.field` works, but array indexing such as `items[0].name` doesn't. For the read-only health digests that AI agents call most, conditions are seldom needed. Prefer `allowFailure` for the case where a resource might not exist.
+The `jsonPath` uses the same path navigator as step arguments and templates. It accepts two interchangeable forms. The first is a dotted or bracketed path over the result object, with array indexing. Paths like `data.field`, `items[0].name`, and plain dotted paths all work. The second is a Go-template expression that exposes the condition result as `.result`, alongside the usual roots. An example is `"{{ (index .result.items 0).name }}"`. For the read-only health digests that agents call most, conditions are seldom needed. Prefer `allowFailure` for the case where a resource might not exist.
 
 ## Budget for cost
 
@@ -246,7 +276,7 @@ These look plausible but are rejected at apply time or ignored. Avoid them:
 | Looks plausible | Reality |
 |---|---|
 | `{{ .<arg> }}` | Always `{{ .input.<arg> }}`; the bare form fails. |
-| `outputs:` on a step | Removed from the schema; use `store: true`. |
+| `outputs:` on a step | Removed from the schema; use the `output` flag, or `spec.output` to shape the response. |
 | `spec.name`, custom annotations to steer the agent | Not part of the schema; pruned or ignored. |
 | Directives on a step's `description` | Never reach the agent; move them to `spec.description`. |
 | `and`/`or` in a condition | One source per condition; compose logic in a `template`. |

--- a/src/content/tutorials/ai-agents/authoring-workflows/index.md
+++ b/src/content/tutorials/ai-agents/authoring-workflows/index.md
@@ -19,7 +19,7 @@ user_questions:
 
 A workflow packages a multi-step operation into a single named tool. You write it as a `Workflow` custom resource, and Muster registers it as a `workflow_<name>` tool that an agent discovers and calls with one request. Muster runs the steps server-side and returns one shaped result. That's the whole value: it collapses what would otherwise be many agent round-trips, each paying prompt tokens both ways, into a single call. A paired trial measured a 10x reduction in cache-read tokens when an agent used a workflow instead of the raw tools. See [why workflows cut agent cost]({{< relref "/overview/ai-agents/architecture" >}}#workflows-cut-agent-token-cost).
 
-This guide documents what the engine implements. Write against these fields and your workflow behaves predictably.
+This guide documents what the engine implements. Write against these fields and your workflow behaves predictably. For the complete field-by-field schema of the `Workflow` resource, see the [Muster resource reference]({{< relref "/reference/muster" >}}).
 
 ## The execution model
 
@@ -307,6 +307,7 @@ Iterate live, then promote to your GitOps pipeline:
 
 ## Related
 
+- [Muster resource reference]({{< relref "/reference/muster" >}}): the complete field-by-field schema for the `Workflow` resource.
 - [Manage MCP servers]({{< relref "/tutorials/ai-agents/managing-mcp-servers" >}}): the servers whose tools your workflow steps call.
 - [Meta-tools and discovery]({{< relref "/overview/ai-agents/meta-tools" >}}): how an agent finds and invokes a `workflow_<name>` tool.
 - [Troubleshooting]({{< relref "/tutorials/ai-agents/troubleshooting" >}}): when a workflow runs but the agent never picks it.

--- a/src/content/tutorials/ai-agents/authoring-workflows/index.md
+++ b/src/content/tutorials/ai-agents/authoring-workflows/index.md
@@ -23,7 +23,7 @@ This guide documents what the engine implements. Write against these fields and 
 
 ## The execution model
 
-A workflow is an ordered list of steps that Muster runs server-side, returning one condensed JSON document. Top-level steps run **sequentially**, but a step isn't always a single tool call: each top-level step is exactly one of a plain `tool` call, a `forEach` loop, or a `parallel` group. A workflow-level `onFailure` block can run best-effort cleanup when a step fails. Design every workflow around one fact: it collapses many agent round-trips into a single call, and its response cost is the sum over everything it runs.
+A workflow is an ordered list of steps that Muster runs server-side, returning one condensed JSON document. Top-level steps run **sequentially**, but a step isn't always a single tool call. Each top-level step is exactly one of a plain `tool` call, a `forEach` loop, or a `parallel` group. A workflow-level `onFailure` block can run best-effort cleanup when a step fails. Design every workflow around one fact: it collapses many agent round-trips into a single call, and its response cost is the sum over everything it runs.
 
 > Control flow (`forEach`, `parallel`, `onFailure`, and template conditions) requires Muster 0.8.0 or later. Plain sequential `tool` steps work on every version.
 
@@ -104,7 +104,7 @@ Without `store: true`, a step still runs, but Muster emits only `{id, tool, stat
 
 ### `allowFailure: true` for legitimately optional steps
 
-By default, a single step error fails the whole workflow and flips its result to an error, which sends the agent chasing the failure with expensive discovery calls. Set `allowFailure: true` on steps that may legitimately fail or return nothing: a resource type not every cluster uses, an optional backend such as the metrics server (`x_prometheus_*`), or a list that depends on RBAC that might be scoped differently. In the earlier example, the events list is marked optional so a cluster without recent crash-loop events still returns a clean digest.
+By default, a single step error fails the whole workflow and flips its result to an error, which sends the agent chasing the failure with expensive discovery calls. Set `allowFailure: true` on steps that may legitimately fail or return nothing. Examples are a resource type not every cluster uses, an optional backend such as the metrics server (`x_prometheus_*`), or a list that depends on RBAC that might be scoped differently. In the earlier example, the events list is marked optional so a cluster without recent crash-loop events still returns a clean digest.
 
 A workflow can mix servers in one digest, for example correlating Kubernetes state with an `x_prometheus_query` step, so a single call returns both the failing pods and the matching metrics. Mark the metrics step `allowFailure: true` so a cluster without `mcp-prometheus` deployed still returns the Kubernetes half.
 
@@ -225,7 +225,7 @@ The `jsonPath` is a **simple dotted path** over the result object: `data.field` 
 
 ## Budget for cost
 
-Total response size is the **sum** over everything the workflow runs, including each `forEach` iteration and every `parallel` sub-step, so an unbounded step is what eventually produces a multi-million-token outlier even when the typical run is small. Latency is the sum for sequential steps but the max within a `parallel` group. Cap every list, get, and log step:
+Total response size is the **sum** over everything the workflow runs, including each `forEach` iteration and every `parallel` sub-step. An unbounded step is what eventually produces a multi-million-token outlier even when the typical run is small. Latency is the sum for sequential steps but the max within a `parallel` group. Cap every list, get, and log step:
 
 - Set `limit:` on every list. Ten events is plenty; more just feeds noise.
 - Set `tailLines: 30` on any log fetch. The default is 100 and the maximum is 1000—enough to blow the prompt window on a healthy system.

--- a/src/content/tutorials/ai-agents/connecting-custom-mcp-servers/index.md
+++ b/src/content/tutorials/ai-agents/connecting-custom-mcp-servers/index.md
@@ -1,0 +1,92 @@
+---
+title: Connect custom MCP servers
+linkTitle: Connect custom servers
+description: Bring third-party and internal MCP servers behind Muster, including servers that don't publish RFC 9728 metadata, using the authorizationServer override.
+weight: 30
+menu:
+  principal:
+    parent: tutorials-ai-agents
+    identifier: tutorials-ai-agents-connecting-custom-mcp-servers
+owner:
+  - https://github.com/orgs/giantswarm/teams/team-bumblebee
+last_review_date: 2026-06-20
+user_questions:
+  - How do I connect a third-party MCP server to Muster?
+  - How do I connect an MCP server that doesn't publish OAuth metadata?
+  - What is the authorizationServer override?
+---
+
+Any MCP server can sit behind Muster—internal tools, vendor services, the reference servers, or a commercial remote server. You register it the same way as any other server, with an [`MCPServer` resource]({{< relref "/tutorials/ai-agents/managing-mcp-servers" >}}). This guide covers the parts specific to third-party servers: unauthenticated servers, bearer-token servers, and OAuth servers that don't advertise their authorization server the standard way.
+
+## An unauthenticated or token-header server
+
+The simplest custom servers need no OAuth. A public or internal server that takes a static bearer token accepts it through `headers`:
+
+```yaml
+apiVersion: muster.giantswarm.io/v1alpha1
+kind: MCPServer
+metadata:
+  name: vendor-tools
+  namespace: muster
+spec:
+  type: streamable-http
+  url: "https://tools.vendor.example.com/mcp"
+  headers:
+    Authorization: "Bearer <token>"
+  description: Vendor MCP server with a static token.
+```
+
+Store the token in a secret and inject it through your deployment pipeline rather than committing it to Git.
+
+## An OAuth server with standard discovery
+
+When a remote server publishes RFC 9728 Protected Resource Metadata, Muster discovers its authorization server automatically. Declare `auth.type: oauth` and Muster runs the login flow for you:
+
+```yaml
+spec:
+  type: streamable-http
+  url: "https://api.example.com/mcp"
+  auth:
+    type: oauth
+```
+
+The first time a user calls a tool from this server, Muster detects the `401` challenge, hands the agent an authorization URL, and—after the user authenticates in the browser—retries the call with the acquired token. The [security model]({{< relref "/overview/ai-agents/security" >}}) walks through this exchange.
+
+## A server that doesn't publish RFC 9728 metadata
+
+Some OAuth servers publish RFC 8414 metadata at their own origin instead of advertising it through RFC 9728. The Atlassian remote MCP server is one example. For these, point Muster at the authorization server directly with `auth.authorizationServer`:
+
+```yaml
+spec:
+  type: streamable-http
+  url: "https://mcp.atlassian.com/v1/sse"
+  auth:
+    type: oauth
+    authorizationServer:
+      issuer: "https://auth.atlassian.com"
+      scopes: "read:jira-work offline_access"
+```
+
+What this does and doesn't change:
+
+- It tells Muster's per-server login flow to skip metadata probing and use the issuer you give. Muster fetches the issuer's metadata through standard OIDC discovery.
+- It **doesn't** suppress the connect-time probe. A server without RFC 9728 metadata still reconciles to `Auth Required` on first connect, then moves to `Connected` after the user logs in. That's expected.
+- It's **mutually exclusive** with `forwardToken: true` and with token exchange. A custom OAuth server uses its own login, not Muster's identity—so don't combine the override with token forwarding. Muster's admission rules reject a resource that sets both.
+
+Muster logs each use of the override, so non-standard servers stay visible to operators.
+
+## Verify the connection
+
+After applying the resource, check that the server registered and reached a sensible state:
+
+```bash
+kubectl get mcpservers -n muster
+muster auth status
+```
+
+A custom OAuth server showing `Auth Required` is normal until a user logs in. If it shows `Failed`, the endpoint is unreachable—check the URL, network policy, and that the server actually speaks the transport you declared. The [troubleshooting guide]({{< relref "/tutorials/ai-agents/troubleshooting" >}}) covers the common failure modes.
+
+## Related
+
+- [Manage MCP servers]({{< relref "/tutorials/ai-agents/managing-mcp-servers" >}}): the full `MCPServer` field set.
+- [Map RBAC and SSO]({{< relref "/tutorials/ai-agents/access-control" >}}): when the custom server shares your identity provider.

--- a/src/content/tutorials/ai-agents/connecting-custom-mcp-servers/index.md
+++ b/src/content/tutorials/ai-agents/connecting-custom-mcp-servers/index.md
@@ -50,7 +50,7 @@ spec:
     type: oauth
 ```
 
-The first time a user calls a tool from this server, Muster detects the `401` challenge, hands the agent an authorization URL, and—after the user authenticates in the browser—retries the call with the acquired token. The [security model]({{< relref "/overview/ai-agents/security" >}}) walks through this exchange.
+The first time a user calls a tool from this server, Muster detects the `401` challenge and hands the agent an authorization URL. After the user authenticates in the browser, Muster retries the call with the acquired token. The [security model]({{< relref "/overview/ai-agents/security" >}}) walks through this exchange.
 
 ## A server that doesn't publish RFC 9728 metadata
 

--- a/src/content/tutorials/ai-agents/deploy-muster/index.md
+++ b/src/content/tutorials/ai-agents/deploy-muster/index.md
@@ -1,0 +1,121 @@
+---
+title: Deploy Muster
+linkTitle: Deploy Muster
+description: Install the CRD and application Helm charts for Muster on a management cluster, and run the aggregator in custom-resource discovery mode.
+weight: 70
+menu:
+  principal:
+    parent: tutorials-ai-agents
+    identifier: tutorials-ai-agents-deploy-muster
+owner:
+  - https://github.com/orgs/giantswarm/teams/team-bumblebee
+last_review_date: 2026-06-20
+user_questions:
+  - How do I deploy Muster on a management cluster?
+  - Which Helm charts does Muster need?
+  - How does Muster read MCPServer and Workflow resources?
+---
+
+Muster ships as two Helm charts: `muster-crds`, which installs the `MCPServer` and `Workflow` CustomResourceDefinitions, and `muster`, which runs the aggregator itself. This guide installs both and explains the custom-resource discovery mode the aggregator runs in on a cluster.
+
+For the concepts behind the aggregator, see the [architecture overview]({{< relref "/overview/ai-agents/architecture" >}}). To protect the deployed endpoint with single sign-on, continue to [set up OAuth]({{< relref "/tutorials/ai-agents/oauth-setup" >}}).
+
+## Prerequisites
+
+- A management cluster you can deploy to, with the Giant Swarm app platform or Helm available.
+- An ingress controller or Gateway API implementation to expose the aggregator. Production OAuth needs HTTPS.
+- An OIDC provider (Dex on a Giant Swarm cluster) if you plan to protect the endpoint, covered in [OAuth setup]({{< relref "/tutorials/ai-agents/oauth-setup" >}}).
+
+## Install the CRDs first
+
+The application chart no longer renders the CRDs. It expects them to exist, so always reconcile `muster-crds` before `muster`. Installing the application first risks the reconciler starting against missing or stale CRDs.
+
+```bash
+helm upgrade --install muster-crds \
+  oci://gsoci.azurecr.io/giantswarm/muster-crds \
+  --namespace muster --create-namespace
+```
+
+The CRDs carry `helm.sh/resource-policy: keep`, so a later `helm uninstall muster-crds` leaves them, and every `MCPServer` and `Workflow` resource, in place. Removing them is a deliberate, destructive step that also deletes the dependent resources.
+
+## Install the application
+
+```bash
+helm upgrade --install muster \
+  oci://gsoci.azurecr.io/giantswarm/muster \
+  --namespace muster
+```
+
+The image comes from `gsoci.azurecr.io/giantswarm/muster`. On a Giant Swarm management cluster, deploy both charts through the app platform with an `App` resource managed by your GitOps pipeline, rather than running Helm by hand. The ordering rule is the same: the CRD chart lands first.
+
+## How the aggregator finds resources
+
+The chart renders a `config.yaml` and runs `muster serve --config-path=/etc/muster`. Two settings drive discovery:
+
+```yaml
+namespace: muster
+kubernetes: true
+```
+
+With `kubernetes: true`, the aggregator watches the cluster for `MCPServer` and `Workflow` resources in `namespace` and reconciles them live. You add a downstream server by applying an [`MCPServer`]({{< relref "/tutorials/ai-agents/managing-mcp-servers" >}}) resource, and a workflow by applying a [`Workflow`]({{< relref "/tutorials/ai-agents/authoring-workflows" >}}). No restart is needed. `namespace` defaults to the release namespace, so this configuration watches the `muster` namespace.
+
+## Configure the aggregator endpoint
+
+The aggregator's HTTP server is configured under `muster.aggregator` in the values:
+
+```yaml
+muster:
+  aggregator:
+    port: 8090
+    transport: "streamable-http"
+```
+
+- `port`: the port the aggregator listens on. The chart's `Service` targets the same port.
+- `transport`: the MCP transport. `streamable-http` is the default and the right choice for remote clients. `sse` is also supported.
+
+The aggregator binds to `0.0.0.0` inside the pod and serves the MCP endpoint at `/mcp` and a health check at `/health`.
+
+## Expose the endpoint
+
+By default the `Service` is `ClusterIP` and the aggregator is reachable only inside the cluster. To let IDEs and the developer portal connect, expose it with either Ingress or Gateway API.
+
+```yaml
+ingress:
+  enabled: true
+  className: "nginx"
+  hosts:
+    - host: muster.<management-cluster>.<base-domain>
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: muster-tls
+      hosts:
+        - muster.<management-cluster>.<base-domain>
+```
+
+For Gateway API, set `gatewayAPI.enabled: true` with a `parentRefs` entry and `hostnames`. On Envoy Gateway, also enable `gatewayAPI.backendTrafficPolicy` with `timeout: "0s"`, because the default fifteen-second backend timeout kills the long-lived streaming connections MCP relies on.
+
+Tokens from enterprise single sign-on can carry many group claims and overflow the default ingress header buffers. Raise `large_client_header_buffers` on the ingress that fronts Muster. The [OAuth setup]({{< relref "/tutorials/ai-agents/oauth-setup" >}}) guide covers the symptom and fix.
+
+## Verify the deployment
+
+```bash
+kubectl get pods -n muster
+kubectl logs -n muster -l app.kubernetes.io/name=muster -f
+```
+
+Once the pod is ready, check the health endpoint through a port-forward:
+
+```bash
+kubectl port-forward -n muster svc/muster 8090:8090
+curl http://localhost:8090/health
+```
+
+A protected deployment rejects unauthenticated MCP calls, which is expected. The `/health` endpoint stays open so probes and load balancers can reach it.
+
+## Next steps
+
+- [Set up OAuth]({{< relref "/tutorials/ai-agents/oauth-setup" >}}): protect the endpoint and proxy authentication to downstream servers.
+- [Manage MCP servers]({{< relref "/tutorials/ai-agents/managing-mcp-servers" >}}): register the downstream servers Muster aggregates.
+- [Multi-cluster token exchange]({{< relref "/tutorials/ai-agents/multi-mc-token-exchange" >}}): bridge single sign-on to remote management clusters.

--- a/src/content/tutorials/ai-agents/managing-mcp-servers/index.md
+++ b/src/content/tutorials/ai-agents/managing-mcp-servers/index.md
@@ -16,7 +16,7 @@ user_questions:
   - How do I expose the same tools across multiple clusters?
 ---
 
-Muster aggregates downstream MCP servers and presents their combined tools through one endpoint. You register each server as an `MCPServer` resource. Muster's reconciler picks it up, connects or starts the server, prefixes its tools to avoid name clashes, and makes them discoverable through the [meta-tools]({{< relref "/overview/ai-agents/meta-tools" >}}). No agent restart is required.
+Muster aggregates downstream MCP servers and presents their combined tools through one endpoint. You register each server as an `MCPServer` resource. Muster's reconciler picks it up, connects or starts the server, prefixes its tools to avoid name clashes, and makes them discoverable through the [meta-tools]({{< relref "/overview/ai-agents/meta-tools" >}}). No agent restart is required. This guide walks the common fields by example; for the complete schema of the `MCPServer` resource, see the [Muster resource reference]({{< relref "/reference/muster" >}}).
 
 ## Choose a transport
 
@@ -130,3 +130,10 @@ kubectl apply -f mcpserver.yaml
 ```
 
 Muster reconciles within seconds. As with workflows, iterate directly while you're configuring, then manage the resource through your GitOps pipeline for production.
+
+## Related
+
+- [Muster resource reference]({{< relref "/reference/muster" >}}): the complete field-by-field schema for the `MCPServer` resource.
+- [Connect custom MCP servers]({{< relref "/tutorials/ai-agents/connecting-custom-mcp-servers" >}}): third-party servers, including ones without standard discovery metadata.
+- [Give agents multi-cluster access]({{< relref "/tutorials/ai-agents/multi-cluster-access" >}}): families and token exchange across a fleet.
+- [Meta-tools and discovery]({{< relref "/overview/ai-agents/meta-tools" >}}): how an agent finds the tools a server contributes.

--- a/src/content/tutorials/ai-agents/managing-mcp-servers/index.md
+++ b/src/content/tutorials/ai-agents/managing-mcp-servers/index.md
@@ -26,7 +26,7 @@ Every `MCPServer` declares a `type`:
 - `streamable-http`: a remote server reachable over HTTP. Use it for servers that run as their own service, including `mcp-kubernetes` and `mcp-prometheus`. Requires `url`.
 - `sse`: a remote server using the Server-Sent Events transport. Requires `url`.
 
-A stdio server must set `command`; a remote server must set `url`. Muster's admission rules reject a resource that mixes them. The `args` and `command` fields apply only to stdio, and `headers` applies only to remote servers.
+A stdio server must set `command`, and a remote server must set `url`. Muster's admission rules reject a resource that mixes them. The `args` and `command` fields apply only to stdio, and `headers` applies only to remote servers.
 
 ### A stdio server
 
@@ -89,7 +89,7 @@ The per-cluster `mcp-prometheus` servers follow the same pattern in their own `p
 
 ## Control startup with `autoStart`
 
-`autoStart: false` (the default) means the server is defined but not started until it's needed, so Muster doesn't spin up a process or load tool definitions for a server irrelevant to the current task. Set `autoStart: true` for servers that should always be available, such as per-cluster `mcp-kubernetes`. When a server starts, its tools are discovered and registered immediately, and the agent's next discovery call reflects them.
+`autoStart: false` (the default) means the server is defined but not started until it's needed, so Muster doesn't spin up a process or load tool definitions for a server irrelevant to the current task. Set `autoStart: true` for servers that should always be available, such as the per-cluster `mcp-kubernetes`. When a server starts, its tools are discovered and registered immediately, and the agent's next discovery call reflects them.
 
 ## Configure authentication
 
@@ -121,7 +121,7 @@ kubectl get mcpservers -n muster
 - Stdio servers report `Running`, `Starting`, `Stopped`, or `Failed`.
 - Remote servers report `Connected`, `Auth Required`, `Connecting`, `Disconnected`, or `Failed`.
 
-`Auth Required` means the server is reachable but needs a login—it's a normal first-connect state for a protected server, not an error. A user authenticates with `muster auth login` and the server moves to `Connected` for that user. The resource-level `state` reflects infrastructure; whether a specific user is authenticated and which tools they see is tracked per user. See the [security model]({{< relref "/overview/ai-agents/security" >}}) for how per-user visibility works.
+`Auth Required` means the server is reachable but needs a login—it's a normal first-connect state for a protected server, not an error. A user authenticates with `muster auth login` and the server moves to `Connected` for that user. The resource-level `state` reflects infrastructure. Whether a specific user is authenticated and which tools they see is tracked per user. See the [security model]({{< relref "/overview/ai-agents/security" >}}) for how per-user visibility works.
 
 ## Apply and iterate
 

--- a/src/content/tutorials/ai-agents/managing-mcp-servers/index.md
+++ b/src/content/tutorials/ai-agents/managing-mcp-servers/index.md
@@ -1,0 +1,132 @@
+---
+title: Manage MCP servers in Muster
+linkTitle: Manage MCP servers
+description: Add and configure downstream MCP servers behind Muster with MCPServer resources, covering stdio and remote transports, tool prefixes, server families, startup control, and authentication.
+weight: 20
+menu:
+  principal:
+    parent: tutorials-ai-agents
+    identifier: tutorials-ai-agents-managing-mcp-servers
+owner:
+  - https://github.com/orgs/giantswarm/teams/team-bumblebee
+last_review_date: 2026-06-20
+user_questions:
+  - How do I add an MCP server to Muster?
+  - What's the difference between stdio and remote MCP servers?
+  - How do I expose the same tools across multiple clusters?
+---
+
+Muster aggregates downstream MCP servers and presents their combined tools through one endpoint. You register each server as an `MCPServer` resource. Muster's reconciler picks it up, connects or starts the server, prefixes its tools to avoid name clashes, and makes them discoverable through the [meta-tools]({{< relref "/overview/ai-agents/meta-tools" >}}). No agent restart is required.
+
+## Choose a transport
+
+Every `MCPServer` declares a `type`:
+
+- `stdio`: Muster starts a local process and talks to it over standard input and output. Use it for servers shipped as a command, such as the reference servers run through `npx`. Requires `command` (and usually `args`).
+- `streamable-http`: a remote server reachable over HTTP. Use it for servers that run as their own service, including `mcp-kubernetes` and `mcp-prometheus`. Requires `url`.
+- `sse`: a remote server using the Server-Sent Events transport. Requires `url`.
+
+A stdio server must set `command`; a remote server must set `url`. Muster's admission rules reject a resource that mixes them. The `args` and `command` fields apply only to stdio, and `headers` applies only to remote servers.
+
+### A stdio server
+
+```yaml
+apiVersion: muster.giantswarm.io/v1alpha1
+kind: MCPServer
+metadata:
+  name: git-tools
+  namespace: muster
+spec:
+  type: stdio
+  autoStart: true
+  command: npx
+  args: ["@modelcontextprotocol/server-git"]
+  description: Git tools for repository operations.
+```
+
+### A remote server
+
+```yaml
+apiVersion: muster.giantswarm.io/v1alpha1
+kind: MCPServer
+metadata:
+  name: remote-api-tools
+  namespace: muster
+spec:
+  type: streamable-http
+  url: "https://api.example.com/mcp"
+  timeout: 30
+  description: Remote MCP server providing API tools.
+```
+
+## Avoid tool-name clashes with `toolPrefix`
+
+When two servers expose a tool with the same name, the prefix keeps them distinct. By default Muster prefixes external tools with the server name, so `get` from a server named `kubernetes` becomes `x_kubernetes_get`. Set `toolPrefix` to choose a shorter or clearer prefix:
+
+```yaml
+spec:
+  type: streamable-http
+  url: "https://mcp-kubernetes.example.com/mcp"
+  toolPrefix: "k8s"
+```
+
+## Group equivalent servers with `family`
+
+When you run several instances of the same server—for example, one `mcp-kubernetes` per management cluster—a **family** exposes them under one tool name with a required argument that selects the instance. Without it, an agent would see one prefixed copy of every tool per cluster, multiplying the surface.
+
+```yaml
+spec:
+  family:
+    name: kubernetes
+    instanceArg: management_cluster
+```
+
+With this, both clusters' `list` tools appear once as `x_kubernetes_list`, and the agent passes `management_cluster: <instance>` to pick the target. The instance argument is **always required**, even for a single-instance family, so tools written against the family name keep working as you add or remove instances.
+
+All servers that share a `family.name` must agree on `instanceArg`. If they disagree, Muster falls back to per-server prefixing for the whole family and logs a warning. The value an agent passes is the **full server name**, for example `my-cluster-mcp-kubernetes`. See [multi-cluster access]({{< relref "/tutorials/ai-agents/multi-cluster-access" >}}) for the contract.
+
+The per-cluster `mcp-prometheus` servers follow the same pattern in their own `prometheus` family, so the cluster's metrics tools (`x_prometheus_query` and friends) collapse to one set selected by the same instance argument. Each downstream server type gets its own family.
+
+## Control startup with `autoStart`
+
+`autoStart: false` (the default) means the server is defined but not started until it's needed, so Muster doesn't spin up a process or load tool definitions for a server irrelevant to the current task. Set `autoStart: true` for servers that should always be available, such as per-cluster `mcp-kubernetes`. When a server starts, its tools are discovered and registered immediately, and the agent's next discovery call reflects them.
+
+## Configure authentication
+
+Remote servers are usually protected. The `auth` block tells Muster how to authenticate on the user's behalf. For servers that trust the same identity provider as Muster, **token forwarding** reuses the user's ID token:
+
+```yaml
+spec:
+  type: streamable-http
+  url: "https://mcp-kubernetes.example.com/mcp"
+  auth:
+    type: oauth
+    forwardToken: true
+    requiredAudiences:
+      - "dex-k8s-authenticator"
+```
+
+`requiredAudiences` lists extra audiences the forwarded token must carry. Muster collects them from every forwarding server at login and requests them from the identity provider, so the downstream server—Kubernetes OIDC in this case—accepts the token.
+
+For cross-cluster single sign-on, where a remote cluster runs its own identity provider, use RFC 8693 **token exchange** instead. That's covered in [multi-cluster access]({{< relref "/tutorials/ai-agents/multi-cluster-access" >}}). For servers that don't publish standard discovery metadata, see [connecting custom MCP servers]({{< relref "/tutorials/ai-agents/connecting-custom-mcp-servers" >}}).
+
+## Check status
+
+Each `MCPServer` reports a `state` you can inspect:
+
+```bash
+kubectl get mcpservers -n muster
+```
+
+- Stdio servers report `Running`, `Starting`, `Stopped`, or `Failed`.
+- Remote servers report `Connected`, `Auth Required`, `Connecting`, `Disconnected`, or `Failed`.
+
+`Auth Required` means the server is reachable but needs a login—it's a normal first-connect state for a protected server, not an error. A user authenticates with `muster auth login` and the server moves to `Connected` for that user. The resource-level `state` reflects infrastructure; whether a specific user is authenticated and which tools they see is tracked per user. See the [security model]({{< relref "/overview/ai-agents/security" >}}) for how per-user visibility works.
+
+## Apply and iterate
+
+```bash
+kubectl apply -f mcpserver.yaml
+```
+
+Muster reconciles within seconds. As with workflows, iterate directly while you're configuring, then manage the resource through your GitOps pipeline for production.

--- a/src/content/tutorials/ai-agents/managing-mcp-servers/index.md
+++ b/src/content/tutorials/ai-agents/managing-mcp-servers/index.md
@@ -72,7 +72,7 @@ spec:
 
 ## Group equivalent servers with `family`
 
-When you run several instances of the same server—for example, one `mcp-kubernetes` per management cluster—a **family** exposes them under one tool name with a required argument that selects the instance. Without it, an agent would see one prefixed copy of every tool per cluster, multiplying the surface.
+When you run several instances of the same server—for example, one `mcp-kubernetes` per management cluster—a **family** exposes them under one tool name. A required argument selects the instance. Without it, an agent would see one prefixed copy of every tool per cluster, multiplying the surface.
 
 ```yaml
 spec:
@@ -89,7 +89,7 @@ The per-cluster `mcp-prometheus` servers follow the same pattern in their own `p
 
 ## Control startup with `autoStart`
 
-`autoStart: false` (the default) means the server is defined but not started until it's needed, so Muster doesn't spin up a process or load tool definitions for a server irrelevant to the current task. Set `autoStart: true` for servers that should always be available, such as the per-cluster `mcp-kubernetes`. When a server starts, its tools are discovered and registered immediately, and the agent's next discovery call reflects them.
+`autoStart: false` (the default) means the server is defined but not started until it's needed. Muster doesn't spin up a process or load tool definitions for a server irrelevant to the current task. Set `autoStart: true` for servers that should always be available, such as the per-cluster `mcp-kubernetes`. When a server starts, its tools are discovered and registered immediately, and the agent's next discovery call reflects them.
 
 ## Configure authentication
 

--- a/src/content/tutorials/ai-agents/managing-mcp-servers/index.md
+++ b/src/content/tutorials/ai-agents/managing-mcp-servers/index.md
@@ -31,12 +31,12 @@ Every `MCPServer` declares a `type`:
 A stdio server must set `command`, and a remote server must set `url`. Muster's admission rules reject a resource that mixes them. The `args` and `command` fields apply only to stdio, and `headers` applies only to remote servers.
 
 {{% notice note %}}
-**`stdio` is for local Muster only.** A `stdio` server runs as a child process **inside the Muster process or pod**. That works well when you run Muster yourself on your own machine (`muster serve`) for local development. It **doesn't** fit a Kubernetes Muster: on the managed Giant Swarm platform or a self-hosted Muster in a cluster, the container can only run the binaries baked into its image, and a single shared process serves every user, so there is nowhere to start a per-user `stdio` process. On those deployments, run each downstream server as its own service and connect to it with a remote transport (`streamable-http` or `sse`). Treat `stdio` as the local-development option and the remote transports as the cluster option.
+**`stdio` is for local Muster only.** A `stdio` server runs as a child process **inside the Muster process or pod**. That works well when you run Muster yourself on your own machine (`muster serve`) for local development. It **doesn't** fit a Kubernetes Muster. There the container runs only the binaries baked into its image, and one shared process serves every user. A Kubernetes deployment, whether the managed Giant Swarm platform or a self-hosted cluster, has nowhere to start a per-user `stdio` process. On those deployments, run each downstream server as its own service and connect to it with a remote transport (`streamable-http` or `sse`). Treat `stdio` as the local-development option and the remote transports as the cluster option.
 {{% /notice %}}
 
 ### A stdio server (local Muster only)
 
-This example assumes Muster runs locally on your own machine. On a Kubernetes Muster, use a remote transport instead (see the note above).
+This example assumes Muster runs locally on your own machine. On a Kubernetes Muster, use a remote transport instead (see the preceding note).
 
 ```yaml
 apiVersion: muster.giantswarm.io/v1alpha1

--- a/src/content/tutorials/ai-agents/managing-mcp-servers/index.md
+++ b/src/content/tutorials/ai-agents/managing-mcp-servers/index.md
@@ -13,6 +13,8 @@ last_review_date: 2026-06-20
 user_questions:
   - How do I add an MCP server to Muster?
   - What's the difference between stdio and remote MCP servers?
+  - Can I use a stdio MCP server on the managed platform or a Kubernetes Muster?
+  - Why do I need a remote transport for MCP servers on a cluster?
   - How do I expose the same tools across multiple clusters?
 ---
 
@@ -28,7 +30,13 @@ Every `MCPServer` declares a `type`:
 
 A stdio server must set `command`, and a remote server must set `url`. Muster's admission rules reject a resource that mixes them. The `args` and `command` fields apply only to stdio, and `headers` applies only to remote servers.
 
-### A stdio server
+{{% notice note %}}
+**`stdio` is for local Muster only.** A `stdio` server runs as a child process **inside the Muster process or pod**. That works well when you run Muster yourself on your own machine (`muster serve`) for local development. It **doesn't** fit a Kubernetes Muster: on the managed Giant Swarm platform or a self-hosted Muster in a cluster, the container can only run the binaries baked into its image, and a single shared process serves every user, so there is nowhere to start a per-user `stdio` process. On those deployments, run each downstream server as its own service and connect to it with a remote transport (`streamable-http` or `sse`). Treat `stdio` as the local-development option and the remote transports as the cluster option.
+{{% /notice %}}
+
+### A stdio server (local Muster only)
+
+This example assumes Muster runs locally on your own machine. On a Kubernetes Muster, use a remote transport instead (see the note above).
 
 ```yaml
 apiVersion: muster.giantswarm.io/v1alpha1

--- a/src/content/tutorials/ai-agents/multi-cluster-access/index.md
+++ b/src/content/tutorials/ai-agents/multi-cluster-access/index.md
@@ -1,0 +1,142 @@
+---
+title: Give agents multi-cluster access
+linkTitle: Multi-cluster access
+description: Expose an entire fleet of management clusters through one central Muster, with the instance-selection argument contract and RFC 8693 token exchange for cross-cluster single sign-on.
+weight: 40
+mermaid: true
+menu:
+  principal:
+    parent: tutorials-ai-agents
+    identifier: tutorials-ai-agents-multi-cluster-access
+owner:
+  - https://github.com/orgs/giantswarm/teams/team-bumblebee
+last_review_date: 2026-06-20
+user_questions:
+  - How do I give AI agents access to multiple management clusters?
+  - How does cross-cluster single sign-on work in Muster?
+  - What value do I pass to select a cluster?
+---
+
+A customer running several management clusters doesn't want a separate connection per cluster. A **central** Muster aggregates the `mcp-kubernetes` (and `mcp-prometheus`) servers on each management cluster and gives every user one endpoint and one login for the whole fleet.
+
+{{< mermaid >}}
+flowchart LR
+  user["SRE / developer"]
+  central["Central Muster<br/>(management cluster)"]
+  mcpA["mcp-kubernetes<br/>(MC A)"]
+  mcpB["mcp-kubernetes<br/>(MC B)"]
+  mcpC["mcp-kubernetes<br/>(MC C)"]
+
+  user -- "one SSO login,<br/>one endpoint" --> central
+  central --> mcpA
+  central --> mcpB
+  central --> mcpC
+{{< /mermaid >}}
+
+This guide assumes the central Muster and the per-cluster `mcp-kubernetes` servers are already deployed. It covers how to wire them together so an agent can reach the whole fleet.
+
+## Two deployment shapes
+
+- **Single management cluster:** Muster with `mcp-kubernetes` and `mcp-prometheus` on one cluster. The simplest setup, and nothing here about instance selection or token exchange applies.
+- **Multiple management clusters:** a central Muster that bridges single sign-on to the `mcp-kubernetes` servers on remote clusters. The rest of this page is about this shape.
+
+## Register each cluster as a family member
+
+Register each cluster's `mcp-kubernetes` as a remote [`MCPServer`]({{< relref "/tutorials/ai-agents/managing-mcp-servers" >}}) and put them all in one **family** so their tools appear once, with an argument that selects the target cluster:
+
+```yaml
+apiVersion: muster.giantswarm.io/v1alpha1
+kind: MCPServer
+metadata:
+  name: cluster-a-mcp-kubernetes
+  namespace: muster
+spec:
+  type: streamable-http
+  url: "https://mcp-kubernetes.cluster-a.<base-domain>/mcp"
+  autoStart: true
+  family:
+    name: kubernetes
+    instanceArg: management_cluster
+  auth:
+    type: oauth
+    tokenExchange:
+      enabled: true
+      dexTokenEndpoint: "https://dex.cluster-a.<base-domain>/token"
+      connectorId: "central-dex"
+      clientCredentialsSecretRef:
+        name: cluster-a-token-exchange-credentials
+```
+
+Every cluster's server shares `family.name: kubernetes` and `instanceArg: management_cluster`, so all their tools collapse to one set (`x_kubernetes_list`, `x_kubernetes_logs`, and the rest).
+
+Register each cluster's `mcp-prometheus` the same way, in its own `prometheus` family, so metrics tools are fleet-wide too:
+
+```yaml
+apiVersion: muster.giantswarm.io/v1alpha1
+kind: MCPServer
+metadata:
+  name: cluster-a-mcp-prometheus
+  namespace: muster
+spec:
+  type: streamable-http
+  url: "https://mcp-prometheus.cluster-a.<base-domain>/mcp"
+  autoStart: true
+  family:
+    name: prometheus
+    instanceArg: management_cluster
+  auth:
+    type: oauth
+    tokenExchange:
+      enabled: true
+      dexTokenEndpoint: "https://dex.cluster-a.<base-domain>/token"
+      connectorId: "central-dex"
+      clientCredentialsSecretRef:
+        name: cluster-a-token-exchange-credentials   # reuse the kubernetes credentials
+```
+
+The Prometheus servers collapse to `x_prometheus_*` tools (such as `x_prometheus_query`), selected by the same `management_cluster` argument. A single token-exchange secret per cluster covers both servers, so an agent that authenticates once reaches each cluster's Kubernetes API and its metrics.
+
+## The instance-selection contract
+
+The value an agent passes for `management_cluster` is the **full MCP server name**, not the bare cluster name. For a server named `cluster-a-mcp-kubernetes`, the correct argument is:
+
+```text
+management_cluster: cluster-a-mcp-kubernetes
+```
+
+This trips up agents in practice: a model often guesses the bare cluster name first and gets a wrong-argument error, then retries. The same rule applies to the `prometheus` family, where the value is the full Prometheus server name (`<cluster>-mcp-prometheus`). If you author [workflows]({{< relref "/tutorials/ai-agents/authoring-workflows" >}}) for a fleet, document this contract in the workflow's argument description, and have the workflow take the full server name. Naming servers consistently (always `<cluster>-mcp-kubernetes` and `<cluster>-mcp-prometheus`) makes the value predictable.
+
+## Cross-cluster single sign-on with token exchange
+
+When remote clusters run their own identity provider, the user's central token isn't valid on them directly. Muster uses **RFC 8693 token exchange**: it exchanges the user's central token for one the remote cluster's identity provider issues, so the user authenticates once and reaches every cluster.
+
+The `tokenExchange` block on each remote server's `auth` configures this:
+
+- `enabled: true` turns it on.
+- `dexTokenEndpoint`: the remote identity provider's token endpoint. This can differ from the issuer when access goes through a proxy.
+- `expectedIssuer`: the issuer expected in the exchanged token. Set it when the endpoint differs from the issuer (a proxy); otherwise Muster derives it from the endpoint.
+- `connectorId`: the connector on the remote identity provider that trusts the central one.
+- `clientCredentialsSecretRef`: a reference to a Kubernetes secret holding the client ID and secret for authenticating to the remote token endpoint.
+
+The remote identity provider must be configured with a connector that trusts the central one. After login, the central Muster waits for token exchange to complete, and `muster auth status` shows each server's mode:
+
+```text
+MCP Servers
+  cluster-a-mcp-kubernetes   Connected [SSO: Exchanged]
+  cluster-b-mcp-kubernetes   Connected [SSO: Exchanged]
+```
+
+Where a remote server trusts the **same** issuer as the central Muster, you don't need exchange at all—set `forwardToken: true` instead and Muster reuses the user's token. See [RBAC and SSO]({{< relref "/tutorials/ai-agents/access-control" >}}) for the difference.
+
+## Operational notes from production
+
+A few details surface only when you run this at scale:
+
+- **`mcp-kubernetes` needs to read kubeconfig secrets** for the clusters it serves, in the relevant namespaces on each management cluster. An interim approach grants cluster-wide secret access; per-namespace RBAC automation is the longer-term direction.
+- **Large tokens overflow default ingress buffers.** Enterprise tokens carrying many group claims can exceed the default nginx header buffer. The `mcp-kubernetes` ingress needs a raised `large_client_header_buffers` to accept them. See [RBAC and SSO]({{< relref "/tutorials/ai-agents/access-control" >}}#large-tokens) for the symptom and fix.
+
+## Related
+
+- [Manage MCP servers]({{< relref "/tutorials/ai-agents/managing-mcp-servers" >}}): the `family` and `auth` fields in full.
+- [Map RBAC and SSO]({{< relref "/tutorials/ai-agents/access-control" >}}): mapping identity to cluster permissions.
+- [Architecture]({{< relref "/overview/ai-agents/architecture" >}}): how fleet-wide aggregation fits together.

--- a/src/content/tutorials/ai-agents/multi-cluster-access/index.md
+++ b/src/content/tutorials/ai-agents/multi-cluster-access/index.md
@@ -19,6 +19,7 @@ user_questions:
 
 A customer running several management clusters doesn't want a separate connection per cluster. A **central** Muster aggregates the `mcp-kubernetes` (and `mcp-prometheus`) servers on each management cluster and gives every user one endpoint and one login for the whole fleet.
 
+<!-- vale off -->
 {{< mermaid >}}
 flowchart LR
   user["SRE / developer"]
@@ -32,6 +33,7 @@ flowchart LR
   central --> mcpB
   central --> mcpC
 {{< /mermaid >}}
+<!-- vale on -->
 
 This guide assumes the central Muster and the per-cluster `mcp-kubernetes` servers are already deployed. It covers how to wire them together so an agent can reach the whole fleet.
 
@@ -104,11 +106,11 @@ The value an agent passes for `management_cluster` is the **full MCP server name
 management_cluster: cluster-a-mcp-kubernetes
 ```
 
-This trips up agents in practice: a model often guesses the bare cluster name first and gets a wrong-argument error, then retries. The same rule applies to the `prometheus` family, where the value is the full Prometheus server name (`<cluster>-mcp-prometheus`). If you author [workflows]({{< relref "/tutorials/ai-agents/authoring-workflows" >}}) for a fleet, document this contract in the workflow's argument description, and have the workflow take the full server name. Naming servers consistently (always `<cluster>-mcp-kubernetes` and `<cluster>-mcp-prometheus`) makes the value predictable.
+This trips up agents in practice: a model often guesses the bare cluster name first and gets a wrong-argument error, then retries. The same rule applies to the `prometheus` family, where the value is the full Prometheus server name (`<cluster>-mcp-prometheus`). If you write [workflows]({{< relref "/tutorials/ai-agents/authoring-workflows" >}}) for a fleet, document this contract in the workflow's argument description, and have the workflow take the full server name. Naming servers consistently (always `<cluster>-mcp-kubernetes` and `<cluster>-mcp-prometheus`) makes the value predictable.
 
 ## Cross-cluster single sign-on with token exchange
 
-When remote clusters run their own identity provider, the user's central token isn't valid on them directly. Muster uses **RFC 8693 token exchange**: it exchanges the user's central token for one the remote cluster's identity provider issues, so the user authenticates once and reaches every cluster.
+When remote clusters run their own identity provider, the user's central token isn't valid on them directly. Muster uses **RFC 8693 token exchange**: it exchanges the user's central token for one the remote cluster's identity provider issues. The user authenticates once and reaches every cluster.
 
 The `tokenExchange` block on each remote server's `auth` configures this:
 

--- a/src/content/tutorials/ai-agents/multi-mc-token-exchange/index.md
+++ b/src/content/tutorials/ai-agents/multi-mc-token-exchange/index.md
@@ -1,0 +1,100 @@
+---
+title: Multi-cluster token exchange
+linkTitle: Multi-cluster token exchange
+description: Compare the single-cluster and central deployment shapes, set up RFC 8693 token exchange to remote management clusters, and grant the kubeconfig access each needs.
+weight: 90
+menu:
+  principal:
+    parent: tutorials-ai-agents
+    identifier: tutorials-ai-agents-multi-mc-token-exchange
+owner:
+  - https://github.com/orgs/giantswarm/teams/team-bumblebee
+last_review_date: 2026-06-20
+user_questions:
+  - How do I give Muster access to multiple management clusters?
+  - How does cross-cluster single sign-on work for AI agents?
+  - What RBAC does mcp-kubernetes need to read kubeconfig secrets?
+---
+
+A customer with more than one management cluster wants a single endpoint and a single login for the whole fleet. This guide covers the two deployment shapes, sets up the RFC 8693 token exchange that bridges single sign-on to remote clusters, and grants the cluster access each `mcp-kubernetes` needs.
+
+It builds on [multi-cluster access]({{< relref "/tutorials/ai-agents/multi-cluster-access" >}}), which covers the `MCPServer` family wiring. This page is about the operational setup: secrets, identity-provider trust, and RBAC.
+
+## Two deployment shapes
+
+- **Scenario 1, single cluster:** one management cluster runs Muster alongside its `mcp-kubernetes` and `mcp-prometheus`. The user's token is already valid on that cluster, so nothing here about token exchange applies. This is the simpler shape and a good place to start.
+- **Scenario 2, central cluster:** a central Muster aggregates the `mcp-kubernetes` servers on several remote management clusters. Each remote cluster runs its own Dex, so the central token isn't valid there directly. Muster exchanges it. The rest of this page is about this shape.
+
+## How the exchange works
+
+When a remote cluster runs its own identity provider, Muster uses RFC 8693 token exchange to turn the user's central token into one the remote provider issues:
+
+1. The user signs in once against the central Muster through enterprise single sign-on.
+2. For each remote server marked for exchange, Muster posts the user's token to that cluster's Dex token endpoint.
+3. The remote Dex, which trusts the central Dex through a connector, issues a token valid on the remote cluster.
+4. Muster caches the exchanged token and uses it for that user's calls, re-exchanging it only as it nears expiry.
+
+The user authenticates once and reaches every cluster. `muster auth status` shows `[SSO: Exchanged]` next to each remote server.
+
+## Set up the remote identity provider
+
+Each remote cluster's Dex needs a connector that trusts the central cluster's Dex. The connector's ID is the `connectorId` you reference from the `MCPServer`. This is the trust anchor: without it, the remote Dex rejects the exchange. Configure it through the remote cluster's usual GitOps pipeline.
+
+## Create the token-exchange credentials
+
+The exchange authenticates to the remote Dex as a confidential client. Create a secret per remote cluster holding that client's credentials, in the namespace where Muster runs:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cluster-a-token-exchange-credentials
+  namespace: muster
+type: Opaque
+stringData:
+  client-id: muster-token-exchange
+  client-secret: <secret-value>
+```
+
+The keys default to `client-id` and `client-secret`. Register a matching client on the remote Dex.
+
+## Wire it on the MCPServer
+
+Reference the secret from each remote server's `auth.tokenExchange` block. The full family wiring lives in [multi-cluster access]({{< relref "/tutorials/ai-agents/multi-cluster-access" >}}#cross-cluster-single-sign-on-with-token-exchange). The exchange-specific fields are:
+
+```yaml
+spec:
+  auth:
+    type: oauth
+    tokenExchange:
+      enabled: true
+      dexTokenEndpoint: "https://dex.cluster-a.<base-domain>/token"
+      connectorId: "central-dex"
+      clientCredentialsSecretRef:
+        name: cluster-a-token-exchange-credentials
+```
+
+- `dexTokenEndpoint`: the remote Dex token endpoint. It can differ from the issuer when access goes through a proxy.
+- `expectedIssuer`: set this to the remote Dex issuer when the endpoint differs from it. Otherwise Muster derives the issuer from the endpoint.
+- `connectorId`: the connector on the remote Dex that trusts the central one.
+- `scopes`: defaults to `openid profile email groups`. For a token the remote Kubernetes API accepts, the exchanged token needs the right audience. Add the Dex cross-client scope, such as `audience:server:client_id:dex-k8s-authenticator`, so the audience isn't the exchange client alone.
+
+One secret per cluster covers both that cluster's `mcp-kubernetes` and `mcp-prometheus`, so reuse it across the family members.
+
+## Grant kubeconfig access on each cluster
+
+Token exchange gets a user authenticated to a remote cluster, but `mcp-kubernetes` still needs the kubeconfig for the clusters it serves. It reads those from Kubernetes secrets in the organization namespaces on each management cluster, so its service account needs `get` on secrets there.
+
+An interim approach grants cluster-wide secret access. Per-namespace RBAC automation is the longer-term direction. If you run the central Muster's own token broker against target secrets in other namespaces, the application chart's `rbac.additionalSecretNamespaces` adds a `Role` and `RoleBinding` granting `get` on secrets in each listed namespace.
+
+## Operational notes
+
+- **Large tokens overflow ingress buffers.** Tokens that carry many group claims can exceed the default nginx header buffer on the `mcp-kubernetes` ingress. Raise `large_client_header_buffers`, as the [OAuth setup]({{< relref "/tutorials/ai-agents/oauth-setup" >}}) guide describes.
+- **A remote cluster can fail on its own.** A single cluster reporting `Disconnected` doesn't take the fleet down. Other clusters keep working while you fix the one. See [troubleshooting]({{< relref "/tutorials/ai-agents/troubleshooting" >}}#a-cluster-shows-as-disconnected).
+
+## Related
+
+- [Multi-cluster access]({{< relref "/tutorials/ai-agents/multi-cluster-access" >}}): the `MCPServer` family and instance-selection contract.
+- [Deploy Muster]({{< relref "/tutorials/ai-agents/deploy-muster" >}}): install the central aggregator.
+- [Set up OAuth]({{< relref "/tutorials/ai-agents/oauth-setup" >}}): the central single sign-on this exchange extends.
+- [Map RBAC and SSO]({{< relref "/tutorials/ai-agents/access-control" >}}): how identity maps to cluster permissions.

--- a/src/content/tutorials/ai-agents/oauth-setup/index.md
+++ b/src/content/tutorials/ai-agents/oauth-setup/index.md
@@ -1,0 +1,130 @@
+---
+title: Set up OAuth for Muster
+linkTitle: OAuth setup
+description: Protect the Muster endpoint with OAuth and Dex, configure the proxy that authenticates to downstream servers, and handle large enterprise tokens.
+weight: 80
+menu:
+  principal:
+    parent: tutorials-ai-agents
+    identifier: tutorials-ai-agents-oauth-setup
+owner:
+  - https://github.com/orgs/giantswarm/teams/team-bumblebee
+last_review_date: 2026-06-20
+user_questions:
+  - How do I protect Muster with OAuth?
+  - How does Muster authenticate to downstream MCP servers?
+  - Why do users with many groups fail to authenticate?
+---
+
+Muster runs two distinct OAuth roles, and you configure them independently:
+
+- **Resource server** (`oauth.server`): Muster protects its own MCP endpoint. Clients present a valid access token to reach any protected endpoint.
+- **Client proxy** (`oauth.mcpClient`): Muster authenticates to downstream MCP servers on a user's behalf, so tokens never reach the client directly.
+
+This guide assumes Muster is already [deployed]({{< relref "/tutorials/ai-agents/deploy-muster" >}}). For the security model behind it, see the [security overview]({{< relref "/overview/ai-agents/security" >}}).
+
+## Protect the endpoint with the resource server
+
+Enable the resource-server role and point it at your OIDC provider. On a Giant Swarm cluster, that's Dex.
+
+```yaml
+muster:
+  oauth:
+    server:
+      enabled: true
+      baseUrl: "https://muster.<management-cluster>.<base-domain>"
+      provider: "dex"
+      dex:
+        issuerUrl: "https://dex.<management-cluster>.<base-domain>"
+        clientId: "muster-server"
+      existingSecret: "muster-oauth"
+      encryptionKey: true
+      storage:
+        type: "valkey"
+        valkey:
+          url: "valkey.muster.svc:6379"
+          tls:
+            enabled: true
+```
+
+- `baseUrl` is Muster's own public HTTPS URL. Muster uses it as the OAuth issuer, so it must match how clients reach the endpoint. Production requires HTTPS for every OAuth endpoint.
+- `dex.issuerUrl` is the Dex issuer. Muster validates user tokens against it.
+- `dex.clientId` is the client registered for Muster in Dex's static clients, with a redirect URI of `{baseUrl}/oauth/callback`.
+
+Muster enforces PKCE on the authorization-code flow and issues access tokens with a thirty-minute lifetime, matched to Dex. Clients refresh automatically.
+
+### Provide the secrets
+
+The resource server reads its secrets from mounted files, not from Helm values. Create the secret the chart expects and reference it through `existingSecret`:
+
+```bash
+kubectl create secret generic muster-oauth -n muster \
+  --from-literal=dex-client-secret=<dex-client-secret> \
+  --from-literal=registration-token=$(openssl rand -hex 32) \
+  --from-literal=oauth-encryption-key=$(openssl rand -base64 32) \
+  --from-literal=valkey-password=<valkey-password>
+```
+
+- `dex-client-secret`: the client secret for `dex.clientId`.
+- `registration-token`: the shared secret a client presents to register (see below).
+- `oauth-encryption-key`: a 32-byte base64 key for encrypting stored tokens at rest. Needed when `encryptionKey: true`.
+- `valkey-password`: only when storage is Valkey.
+
+### Choose token storage
+
+In-memory storage is the default but loses every session on a pod restart and can't be shared across replicas. For production, use Valkey so sessions survive restarts and rolling updates and several replicas share state. The resource-server values shown earlier enable Valkey.
+
+### Let clients register
+
+MCP clients register with Muster before they can obtain a token. Pick the mechanism that fits each client:
+
+- `registrationToken`: a shared secret for managed clients that can store it, such as a portal backend.
+- `trustedPublicRegistrationSchemes`: custom URI schemes for native desktop apps, for example `["cursor", "vscode"]`.
+- `trustedPublicRegistrationRedirectURIs`: stable HTTPS callbacks for hosted clients you control.
+- `allowLocalhostRedirectURIs`: localhost callbacks for the local `muster agent` bridge. On by default.
+
+Avoid `allowPublicClientRegistration` in production. It opens the registration endpoint to anyone.
+
+## Authenticate to downstream servers with the proxy
+
+The client-proxy role lets Muster handle a downstream server's OAuth flow for the user. When a protected downstream server returns a challenge, Muster generates the authorization URL, the user authenticates in a browser, and Muster stores the resulting token scoped to that user.
+
+```yaml
+muster:
+  oauth:
+    mcpClient:
+      enabled: true
+      publicUrl: "https://muster.<management-cluster>.<base-domain>"
+```
+
+- `publicUrl` is Muster's public URL, used to build the proxy callback at `/oauth/proxy/callback`.
+- Leave `clientId` empty to use the self-hosted client metadata document. Muster derives the client identifier as `{publicUrl}/.well-known/oauth-client.json` and serves it there, so no external file hosting is needed.
+
+How Muster reuses or exchanges the user's token per downstream server is set on each [`MCPServer`]({{< relref "/tutorials/ai-agents/managing-mcp-servers" >}}#configure-authentication) resource, not here.
+
+## Large tokens and ingress buffers {#large-tokens-and-ingress-buffers}
+
+Enterprise tokens that carry many group claims hit two limits:
+
+- **Ingress header buffers.** A token with many groups can exceed the default nginx header buffer, and the request is rejected before it reaches Muster. Raise `large_client_header_buffers` on the ingress that fronts Muster, and on any `mcp-kubernetes` ingress that receives forwarded tokens.
+- **Group count.** Users in a very large number of groups were once rejected outright. The OAuth layer now truncates excessive groups to a configurable limit (default 500) instead of rejecting the request. If a user belongs to more groups than the limit, make sure the groups that matter for cluster RBAC fall within it.
+
+If a user can authenticate from a small account but fails from one in many groups, suspect these limits first.
+
+## Verify
+
+After both charts reconcile, a user signs in with the CLI:
+
+```bash
+muster auth login
+muster auth status
+```
+
+`muster auth status` shows the aggregator as authenticated and lists each downstream server's state. A protected MCP call without a token is rejected, while `/health` stays open for probes.
+
+## Related
+
+- [Deploy Muster]({{< relref "/tutorials/ai-agents/deploy-muster" >}}): install the charts this guide configures.
+- [Map RBAC and SSO]({{< relref "/tutorials/ai-agents/access-control" >}}): connect identity-provider groups to cluster permissions.
+- [Multi-cluster token exchange]({{< relref "/tutorials/ai-agents/multi-mc-token-exchange" >}}): cross-cluster single sign-on with RFC 8693.
+- [Security model]({{< relref "/overview/ai-agents/security" >}}): per-user visibility and token handling.

--- a/src/content/tutorials/ai-agents/saving-tokens-with-workflows/index.md
+++ b/src/content/tutorials/ai-agents/saving-tokens-with-workflows/index.md
@@ -35,16 +35,18 @@ Picture the same alert triage both ways:
 
 ## The measured saving
 
-A paired A/B trial ran the same agent, model, and prompt against four real management-cluster alerts. The only difference was the tool surface: one variant could use the raw aggregated tools (`x_kubernetes_*` and `x_prometheus_*`) but no workflow, the other could only call the matching `workflow_*` tool. Aggregated across the four alerts:
+The figures below come from one internal lab trial. Treat them as illustrative of the *shape* of the saving, not as a guarantee: the ratios hold across a range of investigations, but the absolute numbers depend on the model, its pricing, and how much work each alert needs.
+
+The trial was a paired A/B run: the same agent, model, and prompt against four real management-cluster alerts. The only difference was the tool surface—one variant could use the raw aggregated tools (`x_kubernetes_*` and `x_prometheus_*`) but no workflow, the other could only call the matching `workflow_*` tool. Aggregated across the four alerts:
 
 | Metric | Raw aggregated tools | Workflow tool | Reduction |
 |---|--:|--:|--:|
-| Total cost (USD) | $4.32 | $1.57 | 2.8x |
+| Cost | $4.32 | $1.57 | 2.8x |
 | Messages | 334 | 71 | 4.7x |
 | Cache-read input tokens | 11.0M | 1.1M | 9.6x |
 | Tool-call invocations | 68 | 4 | 17x |
 
-Read the tool-call row first: 68 calls became four, one per alert. That's the mechanism in a single number—the entire discover-query-correlate loop became one delegated call. The cache-read row is where the money is, because those tokens drive the dollar cost, and they fell by about 10x.
+Read the tool-call row first: 68 calls became four, one per alert. That's the mechanism in a single number—the entire discover-query-correlate loop became one delegated call. The cache-read row is where the durable saving lives: those tokens drive the dollar cost, and they fell by about 10x regardless of the per-token price.
 
 The saving scales with how much investigation an alert needs. The most exploratory alert saw a 4.7x message reduction at the high end of the run, and the most static one around 2.9x. Heavy, open-ended triage saves the most, while near-static checks save the least.
 

--- a/src/content/tutorials/ai-agents/saving-tokens-with-workflows/index.md
+++ b/src/content/tutorials/ai-agents/saving-tokens-with-workflows/index.md
@@ -1,0 +1,115 @@
+---
+title: Save agent tokens with workflows
+linkTitle: Save tokens with workflows
+description: Why a Muster workflow makes an AI agent dramatically cheaper, with the measured before-and-after numbers and the design rules that maximize the saving.
+weight: 15
+menu:
+  principal:
+    parent: tutorials-ai-agents
+    identifier: tutorials-ai-agents-saving-tokens-with-workflows
+owner:
+  - https://github.com/orgs/giantswarm/teams/team-bumblebee
+last_review_date: 2026-06-20
+user_questions:
+  - Why do workflows make my AI agent cheaper?
+  - How much do Muster workflows reduce token cost?
+  - How do I design a workflow to minimize agent token cost?
+---
+
+A workflow doesn't just save you clicks. It makes your AI agent dramatically cheaper to run. One `workflow_<name>` call runs every step server-side and returns one condensed document, so the agent pays for a single call and a single response instead of many round-trips. This guide makes the economic case with measured numbers, then gives you the design rules that maximize the saving. For the field-by-field mechanics of writing the resource, see [Author a workflow]({{< relref "/tutorials/ai-agents/authoring-workflows" >}}).
+
+## Where the tokens go
+
+When an agent investigates a problem with the raw aggregated tools, it runs a discover-query-correlate loop itself. It finds the right tool and reads its schema. Then it lists pods and events, queries a metric, and reads a log. It reasons over the results to decide what to call next. Every one of those is a separate tool call, and every tool call is a round-trip.
+
+The expensive part isn't the answer. It's the conversation. Each round-trip re-sends the whole transcript so far—the system prompt, every prior tool result, every reasoning step—back to the model as input. As the investigation grows, each new call carries more context than the last. That's why **cache-read input tokens dominate the bill**: the same growing transcript is read over and over. A loop that takes dozens of calls reads millions of cached tokens before it reaches a conclusion.
+
+## What a workflow changes
+
+A workflow collapses that loop into one server-side call. The agent invokes `call_tool(name="workflow_<name>", arguments={...})` once. Muster walks the steps itself, calls the same underlying tools, shapes the combined output, and returns one document. The agent pays for exactly one call and one response. The round-trips that re-read the transcript never happen, because there's no back-and-forth to re-read.
+
+Picture the same alert triage both ways:
+
+- **Raw tools**: discover the Kubernetes tools, read a schema, list not-running pods, list crash-loop events, query a metric, read a log, correlate—each a round-trip that re-sends a growing transcript.
+- **Workflow**: one `call_tool(name="workflow_alert-triage", arguments={management_cluster: "<mc>"})`. Muster runs every step server-side and returns a single digest.
+
+## The measured saving
+
+A paired A/B trial ran the same agent, model, and prompt against four real management-cluster alerts. The only difference was the tool surface: one variant could use the raw aggregated tools (`x_kubernetes_*` and `x_prometheus_*`) but no workflow, the other could only call the matching `workflow_*` tool. Aggregated across the four alerts:
+
+| Metric | Raw aggregated tools | Workflow tool | Reduction |
+|---|--:|--:|--:|
+| Total cost (USD) | $4.32 | $1.57 | 2.8x |
+| Messages | 334 | 71 | 4.7x |
+| Cache-read input tokens | 11.0M | 1.1M | 9.6x |
+| Tool-call invocations | 68 | 4 | 17x |
+
+Read the tool-call row first: 68 calls became four, one per alert. That's the mechanism in a single number—the entire discover-query-correlate loop became one delegated call. The cache-read row is where the money is, because those tokens drive the dollar cost, and they fell by about 10x.
+
+The saving scales with how much investigation an alert needs. The most exploratory alert saw a 4.7x message reduction at the high end of the run, and the most static one around 2.9x. Heavy, open-ended triage saves the most, while near-static checks save the least.
+
+## Design rules that maximize the saving
+
+A workflow saves tokens by default, but a few choices decide whether you capture a 3x win or a 10x one.
+
+### Shape a tight response
+
+The agent pays for everything the workflow returns, so the returned document is the single biggest token lever you control. By default a workflow returns a full envelope: `execution_id`, `workflow`, `status`, `input`, and a `steps[]` array carrying every step's payload. That array grows with every step, every `forEach` iteration, and every `parallel` sub-step. One unbounded step produces a multi-million-token outlier even when the typical run is small.
+
+The strongest fix is a workflow-level `spec.output` projection. It's a templated map, rendered once after every step completes, that **replaces** the default envelope with the exact shape you define. Instead of the whole `steps[]` array, the agent receives one small digest:
+
+```yaml
+spec:
+  output:
+    not_running_pods: "{{ .results.not_running.items }}"
+    backoff_count: "{{ len .results.backoff_events.items }}"
+    cluster: "{{ .input.management_cluster }}"
+```
+
+The projection can read every step result through `{{ .results.<id>.<field> }}`, so you pull just the fields that matter and drop everything else. The projection preserves JSON types, so a bare reference stays an array and a `{{ len ... }}` leaf stays a number. When you declare it, the per-step flags below no longer shape the returned document, and Muster logs a one-line warning naming any flag it made inert. See [shape the response with `spec.output`]({{< relref "/tutorials/ai-agents/authoring-workflows" >}}#shape-the-response-with-specoutput) for the full schema.
+
+Without a projection, the per-step `output` flag is the next lever. Set `output: true` only on the steps whose data the agent actually needs to read. A step without it still runs, and later steps can still read its result, but Muster keeps only its status in the returned document and drops the payload. `store: true` is the deprecated, older name for `output: true`: it still works but logs a warning, so prefer `output`.
+
+Then cap whatever does land in the response:
+
+- Set `limit:` on every list. Ten events is plenty, and more just feeds noise.
+- Set `tailLines: 30` on any log fetch. The default is 100 and the maximum is 1000, enough to swamp the prompt window on a healthy system.
+- Set `output: slim` on lists to strip verbose fields. That's the tool's own response knob, separate from the step-level `output` flag.
+
+### Fan out server-side, not in the agent
+
+When a check spans several clusters or several resource types, do the fan-out inside the workflow so it stays one agent call:
+
+- Use `forEach` to repeat a step over a list argument. Looping over `{{ .input.clusters }}` keeps the whole fleet check in one call instead of one agent round-trip per cluster.
+- Use `parallel` to run independent reads concurrently. Latency becomes the max over the group rather than the sum, while the result still returns as one document.
+
+Both keep the saving intact: the agent still makes a single call no matter how many underlying tools run. Remember that the per-step caps described earlier apply to every iteration, so a loop over a large list is the easiest way to undo the win. The full mechanics are in [Authoring workflows]({{< relref "/tutorials/ai-agents/authoring-workflows" >}}#control-flow).
+
+### Skip the expensive step unless it's needed
+
+The cheapest step is the one that never runs. A step's `condition` reads a prior result and decides whether to run the step or skip it. A skipped step costs nothing: no tool call, and no output in the response. Use it to gate the costly part of a workflow on a cheap signal:
+
+- A `template` condition gates on an input or a prior field without any tool call, for example `'{{ eq .input.env "production" }}'`.
+- A `jsonPath` condition checks a value at a dotted path in an earlier step's result, for example running a deep drill-down only when a quick list already shows something not running.
+
+A `jsonPath` condition is a **gate**, not a way to trim what a step returns. It decides whether the step runs, not how the response is shaped. The path navigates into an earlier step's result, for example `data.field`. So pair a cheap, capped first step with an expensive second step gated on it, and the expensive half runs only when the cheap half found something worth the tokens. See [conditions]({{< relref "/tutorials/ai-agents/authoring-workflows" >}}#conditions) for the full schema.
+
+### Keep the description lean and stop-aware
+
+Only `spec.description` reaches the agent at call time, and it does double duty for cost. Two directives matter most:
+
+- A **stop-when-healthy rule**: state the exact conditions that mean no follow-up is needed, plus an instruction to write a one-line summary and stop. Without it, an agent reads a clean result as an invitation to keep exploring with raw tools, and the saving evaporates.
+- **Discoverable wording**: an agent finds a workflow through a case-insensitive substring match over the description, with no stemming or synonyms. If the description doesn't literally contain the terms the agent searches by, the agent never finds the workflow and falls back to the expensive raw-tool loop. Lead with both the topic keyword and the natural question phrasing.
+
+A few hundred characters of description are far cheaper than the dozen extra calls they prevent.
+
+## The honest trade-off
+
+A workflow is cheaper precisely because it only checks what it was authored to check. For a first responder handling the specific alert that paged, that focus is a feature. For open-ended "what's broken here?" exploration, an agent with the raw tools surfaces more adjacent context at higher cost. In the trial, one alert showed this directly. The workflow correctly reported its alert wasn't firing, while the free-roaming agent dug further and found two unrelated apps broken at about three times the cost. Build workflows for the focused, repeatable questions, and leave the raw tools available for genuine exploration. Both run through the same gateway.
+
+## Related
+
+- [Author a workflow]({{< relref "/tutorials/ai-agents/authoring-workflows" >}}): the field-by-field guide to writing the resource.
+- [Muster architecture]({{< relref "/overview/ai-agents/architecture" >}}#workflows-cut-agent-token-cost): where this saving fits in the bigger picture.
+- [Meta-tools and discovery]({{< relref "/overview/ai-agents/meta-tools" >}}): how an agent finds and invokes a `workflow_<name>` tool.
+- [Give agents multi-cluster access]({{< relref "/tutorials/ai-agents/multi-cluster-access" >}}): the fleet setup that makes `forEach` fan-out worthwhile.

--- a/src/content/tutorials/ai-agents/self-hosting/_index.md
+++ b/src/content/tutorials/ai-agents/self-hosting/_index.md
@@ -1,0 +1,29 @@
+---
+title: Self-hosting Muster
+linkTitle: Self-hosting
+description: Operate your own Muster aggregator. Deploy the Helm charts, protect the endpoint with OAuth and Dex, and bridge single sign-on across multiple management clusters.
+weight: 70
+menu:
+  principal:
+    parent: tutorials-ai-agents
+    identifier: tutorials-ai-agents-self-hosting
+owner:
+  - https://github.com/orgs/giantswarm/teams/team-bumblebee
+last_review_date: 2026-06-21
+user_questions:
+  - How do I deploy and run my own Muster?
+  - How do I protect a self-hosted Muster with OAuth?
+  - How do I host Muster across multiple management clusters?
+---
+
+{{% notice note %}}
+**Applies to self-hosted Muster only.** These guides are for teams who operate their own Muster aggregator. On the managed Giant Swarm platform, Muster is deployed and protected for you, so you can skip this section and go straight to the operational guides such as [managing MCP servers]({{< relref "/tutorials/ai-agents/managing-mcp-servers" >}}) and [authoring workflows]({{< relref "/tutorials/ai-agents/authoring-workflows" >}}).
+{{% /notice %}}
+
+If you run Muster yourself, these guides take you from an empty cluster to a single-sign-on-protected endpoint that an entire fleet can reach.
+
+## In this section
+
+- [Deploy Muster]({{< relref "/tutorials/ai-agents/self-hosting/deploy-muster" >}}): install the CRD and application Helm charts and run the aggregator in custom-resource discovery mode.
+- [Set up OAuth]({{< relref "/tutorials/ai-agents/self-hosting/oauth-setup" >}}): protect the endpoint with Dex and configure the proxy that authenticates to downstream servers.
+- [Multi-cluster token exchange]({{< relref "/tutorials/ai-agents/self-hosting/multi-mc-token-exchange" >}}): bridge single sign-on to remote management clusters with RFC 8693.

--- a/src/content/tutorials/ai-agents/self-hosting/deploy-muster/index.md
+++ b/src/content/tutorials/ai-agents/self-hosting/deploy-muster/index.md
@@ -5,7 +5,7 @@ description: Install the CRD and application Helm charts for Muster on a managem
 weight: 70
 menu:
   principal:
-    parent: tutorials-ai-agents
+    parent: tutorials-ai-agents-self-hosting
     identifier: tutorials-ai-agents-deploy-muster
 owner:
   - https://github.com/orgs/giantswarm/teams/team-bumblebee
@@ -16,15 +16,19 @@ user_questions:
   - How does Muster read MCPServer and Workflow resources?
 ---
 
+{{% notice note %}}
+**Applies to self-hosted Muster only.** Follow this guide when you operate your own Muster. On the managed Giant Swarm platform, Muster is already deployed for you.
+{{% /notice %}}
+
 Muster ships as two Helm charts: `muster-crds`, which installs the `MCPServer` and `Workflow` CustomResourceDefinitions, and `muster`, which runs the aggregator itself. This guide installs both and explains the custom-resource discovery mode the aggregator runs in on a cluster.
 
-For the concepts behind the aggregator, see the [architecture overview]({{< relref "/overview/ai-agents/architecture" >}}). To protect the deployed endpoint with single sign-on, continue to [set up OAuth]({{< relref "/tutorials/ai-agents/oauth-setup" >}}).
+For the concepts behind the aggregator, see the [architecture overview]({{< relref "/overview/ai-agents/architecture" >}}). To protect the deployed endpoint with single sign-on, continue to [set up OAuth]({{< relref "/tutorials/ai-agents/self-hosting/oauth-setup" >}}).
 
 ## Prerequisites
 
 - A management cluster you can deploy to, with the Giant Swarm app platform or Helm available.
 - An ingress controller or Gateway API implementation to expose the aggregator. Production OAuth needs HTTPS.
-- An OIDC provider (Dex on a Giant Swarm cluster) if you plan to protect the endpoint, covered in [OAuth setup]({{< relref "/tutorials/ai-agents/oauth-setup" >}}).
+- An OIDC provider (Dex on a Giant Swarm cluster) if you plan to protect the endpoint, covered in [OAuth setup]({{< relref "/tutorials/ai-agents/self-hosting/oauth-setup" >}}).
 
 ## Install the CRDs first
 
@@ -96,7 +100,7 @@ ingress:
 
 For Gateway API, set `gatewayAPI.enabled: true` with a `parentRefs` entry and `hostnames`. On Envoy Gateway, also enable `gatewayAPI.backendTrafficPolicy` with `timeout: "0s"`, because the default fifteen-second backend timeout kills the long-lived streaming connections MCP relies on.
 
-Tokens from enterprise single sign-on can carry many group claims and overflow the default ingress header buffers. Raise `large_client_header_buffers` on the ingress that fronts Muster. The [OAuth setup]({{< relref "/tutorials/ai-agents/oauth-setup" >}}) guide covers the symptom and fix.
+Tokens from enterprise single sign-on can carry many group claims and overflow the default ingress header buffers. Raise `large_client_header_buffers` on the ingress that fronts Muster. The [OAuth setup]({{< relref "/tutorials/ai-agents/self-hosting/oauth-setup" >}}) guide covers the symptom and fix.
 
 ## Verify the deployment
 
@@ -116,6 +120,6 @@ A protected deployment rejects unauthenticated MCP calls, which is expected. The
 
 ## Next steps
 
-- [Set up OAuth]({{< relref "/tutorials/ai-agents/oauth-setup" >}}): protect the endpoint and proxy authentication to downstream servers.
+- [Set up OAuth]({{< relref "/tutorials/ai-agents/self-hosting/oauth-setup" >}}): protect the endpoint and proxy authentication to downstream servers.
 - [Manage MCP servers]({{< relref "/tutorials/ai-agents/managing-mcp-servers" >}}): register the downstream servers Muster aggregates.
-- [Multi-cluster token exchange]({{< relref "/tutorials/ai-agents/multi-mc-token-exchange" >}}): bridge single sign-on to remote management clusters.
+- [Multi-cluster token exchange]({{< relref "/tutorials/ai-agents/self-hosting/multi-mc-token-exchange" >}}): bridge single sign-on to remote management clusters.

--- a/src/content/tutorials/ai-agents/self-hosting/multi-mc-token-exchange/index.md
+++ b/src/content/tutorials/ai-agents/self-hosting/multi-mc-token-exchange/index.md
@@ -5,7 +5,7 @@ description: Compare the single-cluster and central deployment shapes, set up RF
 weight: 90
 menu:
   principal:
-    parent: tutorials-ai-agents
+    parent: tutorials-ai-agents-self-hosting
     identifier: tutorials-ai-agents-multi-mc-token-exchange
 owner:
   - https://github.com/orgs/giantswarm/teams/team-bumblebee
@@ -15,6 +15,10 @@ user_questions:
   - How does cross-cluster single sign-on work for AI agents?
   - What RBAC does mcp-kubernetes need to read kubeconfig secrets?
 ---
+
+{{% notice note %}}
+**Applies to self-hosted Muster only.** Follow this guide when you operate your own central Muster across several management clusters. On the managed Giant Swarm platform, multi-cluster wiring is handled for you.
+{{% /notice %}}
 
 A customer with more than one management cluster wants a single endpoint and a single login for the whole fleet. This guide covers the two deployment shapes, sets up the RFC 8693 token exchange that bridges single sign-on to remote clusters, and grants the cluster access each `mcp-kubernetes` needs.
 
@@ -89,12 +93,12 @@ An interim approach grants cluster-wide secret access. Per-namespace RBAC automa
 
 ## Operational notes
 
-- **Large tokens overflow ingress buffers.** Tokens that carry many group claims can exceed the default nginx header buffer on the `mcp-kubernetes` ingress. Raise `large_client_header_buffers`, as the [OAuth setup]({{< relref "/tutorials/ai-agents/oauth-setup" >}}) guide describes.
+- **Large tokens overflow ingress buffers.** Tokens that carry many group claims can exceed the default nginx header buffer on the `mcp-kubernetes` ingress. Raise `large_client_header_buffers`, as the [OAuth setup]({{< relref "/tutorials/ai-agents/self-hosting/oauth-setup" >}}) guide describes.
 - **A remote cluster can fail on its own.** A single cluster reporting `Disconnected` doesn't take the fleet down. Other clusters keep working while you fix the one. See [troubleshooting]({{< relref "/tutorials/ai-agents/troubleshooting" >}}#a-cluster-shows-as-disconnected).
 
 ## Related
 
 - [Multi-cluster access]({{< relref "/tutorials/ai-agents/multi-cluster-access" >}}): the `MCPServer` family and instance-selection contract.
-- [Deploy Muster]({{< relref "/tutorials/ai-agents/deploy-muster" >}}): install the central aggregator.
-- [Set up OAuth]({{< relref "/tutorials/ai-agents/oauth-setup" >}}): the central single sign-on this exchange extends.
+- [Deploy Muster]({{< relref "/tutorials/ai-agents/self-hosting/deploy-muster" >}}): install the central aggregator.
+- [Set up OAuth]({{< relref "/tutorials/ai-agents/self-hosting/oauth-setup" >}}): the central single sign-on this exchange extends.
 - [Map RBAC and SSO]({{< relref "/tutorials/ai-agents/access-control" >}}): how identity maps to cluster permissions.

--- a/src/content/tutorials/ai-agents/self-hosting/oauth-setup/index.md
+++ b/src/content/tutorials/ai-agents/self-hosting/oauth-setup/index.md
@@ -5,7 +5,7 @@ description: Protect the Muster endpoint with OAuth and Dex, configure the proxy
 weight: 80
 menu:
   principal:
-    parent: tutorials-ai-agents
+    parent: tutorials-ai-agents-self-hosting
     identifier: tutorials-ai-agents-oauth-setup
 owner:
   - https://github.com/orgs/giantswarm/teams/team-bumblebee
@@ -16,12 +16,16 @@ user_questions:
   - Why do users with many groups fail to authenticate?
 ---
 
+{{% notice note %}}
+**Applies to self-hosted Muster only.** Follow this guide when you operate your own Muster. On the managed Giant Swarm platform, the endpoint is already protected for you.
+{{% /notice %}}
+
 Muster runs two distinct OAuth roles, and you configure them independently:
 
 - **Resource server** (`oauth.server`): Muster protects its own MCP endpoint. Clients present a valid access token to reach any protected endpoint.
 - **Client proxy** (`oauth.mcpClient`): Muster authenticates to downstream MCP servers on a user's behalf, so tokens never reach the client directly.
 
-This guide assumes Muster is already [deployed]({{< relref "/tutorials/ai-agents/deploy-muster" >}}). For the security model behind it, see the [security overview]({{< relref "/overview/ai-agents/security" >}}).
+This guide assumes Muster is already [deployed]({{< relref "/tutorials/ai-agents/self-hosting/deploy-muster" >}}). For the security model behind it, see the [security overview]({{< relref "/overview/ai-agents/security" >}}).
 
 ## Protect the endpoint with the resource server
 
@@ -124,7 +128,7 @@ muster auth status
 
 ## Related
 
-- [Deploy Muster]({{< relref "/tutorials/ai-agents/deploy-muster" >}}): install the charts this guide configures.
+- [Deploy Muster]({{< relref "/tutorials/ai-agents/self-hosting/deploy-muster" >}}): install the charts this guide configures.
 - [Map RBAC and SSO]({{< relref "/tutorials/ai-agents/access-control" >}}): connect identity-provider groups to cluster permissions.
-- [Multi-cluster token exchange]({{< relref "/tutorials/ai-agents/multi-mc-token-exchange" >}}): cross-cluster single sign-on with RFC 8693.
+- [Multi-cluster token exchange]({{< relref "/tutorials/ai-agents/self-hosting/multi-mc-token-exchange" >}}): cross-cluster single sign-on with RFC 8693.
 - [Security model]({{< relref "/overview/ai-agents/security" >}}): per-user visibility and token handling.

--- a/src/content/tutorials/ai-agents/troubleshooting/index.md
+++ b/src/content/tutorials/ai-agents/troubleshooting/index.md
@@ -55,13 +55,13 @@ A related symptom: an agent told to "discover workflows" with a broad glob can p
 
 ## A workflow runs but the agent over-explores
 
-If a workflow returns a clean result and the agent keeps investigating anyway, the description is missing a **stop-when-healthy rule**. Without an explicit rule to write a one-line summary and stop when the result is empty, an agent treats a clean digest as a starting point. Add the rule to `spec.description`; this single change has swung a probe by an order of magnitude in token cost.
+If a workflow returns a clean result and the agent keeps investigating anyway, the description is missing a **stop-when-healthy rule**. Without an explicit rule to write a one-line summary and stop when the result is empty, an agent treats a clean digest as a starting point. Add the rule to `spec.description`. This single change has swung a probe by an order of magnitude in token cost.
 
 ## A long chain drops with a network error
 
 A single agent turn that runs many tool calls back to back can drop with a streaming network error before producing an answer—the HTTP response succeeds, but the stream aborts partway. Fewer, cheaper calls reduce this exposure, which is one more reason to encapsulate multi-step investigations as a [workflow]({{< relref "/tutorials/ai-agents/authoring-workflows" >}}) rather than letting the agent run the whole discover-query-correlate loop itself.
 
-## Authentication fails for heavily-grouped users
+## Authentication fails for users in many groups
 
 If a user can authenticate from one account but fails from one that belongs to many identity-provider groups, suspect token size limits: ingress header buffers and the group-count limit. See [RBAC and SSO]({{< relref "/tutorials/ai-agents/access-control" >}}#large-tokens).
 

--- a/src/content/tutorials/ai-agents/troubleshooting/index.md
+++ b/src/content/tutorials/ai-agents/troubleshooting/index.md
@@ -59,11 +59,11 @@ If a workflow returns a clean result and the agent keeps investigating anyway, t
 
 ## A long chain drops with a network error
 
-A single agent turn that runs many tool calls back to back can drop with a streaming network error before producing an answer—the HTTP response succeeds, but the stream aborts partway. Fewer, cheaper calls reduce this exposure, which is one more reason to encapsulate multi-step investigations as a [workflow]({{< relref "/tutorials/ai-agents/authoring-workflows" >}}) rather than letting the agent run the whole discover-query-correlate loop itself.
+A single agent turn that runs many tool calls back to back can drop with a streaming network error before producing an answer. The HTTP response succeeds, but the stream aborts partway. Fewer, cheaper calls reduce this exposure. That's one more reason to encapsulate multi-step investigations as a [workflow]({{< relref "/tutorials/ai-agents/authoring-workflows" >}}) rather than letting the agent run the whole discover-query-correlate loop itself.
 
 ## Authentication fails for users in many groups
 
-If a user can authenticate from one account but fails from one that belongs to many identity-provider groups, suspect token size limits: ingress header buffers and the group-count limit. See [RBAC and SSO]({{< relref "/tutorials/ai-agents/access-control" >}}#large-tokens).
+If a user can authenticate from one account but fails from one that belongs to many identity-provider groups, suspect token size limits. The usual causes are ingress header buffers and the group-count limit. See [RBAC and SSO]({{< relref "/tutorials/ai-agents/access-control" >}}#large-tokens).
 
 ## Related
 

--- a/src/content/tutorials/ai-agents/troubleshooting/index.md
+++ b/src/content/tutorials/ai-agents/troubleshooting/index.md
@@ -1,0 +1,72 @@
+---
+title: Troubleshoot AI agent access
+linkTitle: Troubleshooting
+description: Work through the common Muster failure modes for platform teams, from authentication loops and disconnected clusters to missing tools and workflows agents can't find.
+weight: 60
+menu:
+  principal:
+    parent: tutorials-ai-agents
+    identifier: tutorials-ai-agents-troubleshooting
+owner:
+  - https://github.com/orgs/giantswarm/teams/team-bumblebee
+last_review_date: 2026-06-20
+user_questions:
+  - Why does my AI agent keep asking me to authenticate?
+  - Why are tools missing from my agent?
+  - Why doesn't my agent find the workflow I wrote?
+  - Why does a cluster show as disconnected?
+---
+
+This guide covers the failure modes platform teams hit when operating Muster. For the basic IDE setup checks—context, login, editor configuration—start with the [AI agent setup troubleshooting]({{< relref "/getting-started/ai-agent-setup" >}}#troubleshooting) section first.
+
+## The agent keeps asking to authenticate
+
+If the `authenticate_muster` tool keeps reappearing, or your assistant loops on login, the session has expired or the token can't be refreshed.
+
+- Run `muster auth login` in a terminal, then restart the MCP server in your IDE.
+- Check `muster auth status`. If the aggregator shows as authenticated but a downstream server shows `Auth Required`, that server needs its own login or its single sign-on is set up incorrectly.
+- For a forwarding server, confirm the downstream trusts Muster's client and the `requiredAudiences` match what the server expects. A token without the right audience is rejected, which looks like an endless re-auth.
+
+## A cluster shows as disconnected
+
+In `muster auth status`, a single cluster reporting `Disconnected` or `Failed` while others are fine usually means that cluster's `mcp-kubernetes` is unreachable, not a Muster problem.
+
+- Check the [`MCPServer`]({{< relref "/tutorials/ai-agents/managing-mcp-servers" >}}) state: `kubectl get mcpservers -n muster`. A `Failed` state means the endpoint is unreachable. Verify the URL, DNS, and any network policy between Muster and that cluster.
+- `Auth Required` isn't a failure: it's the normal state for a protected server until a user logs in.
+- Other clusters keep working independently, so users can still operate the rest of the fleet while you fix the one.
+
+## Tools are missing from the agent
+
+If expected tools don't appear in the agent's discovery results:
+
+1. Confirm the user is authenticated to the server those tools come from. Per-user visibility means a server a user hasn't authenticated with contributes no tools to **their** list, even though it's healthy.
+2. Check the server's state is `Connected` or `Running` and that `autoStart` is set if it should always be available.
+3. Remember discovery is dynamic—no IDE restart is needed. If a server only just started, the agent's next `list_tools` or `filter_tools` call reflects it.
+
+## A workflow runs manually but the agent never uses it
+
+This is the most common workflow-authoring trap, and it's about discoverability, not correctness. The workflow is live: `kubectl get workflow` shows it valid, and you can call it by name. But the agent falls back to raw tools.
+
+The cause is almost always the description. An agent finds a workflow through `filter_tools`, whose description filter is a **case-insensitive substring match** over `spec.description`. If the agent searches for `pod health` and the description only says `check the pods in <mc>`, there's no substring match, and the workflow is invisible to that search.
+
+Fix it by leading `spec.description` with both the topic keyword and the natural phrasing. See [authoring workflows]({{< relref "/tutorials/ai-agents/authoring-workflows" >}}#the-description-also-controls-discoverability) for the full rule.
+
+A related symptom: an agent told to "discover workflows" with a broad glob can pull every workflow's description into context at once, spiking token cost. Steer agents to a **narrow** filter—a specific topic term or name pattern—rather than a catch-all.
+
+## A workflow runs but the agent over-explores
+
+If a workflow returns a clean result and the agent keeps investigating anyway, the description is missing a **stop-when-healthy rule**. Without an explicit rule to write a one-line summary and stop when the result is empty, an agent treats a clean digest as a starting point. Add the rule to `spec.description`; this single change has swung a probe by an order of magnitude in token cost.
+
+## A long chain drops with a network error
+
+A single agent turn that runs many tool calls back to back can drop with a streaming network error before producing an answer—the HTTP response succeeds, but the stream aborts partway. Fewer, cheaper calls reduce this exposure, which is one more reason to encapsulate multi-step investigations as a [workflow]({{< relref "/tutorials/ai-agents/authoring-workflows" >}}) rather than letting the agent run the whole discover-query-correlate loop itself.
+
+## Authentication fails for heavily-grouped users
+
+If a user can authenticate from one account but fails from one that belongs to many identity-provider groups, suspect token size limits: ingress header buffers and the group-count limit. See [RBAC and SSO]({{< relref "/tutorials/ai-agents/access-control" >}}#large-tokens).
+
+## Related
+
+- [Author a workflow]({{< relref "/tutorials/ai-agents/authoring-workflows" >}}): discoverability and stop-when-healthy rules.
+- [Manage MCP servers]({{< relref "/tutorials/ai-agents/managing-mcp-servers" >}}): server states and `autoStart`.
+- [Security model]({{< relref "/overview/ai-agents/security" >}}): per-user visibility and sign-out operations.


### PR DESCRIPTION
## Summary

Adds an `overview/ai-agents/` concept section, a `tutorials/ai-agents/` how-to section, a `reference/muster/` CLI-and-resource reference, and a customer-facing **developer portal AI chat** page to docs.giantswarm.io, documenting how AI agents work on the platform via **Muster** as an MCP gateway.

### Concept pages (`overview/ai-agents/`)

- **`_index.md`** — section overview and the pieces (Muster, mcp-kubernetes, mcp-prometheus, the assistant).
- **`introduction/`** — what Muster is and the MCP-server-sprawl problem it solves.
- **`architecture/`** — the central `muster serve` aggregator exposing one OAuth-protected MCP endpoint that IDEs connect to **directly**, `muster agent` as an optional local bridge, fleet-wide aggregation, and the workflow token-cost win (A/B figures, framed as illustrative).
- **`meta-tools/`** — the 11 meta-tools, the `x_`/`core_`/`workflow_` tool-name prefixes, lazy discovery, and the **Muster 0.9.0** `filter_tools` discovery tier (BM25-ranked `query` with a relevance `score`, a `labels` facet, and bounded summary pages: `limit` default 5, `offset`, `total`, `truncated`, one-line `summary`, `include_schema` default false).
- **`security/`** — OAuth 2.1 + PKCE, per-user tool visibility keyed on the OAuth subject, SSO via token forwarding vs RFC 8693 exchange, and the logout operations.

### Developer portal page (`overview/developer-portal/ai-chat/`)

- **`ai-chat/`** — the built-in portal AI chat: what it is, example questions, how it connects to the central Muster (aggregating per-cluster `mcp-kubernetes` and `mcp-prometheus`), per-user access/security, and current limitations.

### How-to tutorials (`tutorials/ai-agents/`)

Platform-team-facing guides for operating Muster:

- **`authoring-workflows/`** — write a `Workflow` resource that packages a multi-step operation into one `workflow_<name>` tool: **0.8.0 control flow** (`forEach`, `parallel`, `onFailure`, `condition.template`), templating roots, conditions, and the **0.10.0 result model** (per-step `output` flag with `store` as the deprecated alias, the workflow-level `spec.output` projection, and the unified condition `jsonPath` navigator).
- **`saving-tokens-with-workflows/`** — the token-economics case for workflows (one `workflow_<name>` call vs N agent round-trips, with the lab A/B figures framed as illustrative), and the design rules that maximize the saving: lead with the `spec.output` projection as the strongest token lever, then per-step `output`, `forEach`/`parallel` fan-out, conditions, and a lean discoverable `spec.description`.
- **`managing-mcp-servers/`** — add and configure downstream servers with `MCPServer` resources: stdio and remote transports, tool prefixes, server families, autostart, and authentication.
- **`connecting-custom-mcp-servers/`** — bring third-party/internal servers behind the gateway, including ones that don't publish RFC 9728 metadata, via the `authorizationServer` override.
- **`multi-cluster-access/`** — expose a fleet through one central Muster, the instance-selection argument contract, and RFC 8693 token exchange for cross-cluster SSO.
- **`access-control/`** — map identity-provider groups to Kubernetes RBAC so agents act with each user's own permissions; handle large tokens and group limits.
- **`troubleshooting/`** — common Muster failure modes: auth loops, disconnected clusters, missing tools, and workflows agents can't find.

The `tutorials/ai-agents/` index now routes between **operating the managed platform** (the guides above) and **self-hosting your own Muster**. The three self-hosting guides moved into a dedicated `self-hosting/` subsection with its own landing page, and every `relref` to the moved pages was updated. Each tutorial gained an "Applies to" callout naming its audience.

#### Self-hosting (`tutorials/ai-agents/self-hosting/`)

- **`deploy-muster/`** — install the `muster-crds` and `muster` Helm charts (CRD chart first), run the aggregator in custom-resource discovery mode, and expose the endpoint via Ingress or Gateway API.
- **`oauth-setup/`** — protect the endpoint with the resource-server role against Dex, configure the client-proxy role for downstream auth, provide secrets, choose token storage, and handle client registration and large enterprise tokens.
- **`multi-mc-token-exchange/`** — bridge single sign-on to remote management clusters with RFC 8693 token exchange.

### Reference (`reference/muster/`)

A lookup-grade reference section:

- **`_index.md`** — the section hub linking the CLI, meta-tools, and custom-resource references.
- **`cli/`** — per-command reference for the `muster` CLI (`serve`, `agent`, `auth`, `context`, `call`, `check`, `create`, `get`, `list`, `start`, `stop`, `events`, `standalone`, `self-update`, `version`).
- **`meta-tools.md`** — the full argument and response schema for each meta-tool.
- **`crds.md`** — the `MCPServer` and `Workflow` custom-resource field references (`v1alpha1`).

### Getting-started reconciliation

- `getting-started/ai-agent-setup/` is reconciled with the new concept pages so the entry-point tutorial no longer contradicts them on how to connect. It now **leads with Claude Code**, then Cursor and VS Code, and uses **direct URL connection** as the recommended setup (paste the endpoint URL; the client runs the OAuth flow itself). A dedicated **Claude Code** subsection covers `claude mcp add` and a stdio-bridge variant. `muster agent` is demoted to a clearly labeled **fallback** for clients that can't reach a remote OAuth MCP server.
- The bridge-centric ASCII diagram in "How it works" is replaced with a mermaid diagram of the direct connection. The steps are restructured: connect the editor directly → optional `muster` CLI for `auth`/`context` and verification → the local bridge as a fallback. Session-management wording is generalized from "the agent" to the editor or bridge, and a named identity in the forbidden-error example is replaced with a `<user>` placeholder.
- The page also gains pointers to the new overview, security, developer-portal, and CLI-reference pages, and a fix to an unclosed code fence.
- The `introduction` "workflow" link now points to the architecture workflows section (the conceptual home) instead of the meta-tools page.

### Review feedback addressed

A follow-up round reworked client coverage and tutorial structure based on review feedback:

- **Lead with Claude Code.** The getting-started guide, the `overview/ai-agents/` lists, and the architecture page now name Claude Code first (then Cursor, VS Code, the portal chat, and other MCP-capable tools). A new **Claude Code** setup subsection shows `claude mcp add --transport http` and a `muster agent` stdio-bridge variant.
- **Use the Muster URL in any MCP tool.** A new **"Connect from other MCP tools"** section explains that the endpoint is a standard remote, OAuth-protected MCP server, so it works anywhere remote MCP + OAuth is supported — Claude.ai / Claude Desktop, ChatGPT, and any other MCP client (with the `muster agent` bridge or `mcp-remote` for stdio-only clients).
- **`stdio` is local-only.** `managing-mcp-servers/` now calls out that a `stdio` server runs inside the Muster process or pod, so it fits a local Muster only; on the managed platform or a self-hosted Kubernetes Muster, downstream servers must use the remote transports (`streamable-http` / `sse`).
- **Managed platform vs self-hosting split.** The three self-hosting guides moved under a new `tutorials/ai-agents/self-hosting/` subsection with a landing page; the section index routes between operating the managed platform and self-hosting your own Muster, and each page gained an "Applies to" callout.

## Notes

- **Accuracy:** every factual claim was verified against the `giantswarm/muster` source at the **`v0.10.0`** tag — the workflow and `MCPServer` field references are grounded in the `v1alpha1` CRD types, control flow against the 0.8.0 implementation, the discovery tier against 0.9.0, and the result model against 0.10.0. `mcp-prometheus` is documented alongside `mcp-kubernetes` and matches the actual `deploy-mcp-kubernetes` deployment config (family naming, instance selection, token exchange).
- **Connection model:** direct-URL connection is documented as the default across the concept pages **and** the getting-started tutorial; `muster agent` is the optional fallback for clients that can't.
- **Trial figures:** the workflow A/B numbers are framed as illustrative of the *shape* of the saving (durable ratios) rather than guaranteed absolute costs, since dollar figures depend on the model and its pricing.
- **Navigation:** the concept and tutorial pages cross-link into the `reference/muster/` section so it's reachable from the prose, not only the section nav.
- **Public-facing:** placeholders only (`<management-cluster>`, `<workload-cluster>`, `<base-domain>`, `<user>`); no customer/installation details.
- **Vale/reviewdog:** added-line findings kept under the annotation cap (mermaid blocks wrapped in `vale off`/`vale on`, prose split/simplified). `Microsoft.Acronyms` disabled in `.vale.ini` for the technical audience.
- Owner is `team-bumblebee`; cross-links point only to existing pages so the build stays green.

## Test plan

- [x] `markdownlint`, `vale`, and `frontmatter-validator` pre-commit hooks pass (including after the self-hosting moves and feedback edits)
- [x] Local Hugo build renders all concept, tutorial, and reference pages, nav ordering, code highlighting, and mermaid diagrams; all internal `relref` links resolve after the page moves
- [x] CI green on the PR (`vale`, `validate`, CircleCI build/test/registry/catalog)

Made with [Cursor](https://cursor.com)


