### PR TITLE
docs: improve readability of authentication overview

### DIFF
--- a/src/content/overview/architecture/authentication/index.md
+++ b/src/content/overview/architecture/authentication/index.md
@@ -9,8 +9,8 @@ menu:
 user_questions:
   - What are the authentication and authorization mechanisms in the Giant Swarm platform?
 owner:
-  - https://github.com/orgs/giantswarm/teams/team-bigmac
-last_review_date: 2024-07-17
+  - https://github.com/orgs/giantswarm/teams/team-shield
+last_review_date: 2026-06-22
 ---
 
 During the management cluster installation, Giant Swarm sets up authentication and authorization mechanisms to secure access to the platform. These mechanisms ensure that only authorized users can interact with the platform and its resources.
@@ -19,38 +19,38 @@ During the management cluster installation, Giant Swarm sets up authentication a
 
 ### Authentication: Platform API
 
-The platform API is a Kubernetes API that operates on the management cluster. To allow access to the platform API, Giant Swarm sets up a [dex](https://github.com/giantswarm/dex-app) instance in the management cluster, configured with some default connectors that grant our staff access and additional connectors that can be configured by the customer.
+The platform API is a Kubernetes API that operates on the management cluster. To grant access to it, Giant Swarm sets up a [dex](https://github.com/giantswarm/dex-app) instance in the management cluster. This instance comes with **default connectors** that grant our staff access, plus **additional connectors** that you can configure yourself.
 
 Dex acts as a portal to other identity providers (idP) through connectors. The supported connectors are [listed in the official dex documentation](https://dexidp.io/docs/connectors/) and we can walk you through the setup of any of them.
 
 ### Authorization: Platform API
 
-We utilize Kubernetes-native RBAC to control access to resources in the platform API. Resources are segregated into organizations, each represented by a dedicated namespace, enabling improved access control. This approach allows for fine-grained permissions at both the organization and namespace levels. For more detailed information on this topic, you can refer to our comprehensive [multi-tenancy documentation]({{< relref "/overview/fleet-management/multi-tenancy" >}}).
+We use Kubernetes-native RBAC to control access to resources in the platform API. Resources are segregated into organizations, each represented by a dedicated namespace. This gives you **fine-grained permissions** at both the organization and namespace levels. For more detail, see our [multi-tenancy documentation]({{< relref "/overview/fleet-management/multi-tenancy" >}}).
 
 ### Observability
 
-The platform API provides read access to the observability tools, like the Grafana instance running the management cluster, so that you can browse across the data collected in your managed clusters and any additional data you choose to push to the platform. For more detailed information on this topic, you can refer to our comprehensive [grafana organization documentation]({{< relref "/overview/observability/configuration/multi-tenancy/creating-grafana-organization" >}}).
+The platform API provides read access to the observability tools, like the Grafana instance running on the management cluster. This lets you browse the data collected in your managed clusters, plus any additional data you choose to push to the platform. For more detail, see our [Grafana organization documentation]({{< relref "/overview/observability/configuration/multi-tenancy/creating-grafana-organization" >}}).
 
-## Workload Cluster
+## Workload cluster
 
-### Authentication: Workload Cluster
+### Authentication: Workload cluster
 
-For the workload cluster - where you run your applications - we don't enforce any specific OpenID Connect (OIDC) tool to enable single sign-on (SSO). However, if you wish to implement SSO for accessing your workload cluster, we provide a detailed guide on how to configure Dex for this purpose, you can follow our comprehensive guide: [Configure OIDC using Dex to access your clusters]({{< relref "/tutorials/access-management/configure-dex-in-your-cluster/" >}}).
+For the workload cluster—where you run your applications—we don't enforce any specific OpenID Connect (OIDC) tool to enable single sign-on (SSO). However, if you want to implement SSO for your workload cluster, we provide a detailed guide: [Configure OIDC using Dex to access your clusters]({{< relref "/tutorials/access-management/configure-dex-in-your-cluster/" >}}).
 
-### Authorization: Workload Cluster
+### Authorization: Workload cluster
 
 We provide managed apps and tools designed to simplify and automate RBAC configuration for your workload cluster.
 
-One of the key tools we offer is the [rbac-bootstrap-app](https://github.com/giantswarm/rbac-bootstrap-app). This app allows you to create role bindings directly from the management cluster on the workload cluster. This centralized approach simplifies RBAC management across multiple clusters.
+One of the key tools we offer is the [`rbac-bootstrap-app`](https://github.com/giantswarm/rbac-bootstrap-app). This app lets you create role bindings on the workload cluster directly from the management cluster. This centralized approach simplifies RBAC management across multiple clusters.
 
 When implementing authorization for your workload cluster, consider the following best practices:
 
 - Implement the principle of least privilege: Assign the minimum necessary permissions to users and groups.
 - Frequently review and audit permissions to ensure they remain appropriate.
 - Use group-based access control where possible for easier management.
-- Leverage OIDC integration for enhanced security and simplified user management.
+- Use OIDC integration for enhanced security and simplified user management.
 
-Utilizing these tools and following best practices allows you to create a secure, manageable, and flexible authorization system for your workload cluster that meets your organization's specific needs and security requirements.
+Using these tools and following these best practices, you can create a secure, manageable, and flexible authorization system for your workload cluster. It will meet your organization's specific needs and security requirements.
 
 ## We're here to help
 


### PR DESCRIPTION
### What this PR does / why we need it

Improves the readability of the [Authentication overview page](src/content/overview/architecture/authentication/index.md), #8 on the readability difficulty list (Flesch-Kincaid grade 13.2). This page had genuine prose bloat.

Changes:

- Cut wordy hedges — the repeated "For more detailed information on this topic, you can refer to our comprehensive ..." became "For more detail, see our ...".
- Replaced "utilize" / "Utilizing" / "Leverage" with plainer verbs.
- Split several 30+ word sentences and fixed a comma splice in the workload-cluster SSO paragraph.
- Resolved Vale findings: `rbac` → `RBAC` (wrapped the `rbac-bootstrap-app` name in backticks), and sentence-cased the "Workload cluster" headings.
- Capitalized "Grafana" in a link title and fixed "running the management cluster" → "running on the management cluster".

| Metric | Before | After |
|--------|--------|-------|
| Flesch Reading Ease | 26.5 | 30.7 |
| Flesch-Kincaid Grade | 13.2 | 12.1 |
| Gunning Fog | 16.7 | 15.4 |
| LIX | 53.2 | 50.5 |

Vale reports no findings. No meaning or detail was changed or removed.

Also updates the page `owner` from `team-bigmac` (no longer exists) to `team-shield`.

### Things to check/remember before submitting

- [x] Bumped `last_review_date` in the front matter to 2026-06-22.