### PR TITLE
docs(ai-agents): document workflow _debug envelope escape hatch (muster#877)

### DIFF
--- a/src/content/tutorials/ai-agents/authoring-workflows/index.md
+++ b/src/content/tutorials/ai-agents/authoring-workflows/index.md
@@ -9,7 +9,7 @@ menu:
     identifier: tutorials-ai-agents-authoring-workflows
 owner:
   - https://github.com/orgs/giantswarm/teams/team-bumblebee
-last_review_date: 2026-06-20
+last_review_date: 2026-06-23
 user_questions:
   - How do I author a Muster workflow?
   - What fields does a Muster Workflow support?
@@ -131,6 +131,20 @@ spec:
 The projection **preserves JSON types**. A leaf's type comes from the value it evaluates to, not from how the rendered text looks. A single bare reference like `{{ .results.not_running.items }}` keeps its real type, so an array stays an array. A `{{ len ... }}` leaf is a number. A leaf that mixes literal text with an action, such as `"cluster {{ .input.management_cluster }}"`, renders to a string. Values whose form matters survive without coercion, including leading zeros, versions, and IDs like `08` and `1.20`.
 
 When `spec.output` is declared, the per-step `output` and `store` flags no longer affect the returned document. The projection defines it in full. Muster logs a one-line warning naming any flags it made inert. Drop those flags, or drop the projection. The projection is the strongest token lever a workflow has, since it returns a small, shaped payload instead of the full step envelope.
+
+A projection render error no longer discards the step results that already succeeded. Because the projection renders with `missingkey=error`, a single bad reference (a typo, or a field that's absent on some runs) fails the render after every step has already run. The workflow still fails loud—the error is returned and the result is flagged as an error—but the response now carries the full envelope with **every** recorded step result plus an `output_error` message describing the render failure. The underlying data stays recoverable, so you can see what each step returned and fix the projection without re-running the workflow.
+
+### Inspect a projection with `_debug`
+
+A projection deliberately hides the step envelope, which is exactly what you don't want while you're debugging the projection itself. Rather than temporarily deleting the projection to see what each step returned, pass the reserved `_debug: true` execution argument:
+
+```bash
+muster call workflow_pod-health --arg management_cluster=my-cluster-mcp-kubernetes --arg _debug=true
+```
+
+In debug mode the response is the full envelope (`execution_id`, `status`, and `steps[]` with **every** recorded step result, not just the `output: true` ones), and the rendered projection rides along under `output`. Default execution still returns only the projection, so this is purely an inspection escape hatch.
+
+`_debug` is a reserved argument the executor strips before validation and step execution. It never collides with a workflow's own `args` and is never passed through to a step's tool, so you can add it to any workflow execution without declaring it. It applies to non-projection workflows too: there it forces the default envelope to surface every step result regardless of each step's `output` flag.
 
 ### `allowFailure: true` for legitimately optional steps
 

--- a/src/content/tutorials/ai-agents/saving-tokens-with-workflows/index.md
+++ b/src/content/tutorials/ai-agents/saving-tokens-with-workflows/index.md
@@ -9,7 +9,7 @@ menu:
     identifier: tutorials-ai-agents-saving-tokens-with-workflows
 owner:
   - https://github.com/orgs/giantswarm/teams/team-bumblebee
-last_review_date: 2026-06-20
+last_review_date: 2026-06-23
 user_questions:
   - Why do workflows make my AI agent cheaper?
   - How much do Muster workflows reduce token cost?
@@ -69,6 +69,8 @@ spec:
 ```
 
 The projection can read every step result through `{{ .results.<id>.<field> }}`, so you pull just the fields that matter and drop everything else. The projection preserves JSON types, so a bare reference stays an array and a `{{ len ... }}` leaf stays a number. When you declare it, the per-step flags below no longer shape the returned document, and Muster logs a one-line warning naming any flag it made inert. See [shape the response with `spec.output`]({{< relref "/tutorials/ai-agents/authoring-workflows" >}}#shape-the-response-with-specoutput) for the full schema.
+
+Keeping the response this tight costs nothing when you need to debug: pass `_debug: true` on a single execution to see the full envelope and every step result alongside the projection, without widening what production callers receive. See [inspect a projection with `_debug`]({{< relref "/tutorials/ai-agents/authoring-workflows" >}}#inspect-a-projection-with-_debug).
 
 Without a projection, the per-step `output` flag is the next lever. Set `output: true` only on the steps whose data the agent actually needs to read. A step without it still runs, and later steps can still read its result, but Muster keeps only its status in the returned document and drops the payload. `store: true` is the deprecated, older name for `output: true`: it still works but logs a warning, so prefer `output`.
 


### PR DESCRIPTION
## Summary

Documents the workflow result-model escape hatch shipped in [muster#877](https://github.com/giantswarm/muster/pull/892), completing the docs portion of epic giantswarm/giantswarm#36942.

- **Author a workflow**: new `Inspect a projection with _debug` subsection covering the reserved `_debug: true` execution argument (returns the full envelope plus the projection under `output`, stripped before validation/step execution, works on non-projection workflows too), plus a note that a projection render error no longer discards successful step results (the response carries every step result plus an `output_error`).
- **Save agent tokens with workflows**: cross-reference so authors know they can inspect a tight projection with `_debug` on a single run without permanently widening the production response.

The two pages already existed (added in #3193); this only adds the #877 behavior that postdated them.

## Test plan

- [x] `pre-commit` (markdownlint, vale, frontmatter-validator) passes on both files
- [ ] Reviewer confirms anchors resolve (`#inspect-a-projection-with-_debug`)

Made with [Cursor](https://cursor.com)