### PR TITLE
docs(ai-agents): rename "output projection" to "output template"

### DIFF
--- a/src/content/changes/ai-agents/muster/v0.10.0.md
+++ b/src/content/changes/ai-agents/muster/v0.10.0.md
@@ -15,7 +15,7 @@ title: muster release v0.10.0
 
 ### Added
 
-- *(workflow)* Decouple referencing from output, add output projection, unify expression language in [#876](https://github.com/giantswarm/muster/pull/876) by [@teemow](https://github.com/teemow)
+- *(workflow)* Decouple referencing from output, add output template, unify expression language in [#876](https://github.com/giantswarm/muster/pull/876) by [@teemow](https://github.com/teemow)
 
 
 **Full Changelog**: https://github.com/giantswarm/muster/compare/v0.9.1...v0.10.0

--- a/src/content/reference/muster/crds.md
+++ b/src/content/reference/muster/crds.md
@@ -145,7 +145,7 @@ spec:
 | `args` | map | Argument schema, keyed by argument name. See [argument definitions](#workflow-args) |
 | `steps` | array | Required, at least one. The execution flow. See [steps](#workflow-step) |
 | `onFailure` | array | Best-effort cleanup sub-steps run when the workflow fails on a step that doesn't allow failure. They run sequentially and tolerate their own failures |
-| `output` | object | Templated projection that shapes the returned document. See [output projection](#workflow-output) |
+| `output` | object | Output template that shapes the returned document. See [output template](#workflow-output) |
 
 ### Argument definitions {#workflow-args}
 
@@ -219,11 +219,11 @@ As of version `0.10.0`, every step result is always referenceable by later steps
 
 The per-step `output` flag controls only whether a result appears in the returned document. `store` is a deprecated alias kept for backward compatibility: it affects visibility only, and a workflow that still uses it logs a one-line deprecation warning on both the structured authoring path and the reconciler. Prefer `output`.
 
-### Output projection {#workflow-output}
+### Output template {#workflow-output}
 
 `spec.output` is a templated object, rendered once after all steps complete, against `.input`, `.results`, and `.vars`. It replaces the default `{execution_id, workflow, status, input, steps[], ...}` envelope, so a workflow can return a small, shaped response. When omitted, the default envelope is returned unchanged.
 
-The projection preserves JSON types: a leaf's type comes from the value it evaluates to, not from how its rendered text looks.
+The output template preserves JSON types: a leaf's type comes from the value it evaluates to, not from how its rendered text looks.
 
 - A bare reference such as `{{ .results.pods.items }}` keeps its original JSON type, so an array stays an array.
 - A computed leaf keeps its result type, so `{{ len .results.events.items }}` is a number.

--- a/src/content/tutorials/ai-agents/authoring-workflows/index.md
+++ b/src/content/tutorials/ai-agents/authoring-workflows/index.md
@@ -25,7 +25,7 @@ This guide documents what the engine implements. Write against these fields and 
 
 A workflow is an ordered list of steps that Muster runs server-side, returning one JSON document. Top-level steps run **sequentially**, but a step isn't always a single tool call. Each top-level step is exactly one of a plain `tool` call, a `forEach` loop, or a `parallel` group. A workflow-level `onFailure` block can run best-effort cleanup when a step fails. Design every workflow around one fact: it collapses many agent round-trips into a single call, and its response cost is the sum over everything it returns.
 
-Every step's result is **always** available to later steps and the response projection through `{{ .results.<id>.<field> }}`. That holds regardless of any flag. You separately control what the *agent* sees back. The per-step `output` flag picks which step results land in the returned document. The workflow-level `spec.output` projection replaces that document with a shape you define.
+Every step's result is **always** available to later steps and the output template through `{{ .results.<id>.<field> }}`. That holds regardless of any flag. You separately control what the *agent* sees back. The per-step `output` flag picks which step results land in the returned document. The workflow-level `spec.output` template replaces that document with a shape you define.
 
 > Control flow (`forEach`, `parallel`, `onFailure`, and template conditions) requires Muster 0.8.0 or later. Plain sequential `tool` steps work on every version.
 
@@ -102,7 +102,7 @@ Each entry in `spec.args` is typed (`string`, `integer`, `boolean`, `number`, `o
 
 ### `output: true` selects what the agent sees
 
-Every step result is recorded. Later steps and the response projection can read it through `{{ .results.<id>.<field> }}`, with or without a flag. The per-step `output` flag controls one thing: whether the step's data lands in the document the agent receives. Without it, Muster emits only `{id, tool, status}` for the step and drops the data before the response. Set `output: true` on every step whose data the agent must read. The last step's result is merged into the top level even when you set no flag.
+Every step result is recorded. Later steps and the output template can read it through `{{ .results.<id>.<field> }}`, with or without a flag. The per-step `output` flag controls one thing: whether the step's data lands in the document the agent receives. Without it, Muster emits only `{id, tool, status}` for the step and drops the data before the response. Set `output: true` on every step whose data the agent must read. The last step's result is merged into the top level even when you set no flag.
 
 The step-level `output` boolean differs from the `output: slim` argument inside `args`. That argument is a tool's own response knob. In the earlier example, `not_running` sets both. `output: slim` trims the Kubernetes payload, and step-level `output: true` returns the trimmed result.
 
@@ -110,7 +110,7 @@ The step-level `output` boolean differs from the `output: slim` argument inside 
 
 ### Shape the response with `spec.output`
 
-For the tightest response, declare a workflow-level `spec.output` projection. It's a templated map, rendered once after every step completes. It **replaces** the default `{execution_id, workflow, status, input, steps[], ...}` envelope with the shape you define. It reads `.input`, `.results`, and `.vars`. Every step result is available to it, no matter how you flag the step.
+For the tightest response, declare a workflow-level `spec.output` template. It's a templated map, rendered once after every step completes. It **replaces** the default `{execution_id, workflow, status, input, steps[], ...}` envelope with the shape you define. It reads `.input`, `.results`, and `.vars`. Every step result is available to it, no matter how you flag the step.
 
 ```yaml
 spec:
@@ -128,23 +128,23 @@ spec:
     cluster: "{{ .input.management_cluster }}"
 ```
 
-The projection **preserves JSON types**. A leaf's type comes from the value it evaluates to, not from how the rendered text looks. A single bare reference like `{{ .results.not_running.items }}` keeps its real type, so an array stays an array. A `{{ len ... }}` leaf is a number. A leaf that mixes literal text with an action, such as `"cluster {{ .input.management_cluster }}"`, renders to a string. Values whose form matters survive without coercion, including leading zeros, versions, and IDs like `08` and `1.20`.
+The output template **preserves JSON types**. A leaf's type comes from the value it evaluates to, not from how the rendered text looks. A single bare reference like `{{ .results.not_running.items }}` keeps its real type, so an array stays an array. A `{{ len ... }}` leaf is a number. A leaf that mixes literal text with an action, such as `"cluster {{ .input.management_cluster }}"`, renders to a string. Values whose form matters survive without coercion, including leading zeros, versions, and IDs like `08` and `1.20`.
 
-When `spec.output` is declared, the per-step `output` and `store` flags no longer affect the returned document. The projection defines it in full. Muster logs a one-line warning naming any flags it made inert. Drop those flags, or drop the projection. The projection is the strongest token lever a workflow has, since it returns a small, shaped payload instead of the full step envelope.
+When `spec.output` is declared, the per-step `output` and `store` flags no longer affect the returned document. The output template defines it in full. Muster logs a one-line warning naming any flags it made inert. Drop those flags, or drop the output template. The output template is the strongest token lever a workflow has, since it returns a small, shaped payload instead of the full step envelope.
 
-A projection render error no longer discards the step results that already succeeded. Because the projection renders with `missingkey=error`, a single bad reference (a typo, or a field that's absent on some runs) fails the render after every step has already run. The workflow still fails loud—the error is returned and the result is flagged as an error—but the response now carries the full envelope with **every** recorded step result plus an `output_error` message describing the render failure. The underlying data stays recoverable, so you can see what each step returned and fix the projection without re-running the workflow.
+An output template render error no longer discards the step results that already succeeded. Because the output template renders with `missingkey=error`, a single bad reference (a typo, or a field that's absent on some runs) fails the render after every step has already run. The workflow still fails loud—the error is returned and the result is flagged as an error—but the response now carries the full envelope with **every** recorded step result plus an `output_error` message describing the render failure. The underlying data stays recoverable, so you can see what each step returned and fix the output template without re-running the workflow.
 
-### Inspect a projection with `_debug`
+### Inspect an output template with `_debug`
 
-A projection deliberately hides the step envelope, which is exactly what you don't want while you're debugging the projection itself. Rather than temporarily deleting the projection to see what each step returned, pass the reserved `_debug: true` execution argument:
+An output template deliberately hides the step envelope, which is exactly what you don't want while you're debugging the output template itself. Rather than temporarily deleting the output template to see what each step returned, pass the reserved `_debug: true` execution argument:
 
 ```bash
 muster call workflow_pod-health --arg management_cluster=my-cluster-mcp-kubernetes --arg _debug=true
 ```
 
-In debug mode the response is the full envelope (`execution_id`, `status`, and `steps[]` with **every** recorded step result, not just the `output: true` ones), and the rendered projection rides along under `output`. Default execution still returns only the projection, so this is purely an inspection escape hatch.
+In debug mode the response is the full envelope (`execution_id`, `status`, and `steps[]` with **every** recorded step result, not just the `output: true` ones), and the rendered output template rides along under `output`. Default execution still returns only the output template, so this is purely an inspection escape hatch.
 
-`_debug` is a reserved argument the executor strips before validation and step execution. It never collides with a workflow's own `args` and is never passed through to a step's tool, so you can add it to any workflow execution without declaring it. It applies to non-projection workflows too: there it forces the default envelope to surface every step result regardless of each step's `output` flag.
+`_debug` is a reserved argument the executor strips before validation and step execution. It never collides with a workflow's own `args` and is never passed through to a step's tool, so you can add it to any workflow execution without declaring it. It applies to workflows with no output template too: there it forces the default envelope to surface every step result regardless of each step's `output` flag.
 
 ### `allowFailure: true` for legitimately optional steps
 

--- a/src/content/tutorials/ai-agents/saving-tokens-with-workflows/index.md
+++ b/src/content/tutorials/ai-agents/saving-tokens-with-workflows/index.md
@@ -58,7 +58,7 @@ A workflow saves tokens by default, but a few choices decide whether you capture
 
 The agent pays for everything the workflow returns, so the returned document is the single biggest token lever you control. By default a workflow returns a full envelope: `execution_id`, `workflow`, `status`, `input`, and a `steps[]` array carrying every step's payload. That array grows with every step, every `forEach` iteration, and every `parallel` sub-step. One unbounded step produces a multi-million-token outlier even when the typical run is small.
 
-The strongest fix is a workflow-level `spec.output` projection. It's a templated map, rendered once after every step completes, that **replaces** the default envelope with the exact shape you define. Instead of the whole `steps[]` array, the agent receives one small digest:
+The strongest fix is a workflow-level `spec.output` template. It's a templated map, rendered once after every step completes, that **replaces** the default envelope with the exact shape you define. Instead of the whole `steps[]` array, the agent receives one small digest:
 
 ```yaml
 spec:
@@ -68,11 +68,11 @@ spec:
     cluster: "{{ .input.management_cluster }}"
 ```
 
-The projection can read every step result through `{{ .results.<id>.<field> }}`, so you pull just the fields that matter and drop everything else. The projection preserves JSON types, so a bare reference stays an array and a `{{ len ... }}` leaf stays a number. When you declare it, the per-step flags below no longer shape the returned document, and Muster logs a one-line warning naming any flag it made inert. See [shape the response with `spec.output`]({{< relref "/tutorials/ai-agents/authoring-workflows" >}}#shape-the-response-with-specoutput) for the full schema.
+The output template can read every step result through `{{ .results.<id>.<field> }}`, so you pull just the fields that matter and drop everything else. The output template preserves JSON types, so a bare reference stays an array and a `{{ len ... }}` leaf stays a number. When you declare it, the per-step flags below no longer shape the returned document, and Muster logs a one-line warning naming any flag it made inert. See [shape the response with `spec.output`]({{< relref "/tutorials/ai-agents/authoring-workflows" >}}#shape-the-response-with-specoutput) for the full schema.
 
-Keeping the response this tight costs nothing when you need to debug: pass `_debug: true` on a single execution to see the full envelope and every step result alongside the projection, without widening what production callers receive. See [inspect a projection with `_debug`]({{< relref "/tutorials/ai-agents/authoring-workflows" >}}#inspect-a-projection-with-_debug).
+Keeping the response this tight costs nothing when you need to debug: pass `_debug: true` on a single execution to see the full envelope and every step result alongside the output template, without widening what production callers receive. See [inspect an output template with `_debug`]({{< relref "/tutorials/ai-agents/authoring-workflows" >}}#inspect-an-output-template-with-_debug).
 
-Without a projection, the per-step `output` flag is the next lever. Set `output: true` only on the steps whose data the agent actually needs to read. A step without it still runs, and later steps can still read its result, but Muster keeps only its status in the returned document and drops the payload. `store: true` is the deprecated, older name for `output: true`: it still works but logs a warning, so prefer `output`.
+Without an output template, the per-step `output` flag is the next lever. Set `output: true` only on the steps whose data the agent actually needs to read. A step without it still runs, and later steps can still read its result, but Muster keeps only its status in the returned document and drops the payload. `store: true` is the deprecated, older name for `output: true`: it still works but logs a warning, so prefer `output`.
 
 Then cap whatever does land in the response:
 


### PR DESCRIPTION
## Summary

Follows giantswarm/muster#895. "Projection" was database/math jargon for what `spec.output` actually is: a **template** that shapes a workflow's returned document. Renames it to **output template** across:

- `tutorials/ai-agents/authoring-workflows` (incl. the `_debug` section heading + anchor)
- `tutorials/ai-agents/saving-tokens-with-workflows` (cross-reference anchor updated to match)
- `reference/muster/crds.md` (the `{#workflow-output}` explicit anchor is preserved, only link/heading text changed)
- `changes/ai-agents/muster/v0.10.0.md`

No behavior change; `spec.output` and the `_debug` escape hatch are unchanged.

## Test plan

- [x] `pre-commit` (markdownlint, vale, frontmatter-validator) passes
- [x] In-page anchors verified (`#inspect-an-output-template-with-_debug`, `#workflow-output`)

Made with [Cursor](https://cursor.com)