### PR TITLE
docs(ai-agents): rename "envelope" to "response" in workflow result model

### DIFF
--- a/src/content/reference/muster/crds.md
+++ b/src/content/reference/muster/crds.md
@@ -221,7 +221,7 @@ The per-step `output` flag controls only whether a result appears in the returne
 
 ### Output template {#workflow-output}
 
-`spec.output` is a templated object, rendered once after all steps complete, against `.input`, `.results`, and `.vars`. It replaces the default `{execution_id, workflow, status, input, steps[], ...}` envelope, so a workflow can return a small, shaped response. When omitted, the default envelope is returned unchanged.
+`spec.output` is a templated object, rendered once after all steps complete, against `.input`, `.results`, and `.vars`. It replaces the default `{execution_id, workflow, status, input, steps[], ...}` response with a small, shaped result of your own. When omitted, the default response is returned unchanged.
 
 The output template preserves JSON types: a leaf's type comes from the value it evaluates to, not from how its rendered text looks.
 

--- a/src/content/tutorials/ai-agents/authoring-workflows/index.md
+++ b/src/content/tutorials/ai-agents/authoring-workflows/index.md
@@ -110,7 +110,7 @@ The step-level `output` boolean differs from the `output: slim` argument inside 
 
 ### Shape the response with `spec.output`
 
-For the tightest response, declare a workflow-level `spec.output` template. It's a templated map, rendered once after every step completes. It **replaces** the default `{execution_id, workflow, status, input, steps[], ...}` envelope with the shape you define. It reads `.input`, `.results`, and `.vars`. Every step result is available to it, no matter how you flag the step.
+For the tightest response, declare a workflow-level `spec.output` template. It's a templated map, rendered once after every step completes. It **replaces** the default `{execution_id, workflow, status, input, steps[], ...}` response with the shape you define. It reads `.input`, `.results`, and `.vars`. Every step result is available to it, no matter how you flag the step.
 
 ```yaml
 spec:
@@ -130,21 +130,21 @@ spec:
 
 The output template **preserves JSON types**. A leaf's type comes from the value it evaluates to, not from how the rendered text looks. A single bare reference like `{{ .results.not_running.items }}` keeps its real type, so an array stays an array. A `{{ len ... }}` leaf is a number. A leaf that mixes literal text with an action, such as `"cluster {{ .input.management_cluster }}"`, renders to a string. Values whose form matters survive without coercion, including leading zeros, versions, and IDs like `08` and `1.20`.
 
-When `spec.output` is declared, the per-step `output` and `store` flags no longer affect the returned document. The output template defines it in full. Muster logs a one-line warning naming any flags it made inert. Drop those flags, or drop the output template. The output template is the strongest token lever a workflow has, since it returns a small, shaped payload instead of the full step envelope.
+When `spec.output` is declared, the per-step `output` and `store` flags no longer affect the returned document. The output template defines it in full. Muster logs a one-line warning naming any flags it made inert. Drop those flags, or drop the output template. The output template is the strongest token lever a workflow has, since it returns a small, shaped payload instead of the full response.
 
-An output template render error no longer discards the step results that already succeeded. Because the output template renders with `missingkey=error`, a single bad reference (a typo, or a field that's absent on some runs) fails the render after every step has already run. The workflow still fails loud—the error is returned and the result is flagged as an error—but the response now carries the full envelope with **every** recorded step result plus an `output_error` message describing the render failure. The underlying data stays recoverable, so you can see what each step returned and fix the output template without re-running the workflow.
+An output template render error no longer discards the step results that already succeeded. Because the output template renders with `missingkey=error`, a single bad reference (a typo, or a field that's absent on some runs) fails the render after every step has already run. The workflow still fails loud—the error is returned and the result is flagged as an error—but the response now carries **every** recorded step result plus an `output_error` message describing the render failure. The underlying data stays recoverable, so you can see what each step returned and fix the output template without re-running the workflow.
 
 ### Inspect an output template with `_debug`
 
-An output template deliberately hides the step envelope, which is exactly what you don't want while you're debugging the output template itself. Rather than temporarily deleting the output template to see what each step returned, pass the reserved `_debug: true` execution argument:
+An output template deliberately hides the full response, which is exactly what you don't want while you're debugging the output template itself. Rather than temporarily deleting the output template to see what each step returned, pass the reserved `_debug: true` execution argument:
 
 ```bash
 muster call workflow_pod-health --arg management_cluster=my-cluster-mcp-kubernetes --arg _debug=true
 ```
 
-In debug mode the response is the full envelope (`execution_id`, `status`, and `steps[]` with **every** recorded step result, not just the `output: true` ones), and the rendered output template rides along under `output`. Default execution still returns only the output template, so this is purely an inspection escape hatch.
+In debug mode you get the full response (`execution_id`, `status`, and `steps[]` with **every** recorded step result, not just the `output: true` ones), and the rendered output template rides along under `output`. Default execution still returns only the output template, so this is purely an inspection escape hatch.
 
-`_debug` is a reserved argument the executor strips before validation and step execution. It never collides with a workflow's own `args` and is never passed through to a step's tool, so you can add it to any workflow execution without declaring it. It applies to workflows with no output template too: there it forces the default envelope to surface every step result regardless of each step's `output` flag.
+`_debug` is a reserved argument the executor strips before validation and step execution. It never collides with a workflow's own `args` and is never passed through to a step's tool, so you can add it to any workflow execution without declaring it. It applies to workflows with no output template too: there it forces the default response to surface every step result regardless of each step's `output` flag.
 
 ### `allowFailure: true` for legitimately optional steps
 

--- a/src/content/tutorials/ai-agents/saving-tokens-with-workflows/index.md
+++ b/src/content/tutorials/ai-agents/saving-tokens-with-workflows/index.md
@@ -56,9 +56,9 @@ A workflow saves tokens by default, but a few choices decide whether you capture
 
 ### Shape a tight response
 
-The agent pays for everything the workflow returns, so the returned document is the single biggest token lever you control. By default a workflow returns a full envelope: `execution_id`, `workflow`, `status`, `input`, and a `steps[]` array carrying every step's payload. That array grows with every step, every `forEach` iteration, and every `parallel` sub-step. One unbounded step produces a multi-million-token outlier even when the typical run is small.
+The agent pays for everything the workflow returns, so the returned document is the single biggest token lever you control. By default a workflow returns a full response: `execution_id`, `workflow`, `status`, `input`, and a `steps[]` array carrying every step's payload. That array grows with every step, every `forEach` iteration, and every `parallel` sub-step. One unbounded step produces a multi-million-token outlier even when the typical run is small.
 
-The strongest fix is a workflow-level `spec.output` template. It's a templated map, rendered once after every step completes, that **replaces** the default envelope with the exact shape you define. Instead of the whole `steps[]` array, the agent receives one small digest:
+The strongest fix is a workflow-level `spec.output` template. It's a templated map, rendered once after every step completes, that **replaces** the default response with the exact shape you define. Instead of the whole `steps[]` array, the agent receives one small digest:
 
 ```yaml
 spec:
@@ -70,7 +70,7 @@ spec:
 
 The output template can read every step result through `{{ .results.<id>.<field> }}`, so you pull just the fields that matter and drop everything else. The output template preserves JSON types, so a bare reference stays an array and a `{{ len ... }}` leaf stays a number. When you declare it, the per-step flags below no longer shape the returned document, and Muster logs a one-line warning naming any flag it made inert. See [shape the response with `spec.output`]({{< relref "/tutorials/ai-agents/authoring-workflows" >}}#shape-the-response-with-specoutput) for the full schema.
 
-Keeping the response this tight costs nothing when you need to debug: pass `_debug: true` on a single execution to see the full envelope and every step result alongside the output template, without widening what production callers receive. See [inspect an output template with `_debug`]({{< relref "/tutorials/ai-agents/authoring-workflows" >}}#inspect-an-output-template-with-_debug).
+Keeping the response this tight costs nothing when you need to debug: pass `_debug: true` on a single execution to see the full response and every step result alongside the output template, without widening what production callers receive. See [inspect an output template with `_debug`]({{< relref "/tutorials/ai-agents/authoring-workflows" >}}#inspect-an-output-template-with-_debug).
 
 Without an output template, the per-step `output` flag is the next lever. Set `output: true` only on the steps whose data the agent actually needs to read. A step without it still runs, and later steps can still read its result, but Muster keeps only its status in the returned document and drops the payload. `store: true` is the deprecated, older name for `output: true`: it still works but logs a warning, so prefer `output`.
 


### PR DESCRIPTION
## Summary

Follows giantswarm/muster#896. "Envelope" was jargon for the default workflow **response** document (`{execution_id, status, steps[], ...}`). Renamed to "response" across the author/token-saving tutorials and the CRD reference. No behavior change.

## Test plan

- [x] `pre-commit` (markdownlint, vale, frontmatter-validator) passes

Made with [Cursor](https://cursor.com)