### PR TITLE
chore: replace decommissioned giantswarmpublic.azurecr.io registry

### DIFF
--- a/src/content/overview/security/domain-allowlist/index.md
+++ b/src/content/overview/security/domain-allowlist/index.md
@@ -10,7 +10,7 @@ user_questions:
 aliases:
   - /vintage/platform-overview/security/cluster-security/domain-allowlist/
   - /platform-overview/security/cluster-security/domain-allowlist
-last_review_date: 2025-10-03
+last_review_date: 2026-06-25
 owner:
   - https://github.com/orgs/giantswarm/teams/team-teddyfriends
 ---
@@ -28,7 +28,6 @@ List of the external domains we require access to for our clusters to function.
 - `azurecr.io`
     - domains:
         - `giantswarm.azurecr.io`
-        - `giantswarmpublic.azurecr.io`
         - `gsoci.azurecr.io`
         - `gsociprivate.azurecr.io`
         - `.blob.core.windows.net`

--- a/src/content/reference/kubectl-gs/gitops/add-update.md
+++ b/src/content/reference/kubectl-gs/gitops/add-update.md
@@ -6,7 +6,7 @@ weight: 35
 menu:
   principal:
     parent: kubectlgs-gitops
-last_review_date: 2026-06-08
+last_review_date: 2026-06-25
 owner:
   - https://github.com/orgs/giantswarm/teams/team-honeybadger
 user_questions:
@@ -74,7 +74,7 @@ kubectl gs gitops add automatic-update \
   --organization demoorg \
   --workload-cluster demowc \
   --app hello-world \
-  --version-repository giantswarmpublic.azurecr.io/giantswarm-catalog/hello-world \
+  --version-repository gsoci.azurecr.io/charts/giantswarm/hello-world \
   --repository gitops-demo \
   --dry-run
 ```
@@ -132,7 +132,7 @@ kind: ImageRepository
 metadata:
   name: demowc-hello-world
 spec:
-  image: giantswarmpublic.azurecr.io/giantswarm-catalog/hello-world
+  image: gsoci.azurecr.io/charts/giantswarm/hello-world
   interval: 10m0s
 
 
@@ -177,7 +177,7 @@ kubectl gs gitops add automatic-update \
   --organization demoorg \
   --workload-cluster demowc \
   --app hello-world \
-  --version-repository giantswarmpublic.azurecr.io/giantswarm-catalog/hello-world \
+  --version-repository gsoci.azurecr.io/charts/giantswarm/hello-world \
   --repository gitops-demo \
   --dry-run
 ```


### PR DESCRIPTION
### What this PR does / why we need it

The registry `giantswarmpublic.azurecr.io` hosted the Giant Swarm Helm chart catalogs and has been decommissioned. Chart catalogs are now consolidated onto `oci://gsoci.azurecr.io/charts/giantswarm/<chart>`. This PR updates the docs to reference the new registry.

Changes:

- `src/content/reference/kubectl-gs/gitops/add-update.md`: replace the demo `--version-repository` and `image:` references with `gsoci.azurecr.io/charts/giantswarm/hello-world` (the demo chart is named `hello-world` on the new registry).
- `src/content/overview/security/domain-allowlist/index.md`: remove the now-defunct `giantswarmpublic.azurecr.io` allowlist entry under `azurecr.io`. `gsoci.azurecr.io` and the other entries remain intact.

### Things to check/remember before submitting

- Bumped `last_review_date` in the front matter of both touched pages.
