### PR TITLE
feat: add diataxis_content_type column to export-csv

### DIFF
--- a/.claude/skills/export-csv/SKILL.md
+++ b/.claude/skills/export-csv/SKILL.md
@@ -16,6 +16,8 @@ A helper script does the work in code — don't assemble the inventory by hand.
 A CSV file (`export.csv` by default) with one row per page and these columns:
 
 - `title` — from the page's frontmatter
+- `diataxis_content_type` — the page's Diátaxis type (`tutorial`, `how-to-guide`,
+  `reference`, `explanation`, or `none`); empty for list pages and untagged pages
 - `path_l1` through `path_l6` — the first six URL path segments, i.e. the
   navigation hierarchy
 - `url` — the public docs URL (`https://docs.giantswarm.io/<relpath>`)

--- a/.claude/skills/export-csv/export_csv.py
+++ b/.claude/skills/export-csv/export_csv.py
@@ -35,6 +35,7 @@ def export_paths(paths):
         writer = csv.writer(csvfile, quoting=csv.QUOTE_MINIMAL)
         writer.writerow([
             'title',
+            'diataxis_content_type',
             'path_l1', 'path_l2', 'path_l3', 'path_l4', 'path_l5', 'path_l6',
             'url',
         ])
@@ -48,6 +49,7 @@ def export_paths(paths):
 
             writer.writerow([
                 frontmatter['title'],
+                frontmatter.get('diataxis_content_type', ''),
                 path_level(relpath, 0),
                 path_level(relpath, 1),
                 path_level(relpath, 2),


### PR DESCRIPTION
### What this PR does / why we need it

Extends the `export-csv` skill to include each page's Diátaxis type, so the docs inventory can be filtered and pivoted by type in a spreadsheet (e.g. "all explanation pages", or "tutorials per topic area").

- Adds a `diataxis_content_type` column to `export.csv`, right after `title` — read straight from frontmatter.
- Empty for `_index.md` list pages and untagged/out-of-scope pages.
- Updates the skill doc to describe the new column.

Verified locally: the column populates from the merged backfill (how-to-guide 83, reference 78, explanation 41, tutorial 3, empty for list/untagged pages).

### Things to check/remember before submitting

- No content pages touched — only the export-csv helper script and its SKILL.md.
- Follow-up (separate PR): extend `export-to-miro` to color/label boxes by type, consuming this column.