### PR TITLE
feat: color export-to-miro boxes by Diátaxis type

### DIFF
--- a/.claude/skills/export-to-miro/SKILL.md
+++ b/.claude/skills/export-to-miro/SKILL.md
@@ -12,9 +12,21 @@ produces), create one box per row on a Miro board.
 
 Each box is **three independent items**:
 
-1. a `SHAPE` — the bordered rectangle (the box; no text)
+1. a `SHAPE` — the bordered rectangle (the box; no text). Its **border color encodes the
+   page's Diátaxis type** when the CSV has a `diataxis_content_type` column (as the
+   `export-csv` skill now produces)
 2. a `TEXT` — the page **title**, larger font (size 16), as a link to the `url`
 3. a `TEXT` — the **navigation path** (`path_l*` joined by `/`), smaller (size 11), gray
+
+Border colors (matching the SIG Docs Diátaxis deck palette):
+
+| Type | Border |
+|---|---|
+| `tutorial` | teal `#0D9488` |
+| `how-to-guide` | blue `#2563EB` |
+| `reference` | purple `#7C3AED` |
+| `explanation` | amber `#D97706` |
+| `none` / untagged / no column | default `--border` (`#4A6FF3`) |
 
 Two text items are needed because a single Miro item supports only **one** font
 size (see gotchas). A helper script generates the layout DSL deterministically —
@@ -40,7 +52,8 @@ tool.
    because a single `layout_create` call has a ~50k-char DSL limit. Run with
    `-h` for layout options (columns, spacing, box size, fonts, colors). The
    defaults are the agreed design: box 420×120, title size 16, path size 11
-   gray (`#6B7280`), 8 columns.
+   gray (`#6B7280`), 8 columns, and box borders colored by Diátaxis type (read
+   from the `diataxis_content_type` column; `--type-col` to change it).
 
 2. **Create the boxes — delegate to subagents.** Each chunk's `dsl` argument is
    large (tens of KB), and `layout_create` returns an even larger response. To

--- a/.claude/skills/export-to-miro/generate_miro_dsl.py
+++ b/.claude/skills/export-to-miro/generate_miro_dsl.py
@@ -44,6 +44,16 @@ def esc(s):
     return html.escape((s or "").strip(), quote=True)
 
 
+# Border color per Diátaxis type (matches the SIG Docs Diátaxis deck palette).
+# Pages with no type, `none`, or an unknown value fall back to --border.
+QUADRANT_COLORS = {
+    "tutorial": "#0D9488",      # teal
+    "how-to-guide": "#2563EB",  # blue
+    "reference": "#7C3AED",     # purple
+    "explanation": "#D97706",   # amber
+}
+
+
 def main():
     ap = argparse.ArgumentParser(description="Generate Miro layout DSL from a CSV.")
     ap.add_argument("csv_path")
@@ -70,6 +80,8 @@ def main():
     ap.add_argument("--max-chars", type=int, default=44000)
     ap.add_argument("--title-col", default="title")
     ap.add_argument("--url-col", default="url")
+    ap.add_argument("--type-col", default="diataxis_content_type",
+                    help="column holding the Diátaxis type; boxes are bordered by type when the column is present")
     args = ap.parse_args()
 
     with open(args.csv_path, newline="") as f:
@@ -103,12 +115,14 @@ def main():
         title = esc(r.get(args.title_col, ""))
         url = (r.get(args.url_col, "") or "").strip()
         path = esc("/".join(p for p in (r.get(c, "") for c in path_cols) if p and p.strip()))
+        # Color the border by Diátaxis type; fall back to --border for none/unknown/missing.
+        border = QUADRANT_COLORS.get((r.get(args.type_col, "") or "").strip(), args.border)
 
         # Single-quoted href is REQUIRED — double quotes would clash with the
         # double-quoted DSL content string and Miro would strip the link.
         lines.append(
             f"b{i}box SHAPE x={cx} y={cy} w={args.box_width} h={args.box_height} "
-            f"type=rectangle fill=#FFFFFF border_color={args.border} "
+            f"type=rectangle fill=#FFFFFF border_color={border} "
             f'size=12 valign=middle align=left ""'
         )
         lines.append(


### PR DESCRIPTION
### What this PR does / why we need it

Extends the `export-to-miro` skill to **color-code each box by its Diátaxis type**, completing the Diátaxis export tooling (the `export-csv` column landed in #3224).

- Box border color is driven by the `diataxis_content_type` CSV column, using the SIG Docs deck palette: `tutorial` = teal `#0D9488`, `how-to-guide` = blue `#2563EB`, `reference` = purple `#7C3AED`, `explanation` = amber `#D97706`.
- Pages with `none`, an unknown value, or no column keep the default border — so the script stays backward-compatible with CSVs that lack the column.
- Adds a `--type-col` option; updates the skill doc with the palette legend.

This makes a board show the Diátaxis distribution at a glance and surfaces mis-typed clusters.

### Things to check/remember before submitting

- No content pages touched — only the export-to-miro helper script and its SKILL.md.
- Verified locally end-to-end: generated `export.csv`, ran the generator, and confirmed border colors match the type distribution (teal 3, blue 83, purple 78, amber 41, default 57).