### PR TITLE
fix(docs): remove broken relref to unmerged App CR deprecation page

### DIFF
--- a/src/content/getting-started/install-an-application/index.md
+++ b/src/content/getting-started/install-an-application/index.md
@@ -20,7 +20,7 @@ user_questions:
 
 Giant Swarm runs Flux on every management cluster, and Flux HelmRelease is the recommended way to deploy applications to your workload clusters. This guide walks you through installing a hello-world demo and exposing it through Envoy Gateway (the Giant Swarm default for ingress traffic) with a Gateway API `HTTPRoute`.
 
-**Note:** If you have existing deployments using the legacy Giant Swarm `App` custom resource, see [App CR deprecation]({{< relref "/overview/fleet-management/app-management/app-cr-deprecation" >}}) for the migration path. For new deployments, follow this guide.
+**Note:** If you have existing deployments using the legacy Giant Swarm `App` custom resource, migration guidance is coming soon. For new deployments, follow this guide.
 
 For a deeper reference covering every Flux flag and option, see [Deploying an application via a Flux HelmRelease]({{< relref "/tutorials/fleet-management/app-platform/deploy-app-helmrelease" >}}).
 


### PR DESCRIPTION
### What this PR does / why we need it

The `main` build fails with a `REF_NOT_FOUND` error:

```
ERROR [en] REF_NOT_FOUND: Ref "/overview/fleet-management/app-management/app-cr-deprecation": ".../getting-started/install-an-application/index.md:23:121": page not found
```

The install-an-application rewrite (#3176) linked to `/overview/fleet-management/app-management/app-cr-deprecation`, but that target page only exists on the `migrate-to-hr` branch (added in #3171) and hasn't landed on `main` yet. The dangling `relref` broke the build.

This PR drops the link while keeping the migration note as plain text, so the build is green again.

The link should be re-introduced once the migrate-to-hr branch (#3242) merges the deprecation page onto `main`. I've left a note on #3171 for @pipo02mix.

### Things to check/remember before submitting

- Content-only change; no `last_review_date` bump needed for a one-word link removal.