### PR TITLE
fix(docs): close unclosed code fence in creating-grafana-organization

### DIFF
--- a/src/content/overview/observability/configuration/creating-grafana-organization/index.md
+++ b/src/content/overview/observability/configuration/creating-grafana-organization/index.md
@@ -414,7 +414,6 @@ After creating your organization:
 
 2. [**Log in to Grafana**]({{< relref "/overview/observability/data-management/data-exploration/" >}}) and verify:
 
-
 - The organization dropdown menu on the top-left corner shows all expected organizations
 
 ![Switching organization](./organization_switching.png)

--- a/src/content/overview/observability/configuration/creating-grafana-organization/index.md
+++ b/src/content/overview/observability/configuration/creating-grafana-organization/index.md
@@ -410,6 +410,8 @@ After creating your organization:
 
 ```bash
 kubectl get grafanaorganization myonlineshop -o yaml
+```
+
 2. [**Log in to Grafana**]({{< relref "/overview/observability/data-management/data-exploration/" >}}) and verify:
 
 

--- a/src/content/overview/observability/configuration/creating-grafana-organization/index.md
+++ b/src/content/overview/observability/configuration/creating-grafana-organization/index.md
@@ -408,9 +408,9 @@ After creating your organization:
 
 1. **Check organization status:**
 
-```bash
-kubectl get grafanaorganization myonlineshop -o yaml
-```
+   ```bash
+   kubectl get grafanaorganization myonlineshop -o yaml
+   ```
 
 2. [**Log in to Grafana**]({{< relref "/overview/observability/data-management/data-exploration/" >}}) and verify:
 


### PR DESCRIPTION
### What this PR does / why we need it

Closes an unclosed ` ```bash ` code fence in the "Verification steps" section of the *Creating a Grafana organization* page. The `kubectl` command fence was opened but never closed, so `2. Log in to Grafana` and everything after it rendered inside the code block instead of as the numbered list.

Follow-up spotted during the Diátaxis review of team-atlas pages (giantswarm/giantswarm#37021); the fix itself is standalone.
