### PR TITLE
fix(crd-reference): point silence-operator examples at config/samples

### DIFF
--- a/scripts/update-crd-reference/config.yaml
+++ b/scripts/update-crd-reference/config.yaml
@@ -70,7 +70,7 @@ source_repositories:
     crd_paths:
       - config/crd
     cr_paths:
-      - docs/cr
+      - config/samples
     metadata:
       silences.observability.giantswarm.io:
         owner:


### PR DESCRIPTION
## What

Point the `silence-operator` `cr_paths` at `config/samples` instead of `docs/cr`.

## Why

The [`silences.observability.giantswarm.io` reference page](https://docs.giantswarm.io/reference/platform-api/crd/silences.observability.giantswarm.io/) has no example CR. This is not a missing example — silence-operator already ships a valid one at `config/samples/observability_v1alpha2_silence.yaml` (kube-builder naming, matching the v1alpha2 CRD). The example was never picked up because `cr_paths` was set to `docs/cr`, which does not exist in that repo.

## Verification

After merge and the next `update-crd-reference` run, the page should render an "Example CR" section for `v1alpha2`.

Part of an effort to ensure every published CRD reference page has an example. Companion issues (missing examples that need to be added at the source):
- giantswarm/giantswarm#37088
- giantswarm/giantswarm#37087
