### PR TITLE
feat(crd-reference): publish muster CRDs (Workflow, MCPServer)

### DIFF
--- a/scripts/update-crd-reference/config.yaml
+++ b/scripts/update-crd-reference/config.yaml
@@ -320,7 +320,7 @@ source_repositories:
   - url: https://github.com/giantswarm/muster
     organization: giantswarm
     short_name: muster
-    commit_reference: v0.22.8
+    commit_reference: v0.22.10
     crd_paths:
       - helm/muster-crds/files/crds
     cr_paths:

--- a/scripts/update-crd-reference/config.yaml
+++ b/scripts/update-crd-reference/config.yaml
@@ -317,3 +317,18 @@ source_repositories:
           - https://github.com/orgs/giantswarm/teams/team-honeybadger
         topics:
           - configuration
+  - url: https://github.com/giantswarm/muster
+    organization: giantswarm
+    short_name: muster
+    commit_reference: v0.22.8
+    crd_paths:
+      - helm/muster-crds/files/crds
+    cr_paths:
+      - docs/cr
+    metadata:
+      workflows.muster.giantswarm.io:
+        owner:
+          - https://github.com/orgs/giantswarm/teams/team-bumblebee
+      mcpservers.muster.giantswarm.io:
+        owner:
+          - https://github.com/orgs/giantswarm/teams/team-bumblebee

--- a/scripts/update-crd-reference/config.yaml
+++ b/scripts/update-crd-reference/config.yaml
@@ -329,6 +329,12 @@ source_repositories:
       workflows.muster.giantswarm.io:
         owner:
           - https://github.com/orgs/giantswarm/teams/team-bumblebee
+        topics:
+          - managementcluster
+          - agent-platform
       mcpservers.muster.giantswarm.io:
         owner:
           - https://github.com/orgs/giantswarm/teams/team-bumblebee
+        topics:
+          - managementcluster
+          - agent-platform


### PR DESCRIPTION
## What

Registers `giantswarm/muster` as a CRD source repo so its CRDs get published
under [`/reference/platform-api/crd/`](https://docs.giantswarm.io/reference/platform-api/crd/):

- `workflows.muster.giantswarm.io` (Workflow)
- `mcpservers.muster.giantswarm.io` (MCPServer)

Both tagged with topics `managementcluster` and `agent-platform`.
`agent-platform` is a **new topic** — it renders automatically (the index layout
builds topic tags from the value), it just falls back to default tag styling
until/unless a dedicated color is added.

`WorkflowExecution` is intentionally left out for now — it's a controller-created
runtime record, not a user-authored resource. It can be added later by giving it
a `metadata` entry.

## ⚠️ Before merging — bump `commit_reference`

`commit_reference` is currently `v0.22.8`, which has the CRDs but **not** the
example CRs. The example files are added in giantswarm/muster#950. Once that
merges and muster cuts a release, bump `commit_reference` here to that tag so the
pages render with an "Example CR" section. (At `v0.22.8` the pages still generate
fine, just without examples.)

## Notes

- `crd_paths` points at `helm/muster-crds/files/crds` (the CRD Helm chart). The
  three CRD files there include `workflowexecutions`, which is found but skipped
  with a `WARN` because it has no metadata entry — expected.
- Owner set to team-bumblebee (per muster CODEOWNERS).
