### PR TITLE
docs(observability): extract ServiceMonitor/PodMonitor reference (T9)

### DIFF
--- a/src/content/overview/observability/data-management/data-ingestion/_index.md
+++ b/src/content/overview/observability/data-management/data-ingestion/_index.md
@@ -101,11 +101,9 @@ spec:
 
 ### Key requirements
 
-- **Tenant labeling**: All ServiceMonitors and PodMonitors must include the `observability.giantswarm.io/tenant` label
-- **Tenant existence**: The specified tenant must exist in a [Grafana Organization]({{< relref "/overview/observability/configuration/creating-grafana-organization/" >}})
-- **Resource considerations**: Monitor resource usage in the _ServiceMonitors Overview_ dashboard
+Both examples carry the `observability.giantswarm.io/tenant` label, which the metrics agent requires to discover the resource and route the metrics to a tenant. Monitor the resulting resource usage in the _ServiceMonitors Overview_ dashboard.
 
-For detailed configuration options and advanced use cases, refer to the [Prometheus Operator API documentation](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md).
+For the required labels, discovery rules, and a full field reference for ServiceMonitors and PodMonitors, see the [ServiceMonitor and PodMonitor reference]({{< relref "/overview/observability/data-management/data-ingestion/servicemonitor-reference" >}}).
 
 ## Log ingestion
 

--- a/src/content/overview/observability/data-management/data-ingestion/servicemonitor-reference/index.md
+++ b/src/content/overview/observability/data-management/data-ingestion/servicemonitor-reference/index.md
@@ -1,0 +1,63 @@
+---
+title: ServiceMonitor and PodMonitor reference
+linkTitle: ServiceMonitor and PodMonitor reference
+diataxis_content_type: reference
+description: Reference for the Prometheus ServiceMonitor and PodMonitor resources used to collect metrics on the Giant Swarm observability platform, including the required tenant label and their key fields.
+weight: 40
+menu:
+  principal:
+    parent: overview-observability-data-management-data-ingestion
+    identifier: overview-observability-data-management-data-ingestion-servicemonitor-reference
+last_review_date: 2026-07-03
+owner:
+  - https://github.com/orgs/giantswarm/teams/team-atlas
+user_questions:
+  - Which labels must a ServiceMonitor or PodMonitor have to be discovered?
+  - Which ServiceMonitor fields does the metrics agent use?
+  - Which PodMonitor fields does the metrics agent use?
+  - When should I use a PodMonitor instead of a ServiceMonitor?
+---
+
+This page describes the [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator) `ServiceMonitor` and `PodMonitor` custom resources as used to collect metrics on the Giant Swarm Observability Platform. The metrics agent on each cluster discovers these resources and scrapes the targets they select.
+
+For the task-oriented steps to set up metrics collection, see the [data ingestion guide]({{< relref "/overview/observability/data-management/data-ingestion" >}}). For the complete upstream schema, see the [Prometheus Operator API documentation](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md).
+
+## Discovery requirements
+
+For a `ServiceMonitor` or `PodMonitor` to be picked up by the platform:
+
+- **Tenant label**: the resource must carry the `observability.giantswarm.io/tenant` label. It routes the collected metrics to that [tenant]({{< relref "/overview/observability/configuration/multi-tenancy" >}}).
+- **Tenant existence**: the named tenant must already exist in a [Grafana Organization]({{< relref "/overview/observability/configuration/creating-grafana-organization" >}}). Metrics routed to a non-existent tenant are dropped.
+
+## ServiceMonitor
+
+A [`ServiceMonitor`](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#monitoring.coreos.com/v1.ServiceMonitor) collects metrics from applications that expose them through a Kubernetes Service. It's the primary way to configure metric collection.
+
+| Field | Description |
+|-------|-------------|
+| `metadata.labels."observability.giantswarm.io/tenant"` | Required. The tenant the collected metrics are routed to (see [discovery requirements](#discovery-requirements)). |
+| `spec.selector.matchLabels` | Selects the Services to scrape by their labels. |
+| `spec.endpoints[].port` | Named Service port that exposes metrics. |
+| `spec.endpoints[].path` | HTTP path that exposes metrics. Defaults to `/metrics`. |
+| `spec.endpoints[].interval` | Scrape interval, for example `60s`. |
+
+## PodMonitor
+
+A [`PodMonitor`](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#monitoring.coreos.com/v1.PodMonitor) collects metrics directly from Pods, without requiring a Service. Use a `PodMonitor` when:
+
+- Your application doesn't need a Service for its primary function.
+- You need to collect metrics from specific Pod instances.
+- You want more granular control over Pod selection.
+
+| Field | Description |
+|-------|-------------|
+| `metadata.labels."observability.giantswarm.io/tenant"` | Required. The tenant the collected metrics are routed to (see [discovery requirements](#discovery-requirements)). |
+| `spec.selector.matchLabels` | Selects the Pods to scrape by their labels. |
+| `spec.podMetricsEndpoints[].port` | Named Pod port that exposes metrics. |
+| `spec.podMetricsEndpoints[].path` | HTTP path that exposes metrics. Defaults to `/metrics`. |
+| `spec.podMetricsEndpoints[].interval` | Scrape interval, for example `60s`. |
+
+## See also
+
+- [Data ingestion]({{< relref "/overview/observability/data-management/data-ingestion" >}}): how to configure metrics collection, with working ServiceMonitor and PodMonitor examples
+- [Multi-tenancy]({{< relref "/overview/observability/configuration/multi-tenancy" >}}): how tenants isolate observability data


### PR DESCRIPTION
### What this PR does / why we need it

Second step of the **team-atlas Diátaxis split** (giantswarm/giantswarm#37089 — see the [restructuring plan](https://claude.ai/code/artifact/19d2df5d-68c8-43f1-8a6e-73a7cd3b904d), target **T9**).

The _Data ingestion_ how-to described the Prometheus `ServiceMonitor` / `PodMonitor` machinery inline (required labels, discovery rules, per-field explanations) alongside its task steps. This PR extracts that reference material so each page serves a single Diátaxis type:

- **New:** `ServiceMonitor and PodMonitor reference` (`diataxis_content_type: reference`) at `…/data-management/data-ingestion/servicemonitor-reference/` — the required `observability.giantswarm.io/tenant` label, discovery rules, and a key-field reference for both resources.
- **Trimmed:** the _Data ingestion_ how-to keeps its recipe (instrumentation note + working ServiceMonitor/PodMonitor examples + resource-usage tip) and links to the new reference instead of restating the requirements.

Because every merge to `main` publishes immediately, the reference facts are removed from the how-to in the same change — the docs stay duplication-free at all times.

> **Note — stacked on #3253.** This PR targets the `docs/atlas-diataxis-otlp-reference` branch (T2), which introduces the `data-ingestion` branch-bundle conversion this page also relies on. GitHub will retarget it to `main` automatically once #3253 merges. Review/merge #3253 first.

### Things to check/remember before submitting

- `make lint` (markdownlint v0.45.0 + vale) passes on the changed files; `hugo` build is clean (all `relref`s resolve).
- No `last_review_date` change beyond the bump already carried by #3253 on the _Data ingestion_ page.
