### PR TITLE
fix(chart): use .Chart.AppVersion for image tag to unblock Flux HelmRelease migration

### DIFF
--- a/helm/docs-app/templates/deployment.yaml
+++ b/helm/docs-app/templates/deployment.yaml
@@ -36,7 +36,7 @@ spec:
 
       containers:
         - name: docs-app
-          image: gsoci.azurecr.io/giantswarm/docs:{{ .Chart.Version }}
+          image: gsoci.azurecr.io/giantswarm/docs:{{ .Chart.AppVersion }}
           securityContext:
             allowPrivilegeEscalation: false
             runAsNonRoot: true


### PR DESCRIPTION
### What this PR does / why we need it

The `docs-app` chart templates the container image tag from `.Chart.Version`:

```yaml
image: gsoci.azurecr.io/giantswarm/docs:{{ .Chart.Version }}
```

This works today because the chart is deployed via a Giant Swarm **App CR**, where the chart version is a clean semver (e.g. `2.13.9`), so the tag resolves to a real image.

We're migrating `docs-app` to a **Flux `HelmRelease`** sourced from an `OCIRepository`. Flux appends build metadata (`+<checksum>`) to the chart version, so `.Chart.Version` resolves to something like `2.13.9+abc1234`. The image tag would then point at a non-existent tag → **ImagePullBackOff**.

This PR switches the image tag to `.Chart.AppVersion`, which is **not** suffixed by the OCIRepository. Architect stamps both `version` and `appVersion` to the same release value, verified against the published OCI chart:

```
oci://gsoci.azurecr.io/charts/giantswarm/docs-app:2.13.9
  version:    2.13.9
  appVersion: 2.13.9
```

So the change is behavior-preserving under the App CR (still renders `docs:2.13.9`) and unblocks the Flux migration.

The other `.Chart.Version` reference (the `helm.sh/chart` label in `_helpers.tpl`) is left as-is — it sanitizes `+`→`_` and is label-safe.

### Things to check/remember before submitting

- Chart-only change; no docs content pages touched, so no `last_review_date` bumps needed.