### PR TITLE
fix(docs): strip .git suffix in default GitOps HTTPS URL pattern

### DIFF
--- a/src/content/overview/developer-portal/customizing/gitops-links/index.md
+++ b/src/content/overview/developer-portal/customizing/gitops-links/index.md
@@ -8,7 +8,7 @@ menu:
   principal:
     parent: overview-developer-portal-customizing
     identifier: overview-developer-portal-customizing-gitopslinks
-last_review_date: 2025-04-01
+last_review_date: 2026-07-23
 owner:
   - https://github.com/orgs/giantswarm/teams/team-bumblebee
 user_questions:
@@ -123,7 +123,7 @@ By default, the system is pre-configured with two GitHub repository patterns. Th
 - **Default GitHub (HTTPS):**
 
   ```yaml
-  gitRepositoryUrlPattern: '^https:\/\/(?<HOSTNAME>github.+?)\/(?<REPO_PATH>.+?)$'
+  gitRepositoryUrlPattern: '^https:\/\/(?<HOSTNAME>github.+?)\/(?<REPO_PATH>.+?)(\.git)?$'
   targetUrl: 'https://${{HOSTNAME}}/${{REPO_PATH}}/blob/${{REVISION}}/${{PATH}}'
   ```
 


### PR DESCRIPTION
### What this PR does / why we need it

Fixes a bug in the default GitOps HTTPS URL pattern on the [Enabling GitOps links](https://docs.giantswarm.io/overview/developer-portal/customizing/gitops-links/) page, reported in giantswarm/giantswarm#37095.

The default HTTPS `gitRepositoryUrlPattern` was missing the optional `(\.git)?` group before the end anchor:

```diff
- gitRepositoryUrlPattern: '^https:\/\/(?<HOSTNAME>github.+?)\/(?<REPO_PATH>.+?)$'
+ gitRepositoryUrlPattern: '^https:\/\/(?<HOSTNAME>github.+?)\/(?<REPO_PATH>.+?)(\.git)?$'
```

As a result, a URL like `https://github.com/myorg/repo.git` captured `repo.git` as `REPO_PATH` and produced a broken link (`.../repo.git/blob/...`). Adding `(\.git)?` brings the HTTPS default in line with the SSH default and the GitLab example on the same page, which already strip the suffix.

Note: the issue described this as "captures only one char of `REPO_PATH`". Verified empirically (ECMAScript flavour) that the `$` anchor forces the non-greedy `.+?` to the end, so the actual defect is the un-stripped `.git` suffix, not a truncated capture.

### Things to check/remember before submitting

- [x] Bumped `last_review_date` in the front matter of the touched page.