### PR TITLE
perf(docker): build Hugo stage on native platform for faster multi-arch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gsoci.azurecr.io/giantswarm/hugo:0.162.1 AS build
+FROM --platform=$BUILDPLATFORM gsoci.azurecr.io/giantswarm/hugo:0.162.1 AS build
 
 WORKDIR /docs
 


### PR DESCRIPTION
## What

Pin the Dockerfile `build` stage to the native build platform:

```dockerfile
FROM --platform=$BUILDPLATFORM gsoci.azurecr.io/giantswarm/hugo:0.162.1 AS build
```

## Why

Since architect-orb v9, `push-to-registries` builds multi-arch (**amd64 + arm64**) by default, and this repo has no opt-out. Our CircleCI runners are amd64-only, so the arm64 image is built under **QEMU emulation**.

Without a platform pin, the `build` stage inherits the target platform, so the arm64 variant runs the entire **Hugo site generation** and **`gzip -9` over every asset** emulated — a 5–20× slowdown. That output is architecture-independent (byte-identical regardless of build arch), so emulating it is pure waste.

Pinning the stage to `$BUILDPLATFORM` keeps Hugo + gzip running natively (once), while the final `nginx` runtime stage stays per-arch as it should — it only does a `COPY --from=build` of the generated files plus trivial setup (`rm`/`mkdir`/`chown`/`nginx -t`), which is negligible under emulation.

The `hugo:0.162.1` base image supports both arm64 and amd64, and the runtime `nginx` image is unchanged, so both published arches remain correct.

**Result:** push-to-registries took 14 minutes, now takes 3m11s.

## Reference

[architect-orb docs/multi-arch-dockerfiles.md](https://github.com/giantswarm/architect-orb/blob/main/docs/multi-arch-dockerfiles.md) — Pattern B (build arch-independent output on `$BUILDPLATFORM`, `COPY` into the per-arch runtime image).