### PR TITLE
docs: extract Muster CLI reference content into reference/muster

### DIFF
--- a/src/content/getting-started/ai-agent-setup/index.md
+++ b/src/content/getting-started/ai-agent-setup/index.md
@@ -9,7 +9,7 @@ menu:
   principal:
     parent: getting-started
     identifier: getting-started-ai-agent-setup
-last_review_date: 2026-02-27
+last_review_date: 2026-07-23
 owner:
   - https://github.com/orgs/giantswarm/teams/team-bumblebee
 user_questions:
@@ -120,7 +120,7 @@ The direct connection above needs only your editor. Install the `muster` CLI whe
 
 ### Install the CLI
 
-Download the `muster` binary from the [GitHub releases page](https://github.com/giantswarm/muster/releases). It's a single binary with no additional dependencies—just put it somewhere on your `PATH`.
+Download the `muster` binary and put it somewhere on your `PATH`. See [Installing the Muster CLI]({{< relref "/reference/muster/installation" >}}) for the full instructions.
 
 ### Point it at your endpoint
 
@@ -232,20 +232,6 @@ Muster uses a meta-tool architecture. Instead of exposing hundreds of individual
 - **Token expiry:** Access tokens expire every 30 minutes, but your editor (or the local bridge) refreshes them automatically in the background.
 - **Session duration:** Your overall session lasts approximately 30 days (the default) before you need to log in again. This can vary by installation.
 - **Re-authentication:** If your session expires, your editor (or the bridge) detects it and re-authenticates by opening your browser.
-
-## CLI quick reference
-
-| Command | Purpose |
-|---|---|
-| `muster auth login` | Authenticate via SSO |
-| `muster auth status` | Check connectivity to all MCP servers |
-| `muster auth whoami` | Show the currently authenticated identity |
-| `muster auth logout` | Clear stored tokens |
-| `muster context add` | Register a new Muster endpoint |
-| `muster context use` | Switch active context |
-| `muster context current` | Show the name of the active context |
-| `muster context show <name>` | Show a specific context's configuration |
-| `muster context list` | List all contexts |
 
 ## Troubleshooting
 

--- a/src/content/reference/muster/_index.md
+++ b/src/content/reference/muster/_index.md
@@ -19,12 +19,13 @@ owner:
 
 `muster` is the command-line interface for [Muster]({{< relref "/overview/ai-agents/introduction" >}}), the MCP gateway that gives AI agents unified, secure access to your fleet. This section documents the CLI commands, the meta-tools Muster exposes to agents, and the custom resources you author to extend it.
 
-For a conceptual overview, start with [AI agents on the platform]({{< relref "/overview/ai-agents" >}}). To connect your IDE, follow [Set up your AI agent]({{< relref "/getting-started/ai-agent-setup" >}}).
+For a conceptual overview, start with [AI agents on the platform]({{< relref "/overview/ai-agents" >}}). To install the CLI, see [Installation]({{< relref "/reference/muster/installation" >}}). To connect your IDE, follow [Set up your AI agent]({{< relref "/getting-started/ai-agent-setup" >}}).
 
 ## Reference pages {#pages}
 
 | Page | Description |
 |---|---|
+| [Installation]({{< relref "/reference/muster/installation" >}}) | How to install the `muster` CLI and keep it up to date |
 | [Meta-tools]({{< relref "/reference/muster/meta-tools" >}}) | The meta-tools Muster exposes to agents, plus the `core_*` tool catalog |
 | [Custom resources]({{< relref "/reference/muster/crds" >}}) | The `MCPServer` and `Workflow` schemas |
 

--- a/src/content/reference/muster/installation.md
+++ b/src/content/reference/muster/installation.md
@@ -1,0 +1,57 @@
+---
+linkTitle: Installation
+title: Installing the Muster CLI
+diataxis_content_type: how-to-guide
+description: How to install the muster command-line interface and keep it up to date.
+weight: 5
+menu:
+  principal:
+    parent: reference-muster
+    identifier: reference-muster-installation
+owner:
+  - https://github.com/orgs/giantswarm/teams/team-bumblebee
+last_review_date: 2026-07-23
+user_questions:
+  - How do I install the Muster CLI?
+  - Where can I download the muster binary?
+  - How do I keep the Muster CLI up to date?
+---
+
+`muster` is a single, self-contained binary with no additional dependencies. This page explains how to install it and keep it current. For what the CLI does and which commands it offers, see the [Muster CLI reference]({{< relref "/reference/muster" >}}).
+
+You only need the CLI for a terminal view of your fleet, the `auth` and `context` commands, or the local bridge (`muster agent`). Modern AI assistants connect to the Muster endpoint directly over HTTPS with nothing to install — see [Set up your AI agent]({{< relref "/getting-started/ai-agent-setup" >}}).
+
+## Download the binary {#download}
+
+Download the build for your operating system and architecture from the [latest Muster release](https://github.com/giantswarm/muster/releases/latest), then move the binary into a directory on your `PATH`.
+
+On Linux or macOS, once you have unpacked the downloaded archive:
+
+```bash
+sudo mv muster /usr/local/bin/muster
+chmod +x /usr/local/bin/muster
+```
+
+Verify that the CLI is working:
+
+```bash
+muster version
+```
+
+You should see the CLI version and, if a running aggregator is reachable, the server version.
+
+## Keep it up to date {#update}
+
+Update the installed CLI in place to the latest GitHub release:
+
+```bash
+muster self-update
+```
+
+See [`muster self-update`]({{< relref "/reference/muster/cli/self-update" >}}) for details.
+
+## Next steps {#next-steps}
+
+- [Point the CLI at your endpoint]({{< relref "/reference/muster/cli/context" >}}) with a named context.
+- [Authenticate]({{< relref "/reference/muster/cli/auth" >}}) to a remote aggregator.
+- [Set up your AI agent]({{< relref "/getting-started/ai-agent-setup" >}}) to connect your IDE.


### PR DESCRIPTION
### What this PR does / why we need it

Part of the team-bumblebee Diátaxis split (giantswarm/giantswarm#37095): the [Set up your AI agent](https://docs.giantswarm.io/getting-started/ai-agent-setup/) how-to guide carried reference-type Muster CLI content that belongs in the [reference/muster](https://docs.giantswarm.io/reference/muster/) section. This moves it there, mirroring the `reference/kubectl-gs` layout (which has a dedicated Installation sub page).

Changes:

- **New page** `reference/muster/installation.md` — how to download the `muster` binary and keep it up to date (via `muster self-update`), modeled on the kubectl-gs Installation page. Linked from the section index intro and the "Reference pages" table.
- **Slimmed** the how-to's "Install the CLI" step down to a one-line pointer to the new Installation page.
- **Removed** the "CLI quick reference" table from the how-to — it duplicated the per-command pages already under `reference/muster/cli`, which the "Learn more" section already links to.

Verified with a local `hugo` build: no broken `relref`s and no duplicate-menu warnings (the new page sets an explicit menu `identifier` to avoid colliding with the kubectl-gs Installation entry).

### Things to check/remember before submitting

- [x] Bumped `last_review_date` in the front matter of the touched how-to page.
- [x] `diataxis_content_type` set on the new page (`how-to-guide`).