### PR TITLE
chore: restrict Renovate to nights, drop PR limits, skip releases

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,6 +1,37 @@
 {
   extends: [
     'github>giantswarm/renovate-presets:default.json5',
+    // Only act during non-office hours: weeknights 22:00-05:00 plus all weekend.
+    // Resolves to ['* 0-4,22-23 * * 1-5', '* * * * 0,6'].
+    'schedule:nonOfficeHours',
+  ],
+  // The schedule above is interpreted in UTC (Renovate's default), stated for clarity.
+  timezone: 'UTC',
+  // Stay completely idle outside the schedule: don't even rebase or automerge
+  // branches that already exist.
+  updateNotScheduled: false,
+  // No throttling inside the window. The Giant Swarm preset caps these at 10/10/2;
+  // these top-level values override it. 0 means "no limit".
+  prConcurrentLimit: 0,
+  branchConcurrentLimit: 0,
+  prHourlyLimit: 0,
+  // Keep dependency merges from cutting a release. The suffix ends up in the PR
+  // title, which is the whole commit message on main (squash merges here use
+  // PR_TITLE + BLANK body), where .github/workflows/on-merge-create-release.yml
+  // looks for it. `commitBody` would not work: squashing discards the branch commit.
+  commitMessageSuffix: '[do not release]',
+  packageRules: [
+    {
+      // Exception: the Dockerfile pins the hugo and nginx images that build and
+      // serve the site, and publishing only happens on the `v*` tags created by
+      // the release workflow. These updates must release, or the merged pins
+      // would not reach docs.giantswarm.io.
+      description: 'Let Dockerfile updates cut a release, since they change the published site',
+      matchFileNames: [
+        'Dockerfile',
+      ],
+      commitMessageSuffix: '',
+    },
   ],
   customManagers: [
     {


### PR DESCRIPTION
### What this PR does / why we need it

Two related changes to how Renovate behaves in this repo, both in `renovate.json5`.

**1. Only work at night, but without limits.** Renovate currently runs at any time of day, throttled by `giantswarm/renovate-presets:default.json5` (`prConcurrentLimit: 10`, `branchConcurrentLimit: 10`, `prHourlyLimit: 2`), which drip-feeds dependency PRs through working hours. This inverts that:

- `schedule:nonOfficeHours` — weeknights 22:00–05:00 plus all weekend.
- `timezone: 'UTC'` — stated explicitly; it was already the effective default, since neither this repo nor the org preset set a timezone.
- `updateNotScheduled: false` — fully idle outside the window, not even rebasing existing branches.
- All three limits set to `0` (unlimited), so the whole backlog lands in one nightly batch. All three are needed, because the org preset sets each one explicitly — `branchConcurrentLimit` does not inherit from `prConcurrentLimit` when it has a value of its own.

**2. Dependency merges no longer cut a release.** `commitMessageSuffix: '[do not release]'` puts the marker that `on-merge-create-release.yml` looks for into every Renovate PR title. The PR title is the only channel that works here: merges are squash-only with `squash_merge_commit_title: PR_TITLE` and `squash_merge_commit_message: BLANK`, so the commit on `main` is just the title plus co-author trailers. `commitBody` would not work, because squashing discards the branch commit it decorates.

`Dockerfile` is exempted by a `packageRule` that clears the suffix again. That matters because publishing is tag-driven, not branch-driven: `.circleci/config.yml` runs `push-to-registries` and `push-to-app-catalog` only on `/^v.*/` tags and explicitly ignores `main`, and those tags are what the release workflow creates. The Dockerfile pins the `hugo` and `nginx` images that build and serve the site, so suppressing their release would leave the merged pins unpublished.

Known exception, left deliberately: vulnerability-alert PRs still release, because `vulnerabilityAlerts` sets its own `[SECURITY]` suffix that replaces ours.

### Verification

Checked against the fully resolved config with the org preset actually fetched (`renovate --platform=local --dry-run --print-config`), not just against the schema:

- `schedule: ["* 0-4,22-23 * * 1-5", "* * * * 0,6"]`, `timezone: "UTC"`, `updateNotScheduled: false`.
- `prHourlyLimit: 0`, `prConcurrentLimit: 0`, `branchConcurrentLimit: 0` — the preset's `10 / 10 / 2` appear nowhere in the resolved output, so the overrides win.
- `prTitle` resolves to `null`, so titles derive from `commitMessage`, which ends in `{{{commitMessageSuffix}}}`. Expected title: `chore(deps): update dependency muster to v1.4.2 [do not release]`.
- The Dockerfile rule lands as rule 730 of 731 — last in the concatenated array — and is the only `packageRule` in the resolved config touching `commitMessageSuffix`, so nothing can override it.
- `group` overrides only `branchTopic` / `commitMessageTopic`, not `commitMessage`, so grouped PRs keep the suffix too.
- `renovate-config-validator`: valid, no warnings.

### Things to check/remember before submitting

- No content pages touched, so no `last_review_date` bumps needed.
- Expect a larger PR burst each night, each PR triggering `validate.yaml`, `validate-prose.yaml` and the link checks.
- Because of `updateNotScheduled: false`, the preset's patch-automerge now only fires inside the window, so patch bumps land at night rather than continuously.
