### PR TITLE
Update kyverno-policy-operator CRD reference to v0.2.3

### DIFF
--- a/scripts/update-crd-reference/config.yaml
+++ b/scripts/update-crd-reference/config.yaml
@@ -281,7 +281,7 @@ source_repositories:
   - url: https://github.com/giantswarm/kyverno-policy-operator
     organization: giantswarm
     short_name: kyverno-policy-operator
-    commit_reference: v0.2.2
+    commit_reference: v0.2.3
     crd_paths:
       - helm
     cr_paths:

--- a/src/content/reference/platform-api/crd/policyexceptions.policy.giantswarm.io.md
+++ b/src/content/reference/platform-api/crd/policyexceptions.policy.giantswarm.io.md
@@ -13,7 +13,7 @@ crd:
   technical_name: policyexceptions.policy.giantswarm.io
   scope: Namespaced
   source_repository: https://github.com/giantswarm/kyverno-policy-operator
-  source_repository_ref: v0.2.2
+  source_repository_ref: v0.2.3
   versions:
     - v1alpha1
   topics:
@@ -24,7 +24,7 @@ aliases:
   - /use-the-api/management-api/crd/policyexceptions.policy.giantswarm.io/
 technical_name: policyexceptions.policy.giantswarm.io
 source_repository: https://github.com/giantswarm/kyverno-policy-operator
-source_repository_ref: v0.2.2
+source_repository_ref: v0.2.3
 ---
 
 # PolicyException
@@ -51,6 +51,26 @@ source_repository_ref: v0.2.2
 <div class="crd-schema-version">
 <h2 id="v1alpha1">Version v1alpha1</h2>
 
+
+<h3 id="crd-example-v1alpha1">Example CR</h3>
+
+```yaml
+apiVersion: policy.giantswarm.io/v1alpha1
+kind: PolicyException
+metadata:
+  name: my-custom-operator
+  namespace: policy-exceptions
+spec:
+  policies:
+  - disallow-privilege-escalation
+  - require-run-as-nonroot
+  targets:
+  - kind: Deployment
+    names:
+    - my-custom-operator
+    namespaces:
+    - default
+```
 
 
 <h3 id="property-details-v1alpha1">Properties</h3>


### PR DESCRIPTION
The PolicyException CRD reference page was still generated from `kyverno-policy-operator` v0.2.2, which is why it showed "based on kyverno-policy-operator v0.2.2" and had no example CR.

`crd-docs-generator` reads each repo at the exact `commit_reference` pinned in `scripts/update-crd-reference/config.yaml`. v0.2.2 has no `docs/cr/` directory, so the configured `cr_paths: [docs/cr]` matched nothing. v0.2.3 adds `docs/cr/policy.giantswarm.io_v1alpha1_policyexception.yaml`.

Changes:

- Bump `commit_reference` to v0.2.3 for kyverno-policy-operator
- Regenerate the reference page, which now renders the example CR

The CRD schema itself is unchanged between the two tags, so the properties section is untouched.

Renovate would have picked this up on its own, but the docs repo only runs it during non-office hours, so this shortcuts the wait. The muster v1.4.3 page refresh that the same regeneration produces is left out here, since #3327 already contains it.