### PR TITLE
docs: list all three Flux dashboards under cluster automation

### DIFF
--- a/src/content/overview/observability/dashboard-management/prebuilt-dashboards.md
+++ b/src/content/overview/observability/dashboard-management/prebuilt-dashboards.md
@@ -71,7 +71,9 @@ Monitoring infrastructure health:
 
 Platform automation and lifecycle management:
 
+- **Flux Cluster Stats** - Reconciliation and source readiness per cluster, including suspended objects
 - **Flux Control Plane** - GitOps controller health and sync status
+- **Flux Logs** - Logs of the Flux controllers on the management cluster
 - **KEDA** - Kubernetes Event Driven autoscaling metrics
 - **Karpenter** - Node autoscaling performance (AWS)
 - **AWS Load Balancer Controller** - AWS LB controller metrics (AWS)


### PR DESCRIPTION
Towards [roadmap#3259](https://github.com/giantswarm/roadmap/issues/3259). Pairs with giantswarm/dashboards#954.

The pre-built dashboards page listed only **Flux Control Plane**. Two entries were missing:

- **Flux Cluster Stats** — already published to `Shared Org / GitOps`, just undocumented.
- **Flux Logs** — newly published in giantswarm/dashboards#954.

The Flux Logs entry says "on the management cluster" deliberately: workload-cluster Flux logs are not ingested today, because the Alloy pipeline drops pod logs from namespaces with no tenant assignment and WC `flux-system` has none.