### PR TITLE
docs: move cluster config layering out of the base template how-to

### DIFF
--- a/src/content/overview/fleet-management/cluster-management/cluster-concepts/cluster-configuration/index.md
+++ b/src/content/overview/fleet-management/cluster-management/cluster-concepts/cluster-configuration/index.md
@@ -1,4 +1,5 @@
 ---
+linkTitle: Cluster configuration
 title: Cluster configuration
 diataxis_content_type: explanation
 description: Explanation of how cluster configuration works in Cluster API and how you can customize it.
@@ -7,7 +8,7 @@ menu:
   principal:
     parent: overview-fleetmanagement-clustermanagement-concepts
     identifier: overview-fleetmanagement-clustermanagement-concepts-configuration
-last_review_date: 2026-06-22
+last_review_date: 2026-08-19
 owner:
   - https://github.com/orgs/giantswarm/teams/team-phoenix
 user_questions:
@@ -22,3 +23,25 @@ A cluster has **three main configuration sources**:
 - **Default, provider-independent app configuration.** This comes from the cluster chart. If an app carries this configuration, you should probably move it directly to the app's own repository.
 - **Provider-specific app configuration.** This comes from `cluster-<provider>`.
 - **Customer-specified app configuration.** This comes from the `cluster-<provider>` Helm values. It's usually specified in the customer's GitOps repository.
+
+## Where the defaults come from
+
+The interface to define a workload cluster is built on top of Helm and [the app platform]({{< relref "/overview/fleet-management/app-management/" >}}). Creating a cluster means delivering a configured `App` resource to the platform API.
+
+Those definitions come from the cluster provider Helm template, [`cluster-aws`](https://github.com/giantswarm/cluster-aws) for example. That chart carries the provider-specific definition, and depends on two more charts:
+
+- [`cluster`](https://github.com/giantswarm/cluster) holds the basic provider-agnostic definition.
+- [`cluster-shared`](https://github.com/giantswarm/cluster-shared) holds the common resources that every cluster runs by default.
+
+The chain is therefore `cluster-<provider>` → `cluster` → `cluster-shared`, with each link contributing part of what a cluster ends up being.
+
+## How the configuration layers merge
+
+Cluster configuration builds on the [app platform configuration levels]({{< relref "/tutorials/fleet-management/app-platform/app-configuration/#levels" >}}):
+
+- The cluster template provides a default configuration through the `App` resource's `config` field.
+- You add custom configuration through the `App` resource's `extraConfigs` field, which is overlaid on top of the default `config`. Where values collide, the entry with the higher priority prevails.
+
+**Note**: [The RFC on merging configmaps in GitOps](https://github.com/giantswarm/rfc/tree/main/merging-configmaps-gitops) explains why we chose this approach.
+
+To apply this with reusable Kustomize bases, see [creating a base template for your workload cluster]({{< relref "/tutorials/continuous-deployment/bases/" >}}).

--- a/src/content/tutorials/continuous-deployment/bases/index.md
+++ b/src/content/tutorials/continuous-deployment/bases/index.md
@@ -12,7 +12,7 @@ user_questions:
   - How can I create an base template for workload clusters in GitOps?
 owner:
   - https://github.com/orgs/giantswarm/teams/team-honeybadger
-last_review_date: 2026-07-02
+last_review_date: 2026-08-19
 ---
 
 In Giant Swarm the interface to define a workload cluster is built on top of `Helm` and [the app platform]({{< relref "/overview/fleet-management/app-management/" >}}). The application custom resource contains the specification and configuration of the cluster in this format:
@@ -20,6 +20,7 @@ In Giant Swarm the interface to define a workload cluster is built on top of `He
 ```yaml
 apiVersion: application.giantswarm.io/v1alpha1
 kind: App
+metadata:
   name: mycluster
 spec:
   catalog: cluster
@@ -28,18 +29,11 @@ spec:
   ...
 ```
 
-As such, creating cluster means that you need to deliver a configured `App` resource to the platform API also known as the management cluster API where your cluster will run.
+So creating a cluster means delivering a configured `App` resource to the platform API, also known as the management cluster API, where your cluster will run.
 
-Adding definitions is done via the [cluster provider `Helm` template](https://github.com/giantswarm/cluster-aws) (AWS example). The chart definition contains a basic provider agnostic definition which is a dependency and points to the [cluster generic template](https://github.com/giantswarm/cluster). Also, it has another dependency which contains all the common resources running by default within a cluster, it's called [cluster shared](https://github.com/giantswarm/cluster-shared).
+The cluster template provides defaults through the `App` resource's `config` field, and you layer your own values on top through `extraConfigs`. To learn how those layers merge, and how the `cluster-<provider>` chart chain produces the defaults, read [cluster configuration]({{< relref "/overview/fleet-management/cluster-management/cluster-concepts/cluster-configuration/" >}}).
 
-As consequence, the cluster configuration leverages the [app platform configuration]({{< relref "/tutorials/fleet-management/app-platform/app-configuration/#levels" >}}), in the following manner:
-
-- The cluster template has a default configuration via `App` `config` field.
-- User can add additional custom configuration via `App` `extraConfig` field, which is overlaid on top of the default `config`. The file set with higher priority will prevail in case of colliding configuration values.
-
-**Note**: [In the according RFC article](https://github.com/giantswarm/rfc/tree/main/merging-configmaps-gitops) you can find more information why this approach was chosen.
-
-In order to avoid code duplication, the [bases and overlays](https://kubernetes.io/docs/tasks/manage-kubernetes-objects/kustomization/#bases-and-overlays) use Kustomize to enhance the cluster configuration.
+To avoid code duplication, the [bases and overlays](https://kubernetes.io/docs/tasks/manage-kubernetes-objects/kustomization/#bases-and-overlays) pattern uses Kustomize to enhance the cluster configuration.
 
 ## Create a cluster template base {#create-template-base}
 
@@ -90,7 +84,7 @@ In this example you create a custom version for AWS base:
     --provider capa | yq -s '.metadata.name'
     ```
 
-3. The above command generates four files, though in the current example you are only interested in the cluster user configuration file `mywcl-userconfig.yaml`.Extract the values and create a new `cluster-config.yaml` file in our version folder:
+3. The above command generates four files, though in the current example you are only interested in the cluster user configuration file `mywcl-userconfig.yaml`. Extract the values and create a new `cluster_config.yaml` file in our version folder:
 
     ```nohighlight
     cat mywcl-userconfig.yaml | yq eval '.data.values' > bases/clusters/capa/v0.21.0/cluster_config.yaml
@@ -120,8 +114,8 @@ In this example you create a custom version for AWS base:
 4. Replace `mywcl`, `myorg` values from the previous step with variables:
 
     ```nohighlight
-    sed -i "s/myorg/${organization}/g" bases/clusters/capa/0.21.0/cluster_config.yaml
-    sed -i "s/mywcl/${cluster_name}/g" bases/clusters/capa/0.21.0/cluster_config.yaml
+    sed -i "s/myorg/${organization}/g" bases/clusters/capa/v0.21.0/cluster_config.yaml
+    sed -i "s/mywcl/${cluster_name}/g" bases/clusters/capa/v0.21.0/cluster_config.yaml
     ```
 
 5. Check `cluster_config.yaml` against the version-specific `values.yaml`, and tweak it if necessary to match the expected schema. At this point you may also provide extra configuration, like additional availability zones, node pools, etc. If you used `kubectl gs template` to get the values, this should be aligned with the latest version. If you were trying to create a different version, you might need to check proper values for that version.


### PR DESCRIPTION
### What this PR does / why we need it

Part of giantswarm/giantswarm#37092 (sub-issue of giantswarm/giantswarm#37021).

"Creating a base template for your workload cluster" is correctly typed as a `how-to-guide`, but it opened with a block of pure explanation. That material moves to the cluster configuration concept page, which already covers the three cluster config sources and is the natural home for it.

**On `cluster-configuration` (team-phoenix-owned):**

- Gains the `cluster-<provider>` → `cluster` → `cluster-shared` chart dependency chain.
- Gains the `config` / `extraConfigs` merge behavior and the merging-configmaps RFC link.
- Gains the `linkTitle` it was missing. The frontmatter validator requires it alongside a `menu` block, so the page would otherwise fail `validate` as soon as anyone touches it.

**On the bases page:** the intro becomes a two-sentence lead-in plus a `relref`, and four bugs are fixed:

- The example `App` resource was missing `metadata:`, so `name` sat directly under `kind`.
- Step 1 creates `bases/clusters/capa/v0.21.0`, but step 4's two `sed` commands wrote to `.../0.21.0/` — so they silently did nothing.
- Step 3 called the file `cluster-config.yaml`; every command and every other step uses `cluster_config.yaml`.
- Missing space in "…yaml`.Extract the values".

The prose now says `extraConfigs`, which is the actual App CR field name (it said `extraConfig`).

### Things to check/remember before submitting

- `last_review_date` bumped on both pages — real content changes on both sides.
- Verified locally: frontmatter-validator v0.7.0 (the version CI installs) clean, markdownlint clean, Vale 0 errors, Hugo build with no warnings.
- @giantswarm/team-phoenix you own `cluster-configuration` — the added sections are the ones that were duplicating your page from the bases guide.
- Noticed but deliberately **not** changed: step 6 of the bases guide still uses `patchesStrategicMerge`, which Kustomize has deprecated. Out of scope here; worth a follow-up.