### PR TITLE
docs: fix Diataxis types and bugs on the legacy App CR pages

### DIFF
--- a/src/content/tutorials/continuous-deployment/apps/app-sets.md
+++ b/src/content/tutorials/continuous-deployment/apps/app-sets.md
@@ -19,7 +19,7 @@ last_review_date: 2026-07-02
 
 This document is part of the documentation to use GitOps with Giant Swarm app platform. You can find more information about the [app platform in our docs]({{< relref "/overview/fleet-management/app-management/" >}}).
 
-# Creating app sets
+## Creating app sets
 
 It's often desirable to deploy a group of apps together, as a single deployment step. In Giant Swarm, it's called `App Sets`. There's nothing special about `App Sets`: they aren't a separate API entity, but rather just a configuration pattern enabled by [`Kustomize`](https://kustomize.io/) and [`Flux`](https://fluxcd.io/flux/). The purpose brings you the following benefits:
 

--- a/src/content/tutorials/fleet-management/app-platform/app-bundle/index.md
+++ b/src/content/tutorials/fleet-management/app-platform/app-bundle/index.md
@@ -70,7 +70,7 @@ Now, obviously to leverage this management cluster layer, the bundle `App` custo
 
 The first, not so obvious, consequence of installing a bundle in a management cluster before its nested apps are installed in the workload cluster is the requirement for name uniqueness. When a given app bundle is to be installed for more than one workload cluster, each `App` custom resource instance must be given a unique name within the management cluster.
 
-It becomes natural for solitary apps (for example, the [Hello World app]) that when you need to install it twice in the workload cluster, both App custom resource instances must be named uniquely. It's natural because both live under the same namespace. Even if we could break them into separate namespaces, this uniqueness would still be required because both apps target the same workload cluster and must be distinguished by its operators.
+It becomes natural for solitary apps (for example, the [Hello World app](https://github.com/giantswarm/hello-world-app)) that when you need to install it twice in the workload cluster, both App custom resource instances must be named uniquely. It's natural because both live under the same namespace. Even if we could break them into separate namespaces, this uniqueness would still be required because both apps target the same workload cluster and must be distinguished by its operators.
 
 It's less obvious for the bundle apps, because these are usually scattered across the namespaces for the corresponding workload clusters from the very beginning. This gives the impression they're isolated, which we already know to not be the case. Not complying with this rule results in apps competing over certain resources, and hence conflicting.
 

--- a/src/content/tutorials/fleet-management/app-platform/app-configuration/index.md
+++ b/src/content/tutorials/fleet-management/app-platform/app-configuration/index.md
@@ -1,7 +1,7 @@
 ---
 linkTitle: App configuration
 title: App configuration reference
-diataxis_content_type: explanation
+diataxis_content_type: reference
 description: Documentation on the various levels of App configuration and how they get merged into a final values object.
 menu:
   principal:
@@ -163,7 +163,7 @@ The `hello-world-user-values` `ConfigMap` contains the following content:
 
 ```yaml
 apiVersion: v1
-kind: configmap
+kind: ConfigMap
 metadata:
   name: hello-world-user-values
   namespace: i5h93
@@ -177,7 +177,7 @@ The `hello-world-user-secrets` secret contains this:
 
 ```yaml
 apiVersion: v1
-kind: secret
+kind: Secret
 metadata:
   name: hello-world-user-secrets
   namespace: i5h93
@@ -208,7 +208,7 @@ You can use these values throughout your chart using the normal templating of `h
 ```yaml
 # hello-world-app/helm/chart/hello-world/templates/colors-configmap.yaml
 apiVersion: v1
-kind: configmap
+kind: ConfigMap
 metadata:
   name: hello-world-configmap
   namespace: {{ .Release.Namespace }}
@@ -222,7 +222,7 @@ data:
 ```yaml
 # hello-world-app/helm/chart/hello-world/templates/colors-secret.yaml
 apiVersion: v1
-kind: secret
+kind: Secret
 metadata:
   name: hello-world-secret
   namespace: {{ .Release.Namespace }}
@@ -356,7 +356,7 @@ The merge order for `ConfigMaps` (with `P` as the indicated or calculated priori
 4. `Configmap`: `hello-world-values` (P = 50)
 5. `Configmap`: `hello-world-pre-user` (P = 75)
 6. `Configmap`: `hello-world-app-user-values` (P = 100)
-7. `Configmap`: `hello-world-post-user` (P = 125, position in the list: `1)
+7. `Configmap`: `hello-world-post-user` (P = 125, position in the list: 1)
 8. `Configmap`: `hello-world-final` (P = 125, position in the list: 4)
 
 ## Format of values in ConfigMap and Secret {#values-format}
@@ -369,7 +369,7 @@ The `ConfigMap` and `Secret` must contain a `.data.values` key, under which all 
 
 ```yaml
 apiVersion: v1
-kind: configmap
+kind: ConfigMap
 metadata:
   name: hello-world-user-values
   namespace: i5h93
@@ -383,7 +383,7 @@ data:
 
 ```yaml
 apiVersion: v1
-kind: secret
+kind: Secret
 metadata:
   name: hello-world-user-secrets
   namespace: i5h93

--- a/src/content/tutorials/fleet-management/app-platform/defaulting-validation/index.md
+++ b/src/content/tutorials/fleet-management/app-platform/defaulting-validation/index.md
@@ -1,7 +1,7 @@
 ---
 linkTitle: Defaulting and validation
 title: Defaulting and validation of App CRs
-diataxis_content_type: explanation
+diataxis_content_type: reference
 description: How defaulting and validation of app CRs is implemented by app-admission-controller.
 weight: 40
 aliases:


### PR DESCRIPTION
### What this PR does / why we need it

Part of giantswarm/giantswarm#37092 (sub-issue of giantswarm/giantswarm#37021) — the mechanical PR for the four pages documenting the legacy `App` custom resource.

The `App` CR is deprecated in favor of Flux HelmRelease, so per the issue these pages get frontmatter corrections and genuine bug fixes only. No content is moved and no pages are created: the reference material can't move into the schema-generated CRD page, and it isn't worth investing further in deprecated content.

- **App configuration** and **Defaulting and validation**: both declared `explanation` but describe machinery (field tables, merge algorithms, webhook behavior), so they're now `reference`.
- **App configuration**: six Kubernetes object manifests used `kind: configmap` / `kind: secret`, which Kubernetes rejects. Now `ConfigMap` / `Secret`. Note the lowercase `configMap` / `secret` values under `spec.extraConfigs[].kind` are the App CR's *own field values* and are correctly left alone — a blanket replace here would have broken the docs.
- **App configuration**: removed a stray unbalanced backtick in the merge-order list ("P = 125, position in the list: \`1").
- **App bundle**: `[Hello World app]` was a reference-style link with no matching definition anywhere in the file, so it rendered as literal brackets. It now points at the repo. Type was already correct (`explanation`).
- **App Sets**: demoted the body `# Creating app sets` to an H2. The page title comes from frontmatter, so the body must not carry an H1. The `#` lines inside the fenced YAML blocks are comments and are untouched. Type was already correct (`how-to-guide`).

### Things to check/remember before submitting

- `last_review_date` deliberately **not** bumped on any of these pages. Per giantswarm/giantswarm#37021, a `diataxis_content_type` correction is mechanical rather than a content review, and all four dates are well inside the 365-day window.
- Verified locally: frontmatter-validator v0.7.0 (the version CI installs) clean, markdownlint clean, Hugo build with no warnings. Vale reports pre-existing errors on these pages, but none on lines this PR touches — `validate-prose` runs reviewdog with `--filter-mode=added`.