### PR TITLE
docs(muster): drop the removed --yolo and --enable-events serve flags

### DIFF
--- a/src/content/reference/muster/cli/serve.md
+++ b/src/content/reference/muster/cli/serve.md
@@ -12,7 +12,7 @@ owner:
 user_questions:
   - How do I start the Muster aggregator server?
   - How do I enable OAuth protection for Muster?
-last_review_date: 2026-06-21
+last_review_date: 2026-08-26
 ---
 
 `muster serve` starts the aggregator server. It connects the configured MCP servers, exposes their tools behind one unified MCP endpoint, and keeps that endpoint available for IDEs, the developer portal chat, and the other `muster` commands.
@@ -34,8 +34,6 @@ To connect an IDE that can't reach the endpoint directly, bridge it with [`muste
 | `--config-path` | Configuration directory. Defaults to `~/.config/muster` |
 | `--debug` | Enable general debug logging |
 | `--silent` | Disable console log output. Does not silence OTLP export |
-| `--yolo` | Disable the denylist for destructive tool calls. Use with caution |
-| `--enable-events` | Enable Kubernetes event emission (alpha) |
 | `--extra-ca-file` | PEM file whose certificates are appended to the system trust pool at startup |
 
 ### OAuth protection {#oauth}


### PR DESCRIPTION
The `muster serve` flag table documents two flags that no longer exist.

## `--yolo`

Removed in [giantswarm/muster#1074](https://github.com/giantswarm/muster/pull/1074) (v3.0.1),
closing [muster#1068](https://github.com/giantswarm/muster/issues/1068).

The destructive-tool denylist that `--yolo` claimed to disable was never enforced on any
tool-call path — `isDestructiveTool` only ever fed a status counter, so tools in the list
executed identically with and without the flag. Documenting an enforcement control that does
not exist is worse than documenting nothing: an external reviewer read exactly this page and
the matching source comments as a real security boundary. The denylist and the flag are both
gone now.

## `--enable-events`

Event emission became always-on; the flag survives only as a hidden, deprecated no-op that
prints a deprecation notice and has no effect. Describing it as an alpha opt-in is wrong in
both directions — it suggests events are off by default and that this flag turns them on.

## Result

The remaining rows match `muster serve --help` on v3.0.1 exactly:

```
--config-path, --debug, --extra-ca-file, --silent
--oauth-mcp-client, --oauth-mcp-client-id, --oauth-mcp-client-public-url,
--oauth-server, --oauth-server-base-url
```

(the OAuth ones are already covered in the section below the table).

The historical entry in `src/content/changes/ai-agents/muster/v0.1.0.md` still mentions
`--enable-events` and is deliberately left alone — release notes are a record of what shipped
at the time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
